### PR TITLE
Fix #217 : Line count should start at 1 not 0

### DIFF
--- a/src/main/java/org/assertj/core/internal/Diff.java
+++ b/src/main/java/org/assertj/core/internal/Diff.java
@@ -109,7 +109,7 @@ public class Diff {
 
   private List<String> diff(BufferedReader actual, BufferedReader expected) throws IOException {
     List<String> diffs = new ArrayList<String>();
-    int lineNumber = 0;
+    int lineNumber = 1;
     while (true) {
       String actualLine = actual.readLine();
       String expectedLine = expected.readLine();

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -168,7 +168,7 @@ public class SoftAssertionsTest {
 
       assertThat(errors.get(20)).isEqualTo("\nInputStreams do not have equal content:"
                                            + System.getProperty("line.separator")
-                                           + "line:<0>, expected:<B> but was:<A>");
+                                           + "line:<1>, expected:<B> but was:<A>");
 
       assertThat(errors.get(21)).isEqualTo("expected:<2[1]> but was:<2[0]>");
       assertThat(errors.get(22)).isEqualTo("expected:<2[3]> but was:<2[2]>");

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
@@ -73,7 +73,7 @@ public class Diff_diff_File_String_Test {
     String expected = "Touché";
     List<String> diffs = diff.diff(actual, expected, ISO_8859_1);
     assertEquals(1, diffs.size());
-    assertEquals("line:<0>, expected:<Touché> but was:<TouchÃ©>", diffs.get(0));
+    assertEquals("line:<1>, expected:<Touché> but was:<TouchÃ©>", diffs.get(0));
   }
 
   @Test
@@ -83,7 +83,7 @@ public class Diff_diff_File_String_Test {
     List<String> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     System.out.println(diffs);
     assertEquals(1, diffs.size());
-    assertEquals("line:<1>, expected:<line_1> but was:<EOF>", diffs.get(0));
+    assertEquals("line:<2>, expected:<line_1> but was:<EOF>", diffs.get(0));
   }
 
   @Test
@@ -92,6 +92,6 @@ public class Diff_diff_File_String_Test {
     String expected = "line_0";
     List<String> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertEquals(1, diffs.size());
-    assertEquals("line:<1>, expected:<EOF> but was:<line_1>", diffs.get(0));
+    assertEquals("line:<2>, expected:<EOF> but was:<line_1>", diffs.get(0));
   }
 }

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
@@ -74,8 +74,8 @@ public class Diff_diff_File_Test {
     writer.write(expected, "line0", "line1");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(2, diffs.size());
-    assertEquals("line:<0>, expected:<line0> but was:<line_0>", diffs.get(0));
-    assertEquals("line:<1>, expected:<line1> but was:<line_1>", diffs.get(1));
+    assertEquals("line:<1>, expected:<line0> but was:<line_0>", diffs.get(0));
+    assertEquals("line:<2>, expected:<line1> but was:<line_1>", diffs.get(1));
   }
 
   @Test
@@ -84,7 +84,7 @@ public class Diff_diff_File_Test {
     writer.write(expected, "line_0", "line_1");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(1, diffs.size());
-    assertEquals("line:<1>, expected:<line_1> but was:<EOF>", diffs.get(0));
+    assertEquals("line:<2>, expected:<line_1> but was:<EOF>", diffs.get(0));
   }
 
   @Test
@@ -93,6 +93,6 @@ public class Diff_diff_File_Test {
     writer.write(expected, "line_0");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(1, diffs.size());
-    assertEquals("line:<1>, expected:<EOF> but was:<line_1>", diffs.get(0));
+    assertEquals("line:<2>, expected:<EOF> but was:<line_1>", diffs.get(0));
   }
 }

--- a/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_Test.java
@@ -67,8 +67,8 @@ public class Diff_diff_InputStream_Test {
     expected = stream("base", "line0", "line1");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(2, diffs.size());
-    assertEquals("line:<1>, expected:<line0> but was:<line_0>", diffs.get(0));
-    assertEquals("line:<2>, expected:<line1> but was:<line_1>", diffs.get(1));
+    assertEquals("line:<2>, expected:<line0> but was:<line_0>", diffs.get(0));
+    assertEquals("line:<3>, expected:<line1> but was:<line_1>", diffs.get(1));
   }
 
   @Test
@@ -77,7 +77,7 @@ public class Diff_diff_InputStream_Test {
     expected = stream("base", "line_0", "line_1");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(1, diffs.size());
-    assertEquals("line:<2>, expected:<line_1> but was:<EOF>", diffs.get(0));
+    assertEquals("line:<3>, expected:<line_1> but was:<EOF>", diffs.get(0));
   }
 
   @Test
@@ -86,6 +86,6 @@ public class Diff_diff_InputStream_Test {
     expected = stream("base", "line_0");
     List<String> diffs = diff.diff(actual, expected);
     assertEquals(1, diffs.size());
-    assertEquals("line:<2>, expected:<EOF> but was:<line_1>", diffs.get(0));
+    assertEquals("line:<3>, expected:<EOF> but was:<line_1>", diffs.get(0));
   }
 }


### PR DESCRIPTION
When comparing file content the line number in diff
should start at 0 instead of 1.
