### PR TITLE
FileAssert#hasParent should not fail using absolute path

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -246,6 +246,7 @@ public abstract class AbstractFileAssert<S extends AbstractFileAssert<S>> extend
    * @param expected the expected parent {@code File}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the expected parent {@code File} is {@code null}.
+   * @throws FilesException if an I/O error occurs.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} parent is not equal to the expected one.
    * 

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -267,6 +267,7 @@ public class Files {
    * @param actual the given file.
    * @param expected the expected parent {@code File}.
    * @throws NullPointerException if the expected parent {@code File} is {@code null}.
+   * @throws FilesException if an I/O error occurs.
    * @throws AssertionError if the given {@code File} is {@code null}.
    * @throws AssertionError if the given {@code File} does not have a parent.
    * @throws AssertionError if the given {@code File} parent is not equal to the expected one.
@@ -274,7 +275,13 @@ public class Files {
   public void assertHasParent(AssertionInfo info, File actual, File expected) {
     if (expected == null) throw new NullPointerException("The expected parent file should not be null.");
     assertNotNull(info, actual);
-    if (areEqual(expected, actual.getParentFile())) return;
+    try {
+      if (actual.getParentFile() != null
+          && areEqual(expected.getCanonicalFile(), actual.getParentFile().getCanonicalFile()))
+        return;
+    } catch (IOException e) {
+      throw new FilesException(String.format("Unable to get canonical form of [%s] or [%s].", actual, expected), e);
+    }
     throw failures.failure(info, shouldHaveParent(actual, expected));
   }
 

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
@@ -2,15 +2,19 @@ package org.assertj.core.internal.files;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.FilesException;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for
@@ -64,6 +68,39 @@ public class Files_assertHasParent_Test extends FilesBaseTest {
 
   @Test
   public void should_pass_if_actual_has_expected_parent() throws Exception {
+    files.assertHasParent(someInfo(), actual, expectedParent);
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_parent_when_actual_form_is_absolute() throws Exception {
+    files.assertHasParent(someInfo(), actual.getAbsoluteFile(), expectedParent);
+  }
+
+  @Test
+  public void should_pass_if_actual_has_expected_parent_when_actual_form_is_canonical() throws Exception {
+    files.assertHasParent(someInfo(), actual.getCanonicalFile(), expectedParent);
+  }
+
+  @Test
+  public void should_throw_exception_when_canonical_form_representation_fail() throws Exception {
+    thrown.expect(FilesException.class);
+
+    File actual = mock(File.class);
+    File expectedParent = mock(File.class);
+
+    when(actual.getParentFile()).thenReturn(expectedParent);
+    when(expectedParent.getCanonicalFile()).thenThrow(new IOException());
+
+    files.assertHasParent(someInfo(), actual, expectedParent);
+  }
+
+  @Test
+  public void should_throw_exception_when_canonical_form_representation_fail_for_expected_parent() throws Exception {
+    thrown.expect(FilesException.class);
+
+    File expectedParent = mock(File.class);
+    when(expectedParent.getCanonicalFile()).thenThrow(new IOException());
+
     files.assertHasParent(someInfo(), actual, expectedParent);
   }
 }


### PR DESCRIPTION
Fix for issue #193
