### PR TITLE
simple solution for issue #144 "Introduce IteratorAssert" without introducing IteratorAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -187,10 +187,11 @@ public class Assertions {
   }
 
   /**
-   * Creates a new instance of <code>{@link IterableAssert}</code> by consuming the given <code>{@link Iterator}</code>
-   * to build an <code>{@link Iterable}</code>
+   * Creates a new instance of <code>{@link IterableAssert}</code>.
    * <p/>
-   * <b>Be aware thar the given Iterator can't be use anymore since it has been consumed !</b>
+   * <b>Be aware that calls to most methods on returned IterableAssert will consume Iterator so it won't be possible to
+   * iterate over it again.</b> Calling multiple methods on returned IterableAssert is safe as Iterator's elements are
+   * cached by IterableAssert first time Iterator is consumed.
    *
    * @param actual the actual value.
    * @return the created assertion object.

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Iterator_Test.java
@@ -1,12 +1,13 @@
 package org.assertj.core.api;
 
-import static org.assertj.core.util.Sets.newLinkedHashSet;
-
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.hasItems;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.Iterator;
 
@@ -38,5 +39,18 @@ public class Assertions_assertThat_with_Iterator_Test {
   public void should_allow_null() {
     IterableAssert<?> assertions = assertThat((Iterator<?>) null);
     assertThat(assertions.actual).isNull();
+  }
+
+  @Test
+  public void should_not_consume_iterator_when_asserting_non_null() throws Exception {
+    Iterator<?> iterator = mock(Iterator.class);
+    assertThat(iterator).isNotNull();
+    verifyZeroInteractions(iterator);
+  }
+
+  @Test
+  public void iterator_can_be_asserted_twice_even_though_it_can_be_iterated_only_once() throws Exception {
+    Iterator<String> names = asList("Luke", "Leia").iterator();
+    assertThat(names).containsExactly("Luke", "Leia").containsExactly("Luke", "Leia");
   }
 }


### PR DESCRIPTION
I believe this patch solves the problem described in https://github.com/joel-costigliola/assertj-core/issues/141 (Introduce IteratorAssert) without actually implementing IteratorAssert which would be a lot of code.

Proposed solution introduces Iterable implementation that consumes Iterator lazily - only when it is requested (in that case by IterableAssert). This way we can reuse IterableAssert in a way that avoids consuming Iterator when it is not needed.
