### PR TITLE
Fix for Files.contentOf test under Windows

### DIFF
--- a/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
@@ -35,8 +35,7 @@ public class Files_contentOf_Test {
   public ExpectedException thrown = none();
 
   private final File sampleFile = new File("src/test/resources/utf8.txt");
-  private final String expectedContent = "A text file encoded in UTF-8, with diacritics:"
-                                           + System.getProperty("line.separator") + "é à";
+  private final String expectedContent = "A text file encoded in UTF-8, with diacritics:\né à";
 
   @Test
   public void should_throw_exception_if_charset_is_null() {


### PR DESCRIPTION
Had an issue running the tests under Windows - Files+contentOf_Test was failing. I tracked this down to the use of "System.getProperty("line.separator")" in the expectedContent setting. The sample file contains "\n" as the line separator and the test originally used the system line separator setting for the expected file contents. This worked on Unix because the system line separator property is "\n" (which matches the file), but on Windows the system line separator is "\r\n" so it doesn't match the file which still has "\n". Explicitly specifying "\n" rather than using the system property seems to be the best solution to the problem.

I have tested that this test now passes out-of-the-box on both Unix and Windows and the tests pass.
