### PR TITLE
fixed issue 108 not to require objects to implement Comparable

### DIFF
--- a/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
@@ -15,8 +15,6 @@ package org.assertj.core.internal;
  * Copyright @2010-2011 the original author or authors.
  */
 
-import static java.lang.String.format;
-
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
@@ -32,7 +30,7 @@ import org.assertj.core.util.Objects;
  * @author Joel Costigliola
  */
 public class StandardComparisonStrategy extends AbstractComparisonStrategy {
-
+ 
   private static final StandardComparisonStrategy INSTANCE = new StandardComparisonStrategy();
 
   /**
@@ -56,17 +54,20 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
   protected Set<Object> newSetUsingComparisonStrategy() {
     // define a comparator so that we can use areEqual to compare objects in Set collections
     // the "less than" comparison does not make much sense here but need to be defined.
-    return new TreeSet<Object>(
-                               new Comparator<Object>() {
-                                 @Override
-                                 public int compare(Object o1, Object o2) {
-                                   if (areEqual(o1, o2)) return 0;
-                                   return Objects.hashCodeFor(o1) < Objects.hashCodeFor(o2) ? -1 : 1;
-                                 }
-                               });
+    return new TreeSet<Object>(hashCodeComparator());
   }
 
-  /**
+    private Comparator<Object> hashCodeComparator() {
+        return new Comparator<Object>() {
+          @Override
+          public int compare(Object o1, Object o2) {
+            if (areEqual(o1, o2)) return 0;
+            return Objects.hashCodeFor(o1) < Objects.hashCodeFor(o2) ? -1 : 1;
+          }
+        };
+    }
+
+    /**
    * Returns true if actual and other are equal based on {@link Objects#areEqual(Object, Object)}, false otherwise.
    * 
    * @param actual the object to compare to other
@@ -148,11 +149,15 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
 
   @Override
   @SuppressWarnings("unchecked")
-  public boolean isGreaterThan(Object actual, Object other) {
-    if (!(actual instanceof Comparable)) {
-      throw new IllegalArgumentException(format("argument '%s' should be Comparable but is not", actual));
+  public boolean isGreaterThan(Object o1, Object o2) {
+    if (!(o1 instanceof Comparable)) {
+        return isPositiveValue(hashCodeComparator().compare(o1, o2));
     }
-    return Comparable.class.cast(actual).compareTo(other) > 0;
+    return isPositiveValue(Comparable.class.cast(o1).compareTo(o2));
   }
+
+    private boolean isPositiveValue(int compareResult) {
+        return compareResult > 0;
+    }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThanOrEqualTo_Test.java
@@ -14,11 +14,11 @@
  */
 package org.assertj.core.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.awt.Rectangle;
+import java.awt.*;
 
-import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.Test;
 
 /**
@@ -38,11 +38,10 @@ public class StandardComparisonStrategy_isGreaterThanOrEqualTo_Test extends Abst
   }
 
   @Test
-  public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(IllegalArgumentException.class);
+  public void should_be_able_to_say_not_comparable_objects_are_equal() {
     Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isGreaterThanOrEqualTo(r1, r2);
+    Rectangle r2 = new Rectangle(10, 20);
+    assertTrue(standardComparisonStrategy.isGreaterThanOrEqualTo(r1, r2));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isGreaterThan_Test.java
@@ -14,12 +14,11 @@
  */
 package org.assertj.core.internal;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.awt.Rectangle;
-
-import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.Test;
 
 /**
@@ -46,9 +45,4 @@ public class StandardComparisonStrategy_isGreaterThan_Test extends AbstractTest_
     assertFalse(standardComparisonStrategy.isGreaterThan(boss, boss));
   }
 
-  @Test
-  public void should_fail_if_first_parameter_is_not_comparable() {
-    thrown.expect(IllegalArgumentException.class);
-    standardComparisonStrategy.isGreaterThan(new Rectangle(), "foo");
-  }
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThanOrEqualTo_Test.java
@@ -14,11 +14,11 @@
  */
 package org.assertj.core.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.awt.Rectangle;
+import java.awt.*;
 
-import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.Test;
 
 /**
@@ -38,11 +38,10 @@ public class StandardComparisonStrategy_isLessThanOrEqualTo_Test extends Abstrac
   }
 
   @Test
-  public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(IllegalArgumentException.class);
-    Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isLessThanOrEqualTo(r1, r2);
+  public void should_be_able_to_say_not_comparable_objects_are_equal() {
+     Rectangle r1 = new Rectangle(10, 20);
+     Rectangle r2 = new Rectangle(10, 20);
+     assertTrue(standardComparisonStrategy.isLessThanOrEqualTo(r1, r2));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThan_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_isLessThan_Test.java
@@ -14,11 +14,9 @@
  */
 package org.assertj.core.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.awt.Rectangle;
-
-import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.Test;
 
 /**
@@ -35,14 +33,6 @@ public class StandardComparisonStrategy_isLessThan_Test extends AbstractTest_Sta
     assertTrue(standardComparisonStrategy.isLessThan(young, boss));
     assertFalse(standardComparisonStrategy.isLessThan(boss, young));
     assertFalse(standardComparisonStrategy.isLessThan(boss, boss));
-  }
-
-  @Test
-  public void should_fail_if_a_parameter_is_not_comparable() {
-    thrown.expect(IllegalArgumentException.class);
-    Rectangle r1 = new Rectangle(10, 20);
-    Rectangle r2 = new Rectangle(20, 10);
-    standardComparisonStrategy.isLessThan(r1, r2);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsOnlyOnce_Test.java
@@ -26,7 +26,9 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Iterables;
@@ -37,6 +39,7 @@ import org.junit.Test;
  * Tests for <code>{@link Iterables#assertContainsOnlyOnce(AssertionInfo, Collection, Object[])}</code>.
  * 
  * @author William Delanoue
+ * @author Tomasz Bartczak
  */
 public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
 
@@ -162,7 +165,7 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
   }
 
   @Test
-  public void should_pass_if_actual_contains_given_values_only_even_if_duplicated_according_to_custom_comparison_strategy() {
+  public void should_fail_if_actual_contains_given_values_only_even_if_duplicated_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
     actual.addAll(newArrayList("LUKE"));
     Object[] expected = array("LUke", "LUke", "lukE", "YOda", "Leia", "Han");
@@ -190,6 +193,41 @@ public class Iterables_assertContainsOnlyOnce_Test extends IterablesBaseTest {
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_fail_with_correct_assertion_error_when_actual_does_not_implement_Comparable() {
+    AssertionInfo info = someInfo();
+    NotComparable expectedElement = new NotComparable("1");
+    Object[] expected = array(expectedElement);
+    List<NotComparable> actual = Arrays.asList(new NotComparable("2"));
+    try {
+      iterables.assertContainsOnlyOnce(info, actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info,
+          shouldContainsOnlyOnce(actual, expected, newLinkedHashSet(expectedElement), newLinkedHashSet()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  public static class NotComparable {
+
+    private String field;
+
+    public NotComparable(String field) {
+      this.field = field;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return ((NotComparable) o).field.equals(field);
+    }
+
+    @Override
+    public int hashCode() {
+      return 1;
+    }
   }
 
 }


### PR DESCRIPTION
This is a fix for https://github.com/joel-costigliola/assertj-core/issues/108
