### PR TITLE
Fixes #18: Add containsExactly(xxx... values) for xxxArrayAssert.

### DIFF
--- a/src/main/java/org/assertj/core/api/BooleanArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/BooleanArrayAssert.java
@@ -239,4 +239,32 @@ public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boole
   public final BooleanArrayAssert usingDefaultElementComparator() {
     throw new UnsupportedOperationException("custom element Comparator is not supported for Boolean array comparison");
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * boolean[] booleans = { true, false };
+   * 
+   * // assertion will pass
+   * assertThat(booleans).containsExactly(true, false);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(booleans).containsExactly(false, true);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public BooleanArrayAssert containsExactly(boolean... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/ByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/ByteArrayAssert.java
@@ -229,4 +229,32 @@ public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> imp
     this.arrays = ByteArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * byte[] bytes = { 1, 2, 3 };
+   * 
+   * // assertion will pass
+   * assertThat(bytes).containsExactly((byte) 1, (byte) 2, (byte) 3);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(bytes).containsExactly((byte) 2, (byte) 1, (byte) 3);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public ByteArrayAssert containsExactly(byte... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/CharArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/CharArrayAssert.java
@@ -229,4 +229,32 @@ public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> imp
     this.arrays = CharArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * char[] chars = { 'a', 'b', 'c' };
+   * 
+   * // assertion will pass
+   * assertThat(chars).containsExactly('a', 'b', 'c');
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(chars).containsExactly('b', 'a', 'c');
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public CharArrayAssert containsExactly(char... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/DoubleArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/DoubleArrayAssert.java
@@ -230,4 +230,31 @@ public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[
     return myself;
   }
 
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * double[] doubles = { 1.0, 2.0, 3.0 };
+   * 
+   * // assertion will pass
+   * assertThat(doubles).containsExactly(1.0, 2.0, 3.0);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(doubles).containsExactly(2.0, 1.0, 3.0);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public DoubleArrayAssert containsExactly(double... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/FloatArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/FloatArrayAssert.java
@@ -229,4 +229,32 @@ public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> 
     this.arrays = FloatArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * float[] floats = { 1.0f, 2.0f, 3.0f };
+   * 
+   * // assertion will pass
+   * assertThat(floats).containsExactly(1.0f, 2.0f, 3.0f);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(floats).containsExactly(2.0f, 1.0f, 3.0f);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+    public FloatArrayAssert containsExactly(float... values) {
+        objects.assertEqual(info, actual, values);
+        return this;
+    }
 }

--- a/src/main/java/org/assertj/core/api/IntArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/IntArrayAssert.java
@@ -229,4 +229,32 @@ public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implem
     this.arrays = IntArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * int[] ints = { 1, 2, 3 };
+   * 
+   * // assertion will pass
+   * assertThat(ints).containsExactly(1, 2, 3);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(ints).containsExactly(2, 1, 3);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public IntArrayAssert containsExactly(int... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/LongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/LongArrayAssert.java
@@ -229,4 +229,32 @@ public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> imp
     this.arrays = LongArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * long[] longs = { 1L, 2L, 3L };
+   * 
+   * // assertion will pass
+   * assertThat(longs).containsExactly(1L, 2L, 3L);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(longs).containsExactly(2L, 1L, 3L);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public LongArrayAssert containsExactly(long... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/main/java/org/assertj/core/api/ShortArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/ShortArrayAssert.java
@@ -229,4 +229,32 @@ public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> 
     this.arrays = ShortArrays.instance();
     return myself;
   }
+
+  /**
+   * Verifies that the actual group contains only the given values and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * 
+   * <pre>
+   * short[] shorts = { 1, 2, 3 };
+   * 
+   * // assertion will pass
+   * assertThat(shorts).containsExactly((short) 1, (short) 2, (short) 3);
+   * 
+   * // assertion will fail as actual and expected orders differ.
+   * assertThat(shorts).containsExactly((short) 2, (short) 1, (short) 3);
+   * </pre>
+   * 
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   */
+  public ShortArrayAssert containsExactly(short... values) {
+    objects.assertEqual(info, actual, values);
+    return this;
+  }
 }

--- a/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/booleanarray/BooleanArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.booleanarray;
+
+import static org.assertj.core.test.BooleanArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.BooleanArrayAssert;
+import org.assertj.core.api.BooleanArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.BooleanArrayAssert#containsExactly(boolean...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class BooleanArrayAssert_containsExactly_Test extends BooleanArrayAssertBaseTest {
+
+  @Override
+  protected BooleanArrayAssert invoke_api_method() {
+    return assertions.containsExactly(true, false);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(true, false));
+  }
+}

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.bytearray;
+
+import static org.assertj.core.test.ByteArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ByteArrayAssert;
+import org.assertj.core.api.ByteArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ByteArrayAssert#containsExactly(byte...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class ByteArrayAssert_containsExactly_Test extends ByteArrayAssertBaseTest {
+
+  @Override
+  protected ByteArrayAssert invoke_api_method() {
+    return assertions.containsExactly((byte) 1, (byte) 2);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+  }
+}

--- a/src/test/java/org/assertj/core/api/chararray/CharArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/chararray/CharArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.chararray;
+
+import static org.assertj.core.test.CharArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharArrayAssert;
+import org.assertj.core.api.CharArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.CharArrayAssert#containsExactly(char...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class CharArrayAssert_containsExactly_Test extends CharArrayAssertBaseTest {
+
+  @Override
+  protected CharArrayAssert invoke_api_method() {
+    return assertions.containsExactly('a', 'b');
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf('a', 'b'));
+  }
+}

