### PR TITLE
#134 add message about actual value when assertion failed

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingOnlyGivenFields.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingOnlyGivenFields.java
@@ -27,31 +27,36 @@ public class ShouldBeEqualByComparingOnlyGivenFields extends BasicErrorMessageFa
 
   /**
    * Creates a new </code>{@link ShouldBeEqualByComparingOnlyGivenFields}</code>.
-   * 
+   *
+   *
    * @param actual the actual value in the failed assertion.
-   * @param rejectedFields fields name not matching
-   * @param expectedValues fields value not matching
+   * @param rejectedFields fields names not matching
+   * @param rejectedValues fields values not matching
+   * @param expectedValues expected fields values
    * @param acceptedFields fields on which is based the lenient equality
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBeEqualComparingOnlyGivenFields(Object actual, List<String> rejectedFields,
-      List<Object> expectedValues, List<String> acceptedFields) {
+                                                                          List<Object> rejectedValues, List<Object> expectedValues,
+                                                                          List<String> acceptedFields) {
     if (rejectedFields.size() == 1) {
-      return new ShouldBeEqualByComparingOnlyGivenFields(actual, rejectedFields.get(0), expectedValues.get(0), acceptedFields);
+      return new ShouldBeEqualByComparingOnlyGivenFields(actual, rejectedFields.get(0), rejectedValues.get(0), expectedValues.get(0),
+          acceptedFields);
     } else {
-      return new ShouldBeEqualByComparingOnlyGivenFields(actual, rejectedFields, expectedValues, acceptedFields);
+      return new ShouldBeEqualByComparingOnlyGivenFields(actual, rejectedFields, rejectedValues, expectedValues, acceptedFields);
     }
   }
 
-  private ShouldBeEqualByComparingOnlyGivenFields(Object actual, List<String> rejectedFields, List<Object> expectedValue,
-                                                   List<String> acceptedFields) {
-    super("\nExpecting values:\n  <%s>\nin fields:\n  <%s>\nof <%s>.\nComparison was performed on fields:\n  <%s>",
-        expectedValue, rejectedFields, actual, acceptedFields);
+  private ShouldBeEqualByComparingOnlyGivenFields(Object actual, List<String> rejectedFields, List<Object> rejectedValues,
+                                                  List<Object> expectedValue, List<String> acceptedFields) {
+    super("\nExpecting values:\n  <%s>\nin fields:\n  <%s>\nbut were:\n  <%s>\nin <%s>.\nComparison was performed on fields:\n  <%s>",
+        expectedValue, rejectedFields, rejectedValues, actual, acceptedFields);
   }
 
-  private ShouldBeEqualByComparingOnlyGivenFields(Object actual, String rejectedField, Object rejectedValue,
+  private ShouldBeEqualByComparingOnlyGivenFields(Object actual, String rejectedField, Object rejectedValue, Object expectedValue,
                                                    List<String> acceptedFields) {
-    super("\nExpecting value <%s> in field <%s> of <%s>", rejectedValue, rejectedField, actual, acceptedFields);
+    super("\nExpecting value <%s> in field <%s> but was <%s> in <%s>", expectedValue, rejectedField, rejectedValue, actual,
+        acceptedFields);
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualToIgnoringFields.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualToIgnoringFields.java
@@ -25,50 +25,57 @@ import java.util.List;
  */
 public class ShouldBeEqualToIgnoringFields extends BasicErrorMessageFactory {
 
+  private static final String EXPECTED_MULTIPLE = "\nExpecting values:\n  <%s>\nin fields:\n  <%s>\nbut were:\n  <%s>\nin <%s>.\n";
+  private static final String EXPECTED_SINGLE = "\nExpecting value <%s> in field <%s> but was <%s> in <%s>.\n";
+  private static final String COMPARISON  = "Comparison was performed on all fields";
+  private static final String EXCLUDING  = " but <%s>";
+
   /**
    * Creates a new </code>{@link ShouldBeEqualToIgnoringFields}</code>.
+   *
    * @param actual the actual value in the failed assertion.
    * @param rejectedFields fields name not matching
-   * @param expectedValues fields value not matching
+   * @param rejectedValues rejected fields values
+   * @param expectedValues expected fields values
    * @param ignoredFields fields which are not base the lenient equality
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldBeEqualToIgnoringGivenFields(Object actual, List<String> rejectedFields,
-                                                                        List<Object> expectedValues, List<String> ignoredFields) {
+                                                                       List<Object> rejectedValues, List<Object> expectedValues,
+                                                                       List<String> ignoredFields) {
     if (rejectedFields.size() == 1) {
       if (ignoredFields.isEmpty()) {
-        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields.get(0), expectedValues.get(0));
+        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields.get(0), rejectedValues.get(0), expectedValues.get(0));
       } else {
-        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields.get(0), expectedValues.get(0), ignoredFields);
+        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields.get(0), rejectedValues.get(0), expectedValues.get(0),
+            ignoredFields);
       }
     } else {
       if (ignoredFields.isEmpty()) {
-        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields, expectedValues);
+        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields, rejectedValues, expectedValues);
       } else {
-        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields, expectedValues, ignoredFields);
+        return new ShouldBeEqualToIgnoringFields(actual, rejectedFields, rejectedValues, expectedValues, ignoredFields);
       }
     }
   }
 
-  private ShouldBeEqualToIgnoringFields(Object actual, List<String> rejectedFields, List<Object> expectedValues,
-                                         List<String> ignoredFields) {
-    super("\nExpecting values:\n  <%s>\nin fields:\n  <%s>\nof <%s>.\nComparison was performed on all fields but <%s>",
-        expectedValues, rejectedFields, actual, ignoredFields);
+  private ShouldBeEqualToIgnoringFields(Object actual, List<String> rejectedFields, List<Object> rejectedValues,
+                                        List<Object> expectedValues, List<String> ignoredFields) {
+    super(EXPECTED_MULTIPLE + COMPARISON  + EXCLUDING , expectedValues, rejectedFields, rejectedValues, actual, ignoredFields);
   }
 
-  private ShouldBeEqualToIgnoringFields(Object actual, String rejectedField, Object expectedValue, List<String> ignoredFields) {
-    super("\nExpecting value <%s> in field <%s> of <%s>.\nComparison was performed on all fields but <%s>", expectedValue,
-        rejectedField, actual, ignoredFields);
+  private ShouldBeEqualToIgnoringFields(Object actual, String rejectedField, Object rejectedValue, Object expectedValue,
+                                        List<String> ignoredFields) {
+    super(EXPECTED_SINGLE + COMPARISON  + EXCLUDING , expectedValue, rejectedField, rejectedValue, actual, ignoredFields);
   }
 
-  private ShouldBeEqualToIgnoringFields(Object actual, List<String> rejectedFields, List<Object> expectedValue) {
-    super("\nExpecting values:\n  <%s>\nin fields:\n  <%s>\nof <%s>.\nComparison was performed on all fields", expectedValue,
-        rejectedFields, actual);
+  private ShouldBeEqualToIgnoringFields(Object actual, List<String> rejectedFields, List<Object> rejectedValues,
+                                        List<Object> expectedValue) {
+    super(EXPECTED_MULTIPLE + COMPARISON , expectedValue, rejectedFields, rejectedValues, actual);
   }
 
-  private ShouldBeEqualToIgnoringFields(Object actual, String rejectedField, Object expectedValue) {
-    super("\nExpecting value <%s> in field <%s> of <%s>.\nComparison was performed on all fields", expectedValue, rejectedField,
-        actual);
+  private ShouldBeEqualToIgnoringFields(Object actual, String rejectedField, Object rejectedValue, Object expectedValue) {
+    super(EXPECTED_SINGLE + COMPARISON , expectedValue, rejectedField, rejectedValue, actual);
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualComparingOnlyGivenFields_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualComparingOnlyGivenFields_create_Test.java
@@ -36,18 +36,24 @@ public class ShouldBeEqualComparingOnlyGivenFields_create_Test {
   @Test
   public void should_create_error_message_with_all_fields_differences() {
     factory = shouldBeEqualComparingOnlyGivenFields(new Jedi("Luke", "blue"), newArrayList("name", "lightSaberColor"),
-                                                    newArrayList((Object) "Yoda", "green"), newArrayList("name", "lightSaberColor"));
+        newArrayList((Object) "Luke", "blue"), newArrayList((Object) "Yoda", "green"), newArrayList("name", "lightSaberColor"));
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting values:\n" + "  <[\"Yoda\", \"green\"]>\n" + "in fields:\n" + "  <[\"name\", \"lightSaberColor\"]>\n"
-        + "of <Luke the Jedi>.\n" + "Comparison was performed on fields:\n  <[\"name\", \"lightSaberColor\"]>", message);
+    assertEquals("[Test] \nExpecting values:\n  <[\"Yoda\", \"green\"]>\n" +
+        "in fields:\n  <[\"name\", \"lightSaberColor\"]>\n" +
+        "but were:\n  <[\"Luke\", \"blue\"]>\n" +
+        "in <Luke the Jedi>.\n" +
+        "Comparison was performed on fields:\n  <[\"name\", \"lightSaberColor\"]>", message);
   }
 
   @Test
   public void should_create_error_message_with_single_field_difference() {
-    factory = shouldBeEqualComparingOnlyGivenFields(new Jedi("Yoda", "green"), newArrayList("lightSaberColor"), newArrayList((Object) "green"),
-                                                    newArrayList("lightSaberColor"));
+    factory = shouldBeEqualComparingOnlyGivenFields(new Jedi("Yoda", "green"), newArrayList("lightSaberColor"),
+        newArrayList((Object) "green"), newArrayList((Object) "blue"), newArrayList("lightSaberColor"));
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting value <\"green\"> in field <\"lightSaberColor\"> of <Yoda the Jedi>", message);
+    assertEquals("[Test] \nExpecting value <\"blue\">" +
+        " in field <\"lightSaberColor\">" +
+        " but was <\"green\">" +
+        " in <Yoda the Jedi>", message);
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringGivenFields_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringGivenFields_create_Test.java
@@ -39,40 +39,50 @@ public class ShouldBeEqualIgnoringGivenFields_create_Test {
 
   @Test
   public void should_create_error_message_with_all_fields_differences() {
-    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "green"), newArrayList("name", "lightSaberColor"),
-                                                 newArrayList((Object) "Yoda", "green"), newArrayList("lightSaberColor"));
+    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "blue"), newArrayList("name", "lightSaberColor"),
+        newArrayList((Object) "Yoda", "blue"), newArrayList((Object) "Yoda", "green"), newArrayList("lightSaberColor"));
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting values:\n  <[\"Yoda\", \"green\"]>\nin fields:\n  <[\"name\", \"lightSaberColor\"]>\n"
-        + "of <Yoda the Jedi>.\n" + "Comparison was performed on all fields but <[\"lightSaberColor\"]>", message);
+    assertEquals("[Test] \nExpecting values:\n  <[\"Yoda\", \"green\"]>\n" +
+        "in fields:\n  <[\"name\", \"lightSaberColor\"]>\n" +
+        "but were:\n  <[\"Yoda\", \"blue\"]>\n" +
+        "in <Yoda the Jedi>.\n" +
+        "Comparison was performed on all fields but <[\"lightSaberColor\"]>", message);
   }
 
   @Test
   public void should_create_error_message_with_single_field_difference() {
-    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "green"), newArrayList("lightSaberColor"), newArrayList((Object) "green"),
-                                                 newArrayList("lightSaberColor"));
+    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "blue"), newArrayList("lightSaberColor"), newArrayList((Object) "blue"),
+        newArrayList((Object) "green"), newArrayList("lightSaberColor"));
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting value <\"green\"> in field <\"lightSaberColor\"> of <Yoda the Jedi>."
-        + "\nComparison was performed on all fields but <[\"lightSaberColor\"]>", message);
+    assertEquals("[Test] \nExpecting value <\"green\"> " +
+        "in field <\"lightSaberColor\"> " +
+        "but was <\"blue\"> in <Yoda the Jedi>.\n" +
+        "Comparison was performed on all fields but <[\"lightSaberColor\"]>", message);
   }
 
   @Test
   public void should_create_error_message_with_all_fields_differences_without_ignored_fields() {
     List<String> ignoredFields = newArrayList();
-    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "green"), newArrayList("name", "lightSaberColor"),
-                                                 newArrayList((Object) "Yoda", "green"), ignoredFields);
+    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "blue"), newArrayList("name", "lightSaberColor"),
+        newArrayList((Object) "Yoda", "blue"), newArrayList((Object) "Yoda", "green"), ignoredFields);
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting values:\n  <[\"Yoda\", \"green\"]>\nin fields:\n  <[\"name\", \"lightSaberColor\"]>\n"
-        + "of <Yoda the Jedi>.\n" + "Comparison was performed on all fields", message);
+    assertEquals("[Test] \nExpecting values:\n  <[\"Yoda\", \"green\"]>\n" +
+        "in fields:\n  <[\"name\", \"lightSaberColor\"]>\n" +
+        "but were:\n  <[\"Yoda\", \"blue\"]>\n" +
+        "in <Yoda the Jedi>.\n" +
+        "Comparison was performed on all fields", message);
   }
 
   @Test
   public void should_create_error_message_with_single_field_difference_without_ignored_fields() {
     List<String> ignoredFields = newArrayList();
-    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "green"), newArrayList("lightSaberColor"), newArrayList((Object) "green"),
-                                                 ignoredFields);
+    factory = shouldBeEqualToIgnoringGivenFields(new Jedi("Yoda", "blue"), newArrayList("lightSaberColor"), newArrayList((Object) "blue"),
+        newArrayList((Object) "green"), ignoredFields);
     String message = factory.create(new TextDescription("Test"));
-    assertEquals("[Test] \nExpecting value <\"green\"> in field <\"lightSaberColor\"> of <Yoda the Jedi>."
-        + "\nComparison was performed on all fields", message);
+    assertEquals("[Test] \nExpecting value <\"green\"> " +
+        "in field <\"lightSaberColor\"> " +
+        "but was <\"blue\"> in <Yoda the Jedi>.\n" +
+        "Comparison was performed on all fields", message);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByAcceptingFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByAcceptingFields_Test.java
@@ -80,9 +80,10 @@ public class Objects_assertIsLenientEqualsToByAcceptingFields_Test extends Objec
       objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, "name", "lightSaberColor");
     } catch (AssertionError err) {
       List<Object> expected = newArrayList((Object) "Blue");
+      List<Object> rejected = newArrayList((Object) "Green");
       verify(failures).failure(
           info,
-          shouldBeEqualComparingOnlyGivenFields(actual, newArrayList("lightSaberColor"), expected,
+          shouldBeEqualComparingOnlyGivenFields(actual, newArrayList("lightSaberColor"), rejected, expected,
                                                 newArrayList("name", "lightSaberColor")));
       return;
     }
@@ -98,9 +99,10 @@ public class Objects_assertIsLenientEqualsToByAcceptingFields_Test extends Objec
       objects.assertIsEqualToComparingOnlyGivenFields(info, actual, other, "name", "lightSaberColor");
     } catch (AssertionError err) {
       List<Object> expected = newArrayList((Object) "Luke");
+      List<Object> rejected = newArrayList((Object) "Yoda");
       verify(failures).failure(
           info,
-          shouldBeEqualComparingOnlyGivenFields(actual, newArrayList("name"), expected,
+          shouldBeEqualComparingOnlyGivenFields(actual, newArrayList("name"), rejected, expected,
                                                 newArrayList("name", "lightSaberColor")));
       return;
     }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByIgnoringFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByIgnoringFields_Test.java
@@ -87,8 +87,8 @@ public class Objects_assertIsLenientEqualsToByIgnoringFields_Test extends Object
     } catch (AssertionError err) {
       verify(failures).failure(
           info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) "Blue"),
-                                             newArrayList("name")));
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) "Green"),
+              newArrayList((Object) "Blue"), newArrayList("name")));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -104,8 +104,8 @@ public class Objects_assertIsLenientEqualsToByIgnoringFields_Test extends Object
     } catch (AssertionError err) {
       verify(failures).failure(
           info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) "Blue"),
-                                             new ArrayList<String>()));
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) "Green"),
+              newArrayList((Object) "Blue"), new ArrayList<String>()));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -121,7 +121,7 @@ public class Objects_assertIsLenientEqualsToByIgnoringFields_Test extends Object
     } catch (AssertionError err) {
       verify(failures).failure(
           info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("name"), newArrayList((Object) "Luke"),
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("name"), newArrayList((Object) "Yoda"), newArrayList((Object) "Luke"),
                                              newArrayList("lightSaberColor")));
       return;
     }
@@ -152,7 +152,8 @@ public class Objects_assertIsLenientEqualsToByIgnoringFields_Test extends Object
     } catch (AssertionError err) {
       List<Object> expected = newArrayList((Object) "Green");
       verify(failures).failure(info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), expected, newArrayList("name")));
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) null), expected,
+              newArrayList("name")));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByIgnoringNullFields_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsLenientEqualsToByIgnoringNullFields_Test.java
@@ -72,7 +72,8 @@ public class Objects_assertIsLenientEqualsToByIgnoringNullFields_Test extends Ob
     } catch (AssertionError err) {
       List<String> emptyList = newArrayList();
       verify(failures).failure(info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) "Green"), emptyList));
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("lightSaberColor"), newArrayList((Object) null),
+              newArrayList((Object) "Green"), emptyList));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
@@ -88,7 +89,8 @@ public class Objects_assertIsLenientEqualsToByIgnoringNullFields_Test extends Ob
     } catch (AssertionError err) {
       List<String> emptyList = newArrayList();
       verify(failures).failure(info,
-          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("name"), newArrayList((Object) "Soda"), emptyList));
+          shouldBeEqualToIgnoringGivenFields(actual, newArrayList("name"), newArrayList((Object) "Yoda"), newArrayList((Object) "Soda"),
+              emptyList));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();


### PR DESCRIPTION
This pull request is for issue: #134

During todays hackaton at @pragmatists we added displaying message about actual value when assertion failed for: `isEqualToComparingFieldByField`, `isEqualToIgnoringGivenFields`, `isEqualToIgnoringNullFields`, `isEqualToComparingOnlyGivenFields`. 

`isEqualToComparingFieldByField` was the subject of the issue. Others (similar cases) were needed to eliminate compilation errors and to make change consistent.

So new message after assertion error will look like this:

`Expecting value <10> in field <"y"> but was <2> in ...`
instead of:
`Expecting value <10> in field <'y'> of ..`

And  

`Expecting values:
  <[9, 11]>
in fields:
  <["x", "z"]>
but were:
  <[1, 3]>
in ...`
instead of:
`Expecting values:
  <[9, 11]>
in fields:
  <['x', 'z']>
of ..`
