### PR TITLE
Fix race condition (in test).

### DIFF
--- a/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInThePast_Test.java
+++ b/src/test/java/org/assertj/core/internal/dates/Dates_assertIsInThePast_Test.java
@@ -56,7 +56,8 @@ public class Dates_assertIsInThePast_Test extends DatesBaseTest {
   public void should_fail_if_actual_is_today() {
     AssertionInfo info = someInfo();
     try {
-      actual = new Date();
+      int oneSecond = 1000;
+      actual = new Date(System.currentTimeMillis() + oneSecond);
       dates.assertIsInThePast(info, actual);
     } catch (AssertionError e) {
       verify(failures).failure(info, shouldBeInThePast(actual));


### PR DESCRIPTION
Just found a race condition while trying to install my testing environment for assertJ on my slow machine :)

Hope I understood the difference to the above test right: This tests that any time today that is not in the past causes the AssertionError and the test above tests that a date in a hundred years causes the AssertionError.

Assuming that, adding a second might be okay.
