### PR TITLE
Hexadecimal bytes assertions messages

### DIFF
--- a/src/main/java/org/assertj/core/util/ArrayFormatter.java
+++ b/src/main/java/org/assertj/core/util/ArrayFormatter.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 /**
  * Creates a {@code String} representation of an array.
- * 
+ *
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
@@ -97,10 +97,11 @@ final class ArrayFormatter {
     }
     StringBuilder buffer = new StringBuilder();
     buffer.append('[');
-    buffer.append(Array.get(o, 0));
+    buffer.append(CompactToString.toStringOf(Array.get(o, 0)));
     for (int i = 1; i < size; i++) {
-      buffer.append(", ");
-      buffer.append(Array.get(o, i));
+      Object element = Array.get(o, i);
+      buffer.append(Collections.elementSeparator(element));
+      buffer.append(CompactToString.toStringOf(element));
     }
     buffer.append("]");
     return buffer.toString();

--- a/src/main/java/org/assertj/core/util/Collections.java
+++ b/src/main/java/org/assertj/core/util/Collections.java
@@ -104,7 +104,7 @@ public final class Collections {
       if (!i.hasNext()) {
         return b.append(end).toString();
       }
-      b.append(", ");
+      b.append(elementSeparator(e));
     }
   }
   
@@ -131,4 +131,12 @@ public final class Collections {
   }
 
   private Collections() {}
+
+  static String elementSeparator(Object o){
+    if (o instanceof Byte) {
+      return ":";
+    } else {
+      return ", ";
+    }
+  }
 }

--- a/src/main/java/org/assertj/core/util/CompactToString.java
+++ b/src/main/java/org/assertj/core/util/CompactToString.java
@@ -1,0 +1,71 @@
+/*
+ * Created on Nov 30, 2013
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2009-2013 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.util.Collection;
+
+import static org.assertj.core.util.Strings.quote;
+
+/**
+ * Obtains the compact version of {@code toString} representation of an object.
+ *
+ * @author Alex Ruiz
+ * @author Joel Costigliola
+ * @author Yvonne Wang
+ * @author Mariusz Smykula
+ */
+public final class CompactToString {
+
+  final protected static char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+  /**
+   * Returns the {@code toString} representation of the given object. It may or not the object's own implementation of
+   * {@code toString}.
+   *
+   * @param o the given object.
+   * @return the {@code toString} representation of the given object.
+   */
+  public static String toStringOf(Object o) {
+    if (o instanceof Class<?>) {
+      return toStringOf((Class<?>) o);
+    }
+    if (o instanceof Collection<?>) {
+      return toStringOf((Collection<?>) o);
+    }
+    if (o instanceof String) {
+      return quote((String) o);
+    }
+    if (o instanceof Byte) {
+      return toStringOf((Byte) o);
+    }
+    return o == null ? null : o.toString();
+  }
+
+  private static String toStringOf(Byte b) {
+    int v = b & 0xFF;
+    return new String(new char[]{hexArray[v >>> 4], hexArray[v & 0x0F]});
+  }
+
+  private static String toStringOf(Class<?> c) {
+    return c.getCanonicalName();
+  }
+
+  private static String toStringOf(Collection<?> c) {
+    return Collections.format(c);
+  }
+
+  private CompactToString() {
+  }
+}

