### PR TITLE
Fix imports warnings

### DIFF
--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNegative_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNegative_Test.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Bytes#assertIsNegative(org.assertj.core.api.AssertionInfo, Comparable)}</code>.
+ * Tests for <code>{@link Bytes#assertIsNegative(AssertionInfo, Comparable)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsZero_Test.java
@@ -17,20 +17,15 @@ package org.assertj.core.internal.bytes;
 import static org.assertj.core.test.TestData.someInfo;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.spy;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Bytes;
 import org.assertj.core.internal.BytesBaseTest;
-import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
-import org.assertj.core.internal.Failures;
-import org.assertj.core.util.AbsValueComparator;
-import org.junit.Before;
 import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Bytes#assertIsNegative(org.assertj.core.api.AssertionInfo, Comparable)}</code>.
+ * Tests for <code>{@link Bytes#assertIsNegative(AssertionInfo, Comparable)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola

--- a/src/test/java/org/assertj/core/internal/longs/Longs_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/longs/Longs_assertIsZero_Test.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Longs#assertIsNegative(org.assertj.core.api.AssertionInfo, Comparable)}</code>.
+ * Tests for <code>{@link Longs#assertIsNegative(AssertionInfo, Comparable)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola

--- a/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/shorts/Shorts_assertIsNotZero_Test.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 
 /**
- * Tests for <code>{@link Shorts#assertIsNotZero(org.assertj.core.api.AssertionInfo, Comparable)}</code>.
+ * Tests for <code>{@link Shorts#assertIsNotZero(AssertionInfo, Comparable)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola


### PR DESCRIPTION
Remove unused imports and use imported classes in JavaDocs.
