### PR TITLE
Configure locale EN as @before in test instead of in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${argLine} -Duser.language=en</argLine>
+          <argLine>${argLine}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
+++ b/src/test/java/org/assertj/core/util/xml/XmlStringPrettyFormatter_prettyFormat_Test.java
@@ -14,10 +14,14 @@
  */
 package org.assertj.core.util.xml;
 
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.assertj.core.util.xml.XmlStringPrettyFormatter.xmlPrettyFormat;
 
+import java.util.Locale;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXParseException;
 
@@ -27,6 +31,12 @@ import org.xml.sax.SAXParseException;
  * @author Joel Costigliola
  */
 public class XmlStringPrettyFormatter_prettyFormat_Test {
+	
+  @Before
+  public void before() {
+	// Set locale to be able to check exception message in English.
+	Locale.setDefault(ENGLISH);
+  }
 
   private static final String EXPECTED_FORMATTED_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<rss version=\"2.0\">\n    <channel>\n"
       + "        <title>Java Tutorials and Examples 1</title>\n"


### PR DESCRIPTION
Correction pour que les tests passe dans Eclipse sans casser Jacoco/Jenkins
