### PR TITLE
Issue #144 - extracting private fields with possibility to disallow it globally

### DIFF
--- a/src/main/java/org/assertj/core/util/introspection/FieldSupport.java
+++ b/src/main/java/org/assertj/core/util/introspection/FieldSupport.java
@@ -38,6 +38,8 @@ public class FieldSupport {
 
   private static final FieldSupport INSTANCE = new FieldSupport();
 
+  private static boolean allowExtractingPrivateFields = true;
+
   /**
    * Returns the singleton instance of this class.
    * 
@@ -49,6 +51,17 @@ public class FieldSupport {
 
   @VisibleForTesting
   FieldSupport() {
+  }
+
+  /**
+   * Globally set whether <code>{@link org.assertj.core.api.AbstractIterableAssert#extracting(String)}</code> and
+   * <code>{@link org.assertj.core.api.AbstractObjectArrayAssert#extracting(String)}</code>
+   * should extract private fields or fail with exception.
+   *
+   * @param allowExtractingPrivateFields allow private fields extraction. Default {@code true}.
+   */
+  public static void setAllowExtractingPrivateFields(boolean allowExtractingPrivateFields) {
+    FieldSupport.allowExtractingPrivateFields = allowExtractingPrivateFields;
   }
 
   /**
@@ -169,7 +182,7 @@ public class FieldSupport {
    */
   public <T> T fieldValue(String fieldName, Class<T> clazz, Object target) {
     try {
-      Object readField = FieldUtils.readField(target, fieldName);
+      Object readField = FieldUtils.readField(target, fieldName, allowExtractingPrivateFields);
       return clazz.cast(readField);
     } catch (ClassCastException e) {
       String msg = format("Unable to obtain the value of the field <'%s'> from <%s> - wrong field type specified <%s>",

--- a/src/test/java/org/assertj/core/util/introspection/FieldSupport_fieldValues_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/FieldSupport_fieldValues_Test.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.test.ExpectedException.none;
 import static org.assertj.core.util.Lists.newArrayList;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.junit.BeforeClass;
@@ -34,7 +33,7 @@ import org.assertj.core.test.ExpectedException;
 import org.assertj.core.test.Name;
 
 /**
- * Tests for <code>{@link FieldSupport#fieldValues(String, Collection)}</code>.
+ * Tests for <code>{@link FieldSupport#fieldValues(String, Class, Iterable)}</code>.
  * 
  * @author Joel Costigliola
  */
@@ -101,10 +100,21 @@ public class FieldSupport_fieldValues_Test {
   }
 
   @Test
-  public void should_throw_error_if_field_not_public() {
-    thrown.expect(IntrospectionError.class,
-                  "Unable to obtain the value of the field <'age'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>, check that field is public.");
-    fieldSupport.fieldValues("age", Integer.class, employees);
+  public void should_return_values_of_private_field() {
+    List<Integer> ages = fieldSupport.fieldValues("age", Integer.class, employees);
+    assertEquals(newArrayList(800, 26), ages);
+  }
+
+  @Test
+  public void should_throw_error_if_field_not_public_and_allowExtractingPrivateFields_set_to_false() {
+    FieldSupport.setAllowExtractingPrivateFields(false);
+    try {
+      thrown.expect(IntrospectionError.class,
+              "Unable to obtain the value of the field <'age'> from <Employee[id=1, name=Name[first='Yoda', last='null'], age=800]>, check that field is public.");
+      fieldSupport.fieldValues("age", Integer.class, employees);
+    } finally { // back to default value
+      FieldSupport.setAllowExtractingPrivateFields(true);
+    }
   }
 
   @Test


### PR DESCRIPTION
We've decided that FieldSupport class is a better place for a global flag since this is a place where the flag will be used. Please let us know whether we should add some more documentation. We will submit a pull request to assertj-examples that removes obsolete comment.
