### PR TITLE
Inversion actual/expected in isEqualTo error message [Issue #201]

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -17,15 +17,17 @@
  */
 package org.assertj.core.error;
 
-import static java.lang.Integer.toHexString;
-
-import static org.assertj.core.util.Arrays.array;
-import static org.assertj.core.util.Objects.*;
-
 import org.assertj.core.description.Description;
-import org.assertj.core.internal.*;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.StandardComparisonStrategy;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.VisibleForTesting;
+
+import static java.lang.Integer.toHexString;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Objects.*;
 
 
 /**
@@ -154,7 +156,7 @@ public class ShouldBeEqual implements AssertionErrorFactory {
     if (comparisonStrategy instanceof ComparatorBasedComparisonStrategy)
       return messageFormatter
                .format(description, representation, EXPECTED_BUT_WAS_MESSAGE_USING_COMPARATOR, actual, expected, comparisonStrategy);
-    return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, expected, actual);
+    return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, actual, expected);
   }
 
   /**
@@ -170,7 +172,7 @@ public class ShouldBeEqual implements AssertionErrorFactory {
     if (comparisonStrategy instanceof ComparatorBasedComparisonStrategy)
       return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE_USING_COMPARATOR, detailedActual(),
                                      detailedExpected(), comparisonStrategy);
-    return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, detailedExpected(), detailedActual());
+    return messageFormatter.format(description, representation, EXPECTED_BUT_WAS_MESSAGE, detailedActual(), detailedExpected());
   }
 
   private AssertionError comparisonFailure(Description description) {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
@@ -14,15 +14,6 @@
  */
 package org.assertj.core.error;
 
-import static java.lang.Integer.toHexString;
-import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
-import static org.assertj.core.util.Strings.concat;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Comparator;
-
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 import org.assertj.core.internal.ComparisonStrategy;
@@ -30,6 +21,15 @@ import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Comparator;
+
+import static java.lang.Integer.toHexString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
+import static org.assertj.core.util.Strings.concat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for <code>{@link ShouldBeEqual#newAssertionError(Description, org.assertj.core.presentation.Representation)}</code>.
@@ -54,8 +54,10 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     shouldBeEqual = (ShouldBeEqual) shouldBeEqual(actual, expected, new StandardRepresentation());
     shouldBeEqual.descriptionFormatter = mock(DescriptionFormatter.class);
     when(shouldBeEqual.descriptionFormatter.format(description)).thenReturn(formattedDescription);
+
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
-    assertEquals("[my test] expected:<42.0[]> but was:<42.0[f]>", error.getMessage());
+
+    assertThat(error.getMessage()).isEqualTo("[my test] expected:<42.0[]> but was:<42.0[f]>");
   }
 
   @Test
@@ -65,10 +67,14 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
     shouldBeEqual = (ShouldBeEqual) shouldBeEqual(actual, expected, new StandardRepresentation());
     shouldBeEqual.descriptionFormatter = mock(DescriptionFormatter.class);
     when(shouldBeEqual.descriptionFormatter.format(description)).thenReturn(formattedDescription);
+
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
-    assertEquals("[my test] \nExpecting:\n <\"Person[name=Jake] (Person@" + toHexString(expected.hashCode())
-        + ")\">\nto be equal to:\n <\"Person[name=Jake] (Person@" + toHexString(actual.hashCode()) + ")\">\nbut was not.",
-        error.getMessage());
+
+    assertThat(error.getMessage()).isEqualTo(
+        "[my test] \nExpecting:\n <\"Person[name=Jake] (Person@" + toHexString(actual.hashCode())
+            + ")\">\nto be equal to:\n <\"Person[name=Jake] (Person@" + toHexString(expected.hashCode())
+            + ")\">\nbut was not."
+    );
   }
 
   @Test
@@ -80,10 +86,13 @@ public class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual
         new StandardRepresentation());
     shouldBeEqual.descriptionFormatter = mock(DescriptionFormatter.class);
     when(shouldBeEqual.descriptionFormatter.format(description)).thenReturn(formattedDescription);
+
     AssertionError error = shouldBeEqual.newAssertionError(description, new StandardRepresentation());
-    assertEquals("[my test] \nExpecting:\n <\"Person[name=Jake] (Person@" + toHexString(actual.hashCode())
-        + ")\">\nto be equal to:\n <\"Person[name=Jake] (Person@" + toHexString(expected.hashCode())
-        + ")\">\naccording to 'PersonComparator' comparator but was not.", error.getMessage());
+
+    assertThat(error.getMessage())
+        .isEqualTo("[my test] \nExpecting:\n <\"Person[name=Jake] (Person@" + toHexString(actual.hashCode())
+            + ")\">\nto be equal to:\n <\"Person[name=Jake] (Person@" + toHexString(expected.hashCode())
+            + ")\">\naccording to 'PersonComparator' comparator but was not.");
   }
 
   private static class Person {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
@@ -14,19 +14,17 @@
  */
 package org.assertj.core.error;
 
-import static junit.framework.Assert.*;
-
-import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
-import static org.assertj.core.util.Arrays.array;
-
-import static org.mockito.Mockito.*;
-
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.Before;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -69,8 +67,9 @@ public class ShouldBeEqual_newAssertionError_without_JUnit_Test {
 
   private void check(AssertionError error) throws Exception {
     createComparisonFailure(verify(constructorInvoker));
-    assertFalse(error instanceof ComparisonFailure);
-    assertEquals("[Jedi] \nExpecting:\n <\"Yoda\">\nto be equal to:\n <\"Luke\">\nbut was not.", error.getMessage());
+    assertThat(error).isNotInstanceOf(ComparisonFailure.class);
+    assertThat(error.getMessage())
+        .isEqualTo("[Jedi] \nExpecting:\n <\"Luke\">\nto be equal to:\n <\"Yoda\">\nbut was not.");
   }
 
   private static Object createComparisonFailure(ConstructorInvoker invoker) throws Exception {


### PR DESCRIPTION
Actual and expected were inverted when formatting message since
"expected:\n<%s>\n but was:\n<%s>" changed to "\nExpecting:\n <%s>\nto be
equal to:\n <%s>\nbut was not." in 3dfe40e43bd24bd2f4d3ef394d0bda6d2b5d806e. 
It was only happening when JUnit was not available in classpath.
