### PR TITLE
Allow users to simply wrap their custom asserts with our assertThat(..)

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -358,6 +358,48 @@ public class Assertions {
   }
 
   /**
+   * Returns the given assertion. This method improves code readability by surrounding the given assertion with
+   * <code>assertThat</code>.
+   * <p>
+   * For example, let's assume we have the following custom assertion class:
+   * 
+   * <pre>
+   * public class ServerSocketAssertion implements AutoAssert {
+   *   private final ServerSocket socket;
+   * 
+   *   public ServerSocketAssertion(ServerSocket socket) {
+   *     this.socket = socket;
+   *   }
+   * 
+   *   public ServerSocketAssert isConnectedTo(int port) {
+   *     assertThat(socket.isBound()).isTrue();
+   *     assertThat(socket.getLocalPort()).isEqualTo(port);
+   *     assertThat(socket.isClosed()).isFalse();
+   *     return this;
+   *   }
+   * }
+   * </pre>
+   * 
+   * </p>
+   * <p>
+   * We can wrap that assertion with "<code>assertThat</code>" to improve test code readability.
+   * 
+   * <pre>
+   * ServerSocketAssertion socket = new ServerSocketAssertion(server.getSocket());
+   * assertThat(socket).isConnectedTo(2000);
+   * </pre>
+   * 
+   * </p>
+   * 
+   * @param <T> the generic type of the user-defined assert.
+   * @param assertion the assertion to return.
+   * @return the given assertion.
+   */
+  public static <T extends AutoAssert> T assertThat(T assertion) {
+    return assertion;
+  }
+
+  /**
    * Creates a new instance of <code>{@link ObjectArrayAssert}</code>.
    *
    * @param actual the actual value.

--- a/src/main/java/org/assertj/core/api/AutoAssert.java
+++ b/src/main/java/org/assertj/core/api/AutoAssert.java
@@ -1,0 +1,31 @@
+package org.assertj.core.api;
+
+/**
+ * A marker interface that can be used to adapt your test code to the assertion-style.
+ * <p>
+ * Consider the following class:
+ * 
+ * <pre>
+ * public class ServerSocketAssertion implements AutoAssert {
+ *   private final ServerSocket socket;
+ * 
+ *   public ServerSocketAssertion(ServerSocket socket) {
+ *     this.socket = socket;
+ *   }
+ * 
+ *   public ServerSocketAssert isConnectedTo(int port) {
+ *     assertThat(socket.isBound()).isTrue();
+ *     assertThat(socket.getLocalPort()).isEqualTo(port);
+ *     assertThat(socket.isClosed()).isFalse();
+ *     return this;
+ *   }
+ * }
+ * </pre>
+ * 
+ * You could then use <code>assertThat(serverSocket).isConnectedTo(80);</code> where <code>serverSocket</code> is an
+ * object of <code>ServerSocketAssertion</code>.
+ * 
+ * @author Christian Rösch
+ */
+public interface AutoAssert {
+}

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_AutoAssert_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_AutoAssert_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Created on Oct 20, 2010
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2010-2011 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(AutoAssert)}</code>.
+ * 
+ * @author Christian Rösch
+ */
+public class Assertions_assertThat_with_AutoAssert_Test {
+
+  @Test
+  public void should_pass_AutoAssert() {
+    MyAssert assertion = new MyAssert(true);
+    assertThat(assertion).isCompletelyTrue();
+
+    Object result = assertThat(assertion);
+    assertThat(result).isSameAs(assertion);
+  }
+
+  private static class MyAssert implements AutoAssert {
+    private boolean value;
+
+    public MyAssert(boolean v) {
+      value = v;
+    }
+
+    void isCompletelyTrue() {
+      assertThat(value).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
As fest-assert had this feature I would expect assertJ to have it to:

Wrap your own assertion-like classes with our assertThat(..) methods.