--- a/src/main/java/org/assertj/core/util/ToString.java
+++ b/src/main/java/org/assertj/core/util/ToString.java
@@ -18,7 +18,6 @@ import static org.assertj.core.util.Arrays.isArray;
 import static org.assertj.core.util.Strings.quote;
 
 import java.io.File;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -30,7 +29,7 @@ import java.util.*;
  * @author Yvonne Wang
  */
 public final class ToString {
-  
+
   /**
    * Returns the {@code toString} representation of the given object. It may or not the object's own implementation of
    * {@code toString}.
@@ -45,12 +44,6 @@ public final class ToString {
     if (o instanceof Calendar) {
       return toStringOf((Calendar) o);
     }
-    if (o instanceof Class<?>) {
-      return toStringOf((Class<?>) o);
-    }
-    if (o instanceof Collection<?>) {
-      return toStringOf((Collection<?>) o);
-    }
     if (o instanceof Date) {
       return toStringOf((Date) o);
     }
@@ -60,14 +53,14 @@ public final class ToString {
     if (o instanceof Long) {
       return toStringOf((Long) o);
     }
+    if (o instanceof Byte) {
+      return toStringOf((Byte) o);
+    }
     if (o instanceof File) {
       return toStringOf((File) o);
     }
     if (o instanceof Map<?, ?>) {
       return toStringOf((Map<?, ?>) o);
-    }
-    if (o instanceof String) {
-      return quote((String) o);
     }
     if (o instanceof Comparator) {
       return toStringOf((Comparator<?>) o);
@@ -75,7 +68,7 @@ public final class ToString {
     if (o instanceof SimpleDateFormat) {
       return toStringOf((SimpleDateFormat) o);
     }
-    return o == null ? null : o.toString();
+    return CompactToString.toStringOf(o);
   }
 
   private static String toStringOf(Comparator<?> comparator) {
@@ -87,12 +80,9 @@ public final class ToString {
     return Dates.formatAsDatetime(c);
   }
 
-  private static String toStringOf(Class<?> c) {
-    return c.getCanonicalName();
-  }
+  private static String toStringOf(Byte b) {
+    return "0x" + CompactToString.toStringOf(b);
 
-  private static String toStringOf(Collection<?> c) {
-    return Collections.format(c);
   }
 
   private static String toStringOf(Date d) {

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -128,9 +128,9 @@ public class SoftAssertionsTest {
       assertThat(errors.get(2)).isEqualTo("expected:<[tru]e> but was:<[fals]e>");
       assertThat(errors.get(3)).isEqualTo("expected:<[[tru]e]> but was:<[[fals]e]>");
 
-      assertThat(errors.get(4)).isEqualTo("expected:<[1]> but was:<[0]>");
-      assertThat(errors.get(5)).isEqualTo("expected:<[3]> but was:<[2]>");
-      assertThat(errors.get(6)).isEqualTo("expected:<[[5]]> but was:<[[4]]>");
+      assertThat(errors.get(4)).isEqualTo("expected:<0x0[1]> but was:<0x0[0]>");
+      assertThat(errors.get(5)).isEqualTo("expected:<0x0[3]> but was:<0x0[2]>");
+      assertThat(errors.get(6)).isEqualTo("expected:<[0[5]]> but was:<[0[4]]>");
 
       assertThat(errors.get(7)).isEqualTo("expected:<[B]> but was:<[A]>");
       assertThat(errors.get(8)).isEqualTo("expected:<[D]> but was:<[C]>");

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNegative_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNegative_Test.java
@@ -37,20 +37,20 @@ public class Bytes_assertIsNegative_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_since_actual_is_not_negative() {
-    thrown.expectAssertionError("\nExpecting:\n <6>\nto be less than:\n <0>");
-    bytes.assertIsNegative(someInfo(), (byte) 6);
+    thrown.expectAssertionError("\nExpecting:\n <0x06>\nto be less than:\n <0x00>");
+    bytes.assertIsNegative(someInfo(), (byte) 0x06);
   }
 
   @Test
   public void should_fail_since_actual_is_not_negative_according_to_absolute_value_comparison_strategy() {
-    thrown.expectAssertionError("\nExpecting:\n <-6>\nto be less than:\n <0> according to 'AbsValueComparator' comparator");
-    bytesWithAbsValueComparisonStrategy.assertIsNegative(someInfo(), (byte) -6);
+    thrown.expectAssertionError("\nExpecting:\n <0xFA>\nto be less than:\n <0x00> according to 'AbsValueComparator' comparator");
+    bytesWithAbsValueComparisonStrategy.assertIsNegative(someInfo(), (byte) 0xFA);
   }
 
   @Test
   public void should_fail_since_actual_is_not_negative_according_to_absolute_value_comparison_strategy2() {
-    thrown.expectAssertionError("\nExpecting:\n <6>\nto be less than:\n <0> according to 'AbsValueComparator' comparator");
-    bytesWithAbsValueComparisonStrategy.assertIsNegative(someInfo(), (byte) 6);
+    thrown.expectAssertionError("\nExpecting:\n <0x06>\nto be less than:\n <0x00> according to 'AbsValueComparator' comparator");
+    bytesWithAbsValueComparisonStrategy.assertIsNegative(someInfo(), (byte) 0x06);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotNegative_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotNegative_Test.java
@@ -16,6 +16,8 @@ package org.assertj.core.internal.bytes;
 
 import static org.assertj.core.test.TestData.someInfo;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Bytes;
 import org.assertj.core.internal.BytesBaseTest;
 import org.junit.Test;
 
@@ -39,8 +41,8 @@ public class Bytes_assertIsNotNegative_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_since_actual_is_negative() {
-    thrown.expectAssertionError("\nExpecting:\n <-6>\nto be greater than or equal to:\n <0>");
-    bytes.assertIsNotNegative(someInfo(), (byte) -6);
+    thrown.expectAssertionError("\nExpecting:\n <0xFA>\nto be greater than or equal to:\n <0x00>");
+    bytes.assertIsNotNegative(someInfo(), (byte) 0xFA);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotPositive_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotPositive_Test.java
@@ -16,6 +16,8 @@ package org.assertj.core.internal.bytes;
 
 import static org.assertj.core.test.TestData.someInfo;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Bytes;
 import org.assertj.core.internal.BytesBaseTest;
 import org.junit.Test;
 
@@ -39,20 +41,20 @@ public class Bytes_assertIsNotPositive_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_since_actual_is_positive() {
-    thrown.expectAssertionError("\nExpecting:\n <6>\nto be less than or equal to:\n <0>");
-    bytes.assertIsNotPositive(someInfo(), (byte) 6);
+    thrown.expectAssertionError("\nExpecting:\n <0x06>\nto be less than or equal to:\n <0x00>");
+    bytes.assertIsNotPositive(someInfo(), (byte) 0x06);
   }
 
   @Test
   public void should_fail_since_actual_can_be_positive_according_to_custom_comparison_strategy() {
-    thrown.expectAssertionError("\nExpecting:\n <-1>\nto be less than or equal to:\n <0> according to 'AbsValueComparator' comparator");
-    bytesWithAbsValueComparisonStrategy.assertIsNotPositive(someInfo(), (byte) -1);
+    thrown.expectAssertionError("\nExpecting:\n <0xFF>\nto be less than or equal to:\n <0x00> according to 'AbsValueComparator' comparator");
+    bytesWithAbsValueComparisonStrategy.assertIsNotPositive(someInfo(), (byte) 0xFF);
   }
 
   @Test
   public void should_fail_since_actual_is_positive_according_to_custom_comparison_strategy() {
-    thrown.expectAssertionError("\nExpecting:\n <1>\nto be less than or equal to:\n <0> according to 'AbsValueComparator' comparator");
-    bytesWithAbsValueComparisonStrategy.assertIsNotPositive(someInfo(), (byte) 1);
+    thrown.expectAssertionError("\nExpecting:\n <0x01>\nto be less than or equal to:\n <0x00> according to 'AbsValueComparator' comparator");
+    bytesWithAbsValueComparisonStrategy.assertIsNotPositive(someInfo(), (byte) 0x01);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsNotZero_Test.java
@@ -39,8 +39,8 @@ public class Bytes_assertIsNotZero_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_since_actual_is_zero() {
-    thrown.expectAssertionError("\nExpecting:\n <0>\nnot to be equal to:\n <0>\n");
-    bytes.assertIsNotZero(someInfo(), (byte) 0);
+    thrown.expectAssertionError("\nExpecting:\n <0x00>\nnot to be equal to:\n <0x00>\n");
+    bytes.assertIsNotZero(someInfo(), (byte) 0x00);
   }
 
   @Test
@@ -51,9 +51,9 @@ public class Bytes_assertIsNotZero_Test extends BytesBaseTest {
   @Test
   public void should_fail_since_actual_is_not_zero_whatever_custom_comparison_strategy_is() {
     try {
-      bytesWithAbsValueComparisonStrategy.assertIsNotZero(someInfo(), (byte) 0);
+      bytesWithAbsValueComparisonStrategy.assertIsNotZero(someInfo(), (byte) 0x00);
     } catch (AssertionError e) {
-      assertEquals(e.getMessage(), "\nExpecting:\n <0>\nnot to be equal to:\n <0>\n");
+      assertEquals(e.getMessage(), "\nExpecting:\n <0x00>\nnot to be equal to:\n <0x00>\n");
     }
   }
 

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsPositive_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsPositive_Test.java
@@ -36,8 +36,8 @@ public class Bytes_assertIsPositive_Test extends BytesBaseTest {
 
   @Test
   public void should_fail_since_actual_is_not_positive() {
-    thrown.expectAssertionError("\nExpecting:\n <-6>\nto be greater than:\n <0>");
-    bytes.assertIsPositive(someInfo(), (byte) -6);
+    thrown.expectAssertionError("\nExpecting:\n <0xFA>\nto be greater than:\n <0x00>");
+    bytes.assertIsPositive(someInfo(), (byte) 0xFA);
   }
 
   @Test
@@ -48,7 +48,7 @@ public class Bytes_assertIsPositive_Test extends BytesBaseTest {
   @Test
   public void should_fail_since_actual_is_not_positive_according_to_custom_comparison_strategy() {
     thrown
-        .expectAssertionError("\nExpecting:\n <0>\nto be greater than:\n <0> according to 'AbsValueComparator' comparator");
-    bytesWithAbsValueComparisonStrategy.assertIsPositive(someInfo(), (byte) 0);
+        .expectAssertionError("\nExpecting:\n <0x00>\nto be greater than:\n <0x00> according to 'AbsValueComparator' comparator");
+    bytesWithAbsValueComparisonStrategy.assertIsPositive(someInfo(), (byte) 0x00);
   }
 }

--- a/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/bytes/Bytes_assertIsZero_Test.java
@@ -40,29 +40,29 @@ public class Bytes_assertIsZero_Test extends BytesBaseTest {
 
   @Test
   public void should_succeed_since_actual_is_zero() {
-    bytes.assertIsZero(someInfo(), (byte) 0);
+    bytes.assertIsZero(someInfo(), (byte) 0x00);
   }
 
   @Test
   public void should_fail_since_actual_is_not_zero() {
     try {
-      bytes.assertIsZero(someInfo(), (byte) 2);
+      bytes.assertIsZero(someInfo(), (byte) 0x02);
     } catch (AssertionError e) {
-      assertEquals("expected:<[0]> but was:<[2]>", e.getMessage());
+      assertEquals("expected:<0x0[0]> but was:<0x0[2]>", e.getMessage());
     }
   }
 
   @Test
   public void should_succeed_since_actual_is_zero_whatever_custom_comparison_strategy_is() {
-    bytesWithAbsValueComparisonStrategy.assertIsZero(someInfo(), (byte) 0);
+    bytesWithAbsValueComparisonStrategy.assertIsZero(someInfo(), (byte) 0x00);
   }
 
   @Test
   public void should_fail_since_actual_is_not_zero_whatever_custom_comparison_strategy_is() {
     try {
-      bytesWithAbsValueComparisonStrategy.assertIsZero(someInfo(), (byte) 1);
+      bytesWithAbsValueComparisonStrategy.assertIsZero(someInfo(), (byte) 0x01);
     } catch (AssertionError e) {
-      assertEquals("expected:<[0]> but was:<[1]>", e.getMessage());
+      assertEquals("expected:<0x0[0]> but was:<0x0[1]>", e.getMessage());
     }
   }
 

--- a/src/test/java/org/assertj/core/util/ArrayFormatter_format_Test.java
+++ b/src/test/java/org/assertj/core/util/ArrayFormatter_format_Test.java
@@ -55,7 +55,7 @@ public class ArrayFormatter_format_Test {
 
   @Test
   public void should_format_byte_array() {
-    assertEquals("[6, 8]", formatter.format(new byte[] { 6, 8 }));
+    assertEquals("[06:08]", formatter.format(new byte[] { 6, 8 }));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/Arrays_format_Test.java
+++ b/src/test/java/org/assertj/core/util/Arrays_format_Test.java
@@ -50,7 +50,7 @@ public class Arrays_format_Test {
   @Test
   public void should_format_byte_array() {
     Object o = new byte[] { (byte) 3, (byte) 8 };
-    assertEquals("[3, 8]", Arrays.format(o));
+    assertEquals("[03:08]", Arrays.format(o));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/util/ToString_toStringOf_Test.java
+++ b/src/test/java/org/assertj/core/util/ToString_toStringOf_Test.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 
 /**
  * Tests for {@link ToString#toStringOf(Object)}.
- * 
+ *
  * @author Joel Costigliola
  */
 public class ToString_toStringOf_Test {
@@ -148,6 +148,13 @@ public class ToString_toStringOf_Test {
     assertFalse(toStringOf(20L).equals(toStringOf(20)));
     assertEquals("20", toStringOf(20));
     assertEquals("20L", toStringOf(20L));
+  }
+
+  @Test
+  public void should_format_bytes_as_hex() {
+    assertFalse(toStringOf((byte) 20).equals(toStringOf((char) 20)));
+    assertFalse(toStringOf((byte) 20).equals(toStringOf((short) 20)));
+    assertEquals("0x20", toStringOf((byte) 32));
   }
 
   @Test


### PR DESCRIPTION
- Hexadecimal values for bytes and byte arrays are easier to read