--- a/src/test/java/org/assertj/core/api/doublearray/DoubleArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/doublearray/DoubleArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.doublearray;
+
+import static org.assertj.core.test.DoubleArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleArrayAssert;
+import org.assertj.core.api.DoubleArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.DoubleArrayAssert#containsExactly(double...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class DoubleArrayAssert_containsExactly_Test extends DoubleArrayAssertBaseTest {
+
+  @Override
+  protected DoubleArrayAssert invoke_api_method() {
+    return assertions.containsExactly(1d, 2d);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1d, 2d));
+  }
+}

--- a/src/test/java/org/assertj/core/api/floatarray/FloatArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/floatarray/FloatArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.floatarray;
+
+import static org.assertj.core.test.FloatArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatArrayAssert;
+import org.assertj.core.api.FloatArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.FloatArrayAssert#containsExactly(float...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class FloatArrayAssert_containsExactly_Test extends FloatArrayAssertBaseTest {
+
+  @Override
+  protected FloatArrayAssert invoke_api_method() {
+    return assertions.containsExactly(1.0f, 2.0f);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1.0f, 2.0f));
+  }
+}

--- a/src/test/java/org/assertj/core/api/intarray/IntArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/intarray/IntArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.intarray;
+
+import static org.assertj.core.test.IntArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.IntArrayAssert;
+import org.assertj.core.api.IntArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.IntArrayAssert#containsExactly(int...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class IntArrayAssert_containsExactly_Test extends IntArrayAssertBaseTest {
+
+  @Override
+  protected IntArrayAssert invoke_api_method() {
+    return assertions.containsExactly(1, 2);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+  }
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.LongArrayAssert#containsExactly(long...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class LongArrayAssert_containsExactly_Test extends LongArrayAssertBaseTest {
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsExactly(1L, 2L);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1L, 2L));
+  }
+}

--- a/src/test/java/org/assertj/core/api/shortarray/ShortArrayAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/shortarray/ShortArrayAssert_containsExactly_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.shortarray;
+
+import static org.assertj.core.test.ShortArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ShortArrayAssert;
+import org.assertj.core.api.ShortArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ShortArrayAssert#containsExactly(short...)}</code>.
+ * 
+ * @author Jean-Christophe Gay
+ */
+public class ShortArrayAssert_containsExactly_Test extends ShortArrayAssertBaseTest {
+
+  @Override
+  protected ShortArrayAssert invoke_api_method() {
+    return assertions.containsExactly((short) 1, (short) 2);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertEqual(getInfo(assertions), getActual(assertions), arrayOf(1, 2));
+  }
+}


### PR DESCRIPTION
I have used Objects#assertEqual to implements the feature as it was done for ObjectArrayAssert.
