### PR TITLE
Dates.assertIsEqualWithPrecision  bug

### DIFF
--- a/src/main/java/org/assertj/core/internal/Dates.java
+++ b/src/main/java/org/assertj/core/internal/Dates.java
@@ -167,8 +167,8 @@ public class Dates {
         calendarActual.set(Calendar.DAY_OF_WEEK, 0);
         calendarOther.set(Calendar.DAY_OF_WEEK, 0);
       case HOURS:
-        calendarActual.set(Calendar.HOUR, 0);
-        calendarOther.set(Calendar.HOUR, 0);
+        calendarActual.set(Calendar.HOUR_OF_DAY, 0);
+        calendarOther.set(Calendar.HOUR_OF_DAY, 0);
       case MINUTES:
         calendarActual.set(Calendar.MINUTE, 0);
         calendarOther.set(Calendar.MINUTE, 0);


### PR DESCRIPTION
assertIsEqualWithPrecision Hours does not work with a date in the morning and a date in the afternoon
