### PR TITLE
Add haveAtLeastOne(condition) to ObjectEnumerableAssert as an alias for ...

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -316,6 +316,12 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
     return myself;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public S haveAtLeastOne(Condition<? super T> condition) {
+    return haveAtLeast(1, condition);
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -257,6 +257,12 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
 
   /** {@inheritDoc} */
   @Override
+  public S haveAtLeastOne(Condition<? super T> condition) {
+    return haveAtLeast(1, condition);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public S haveAtLeast(int times, Condition<? super T> condition) {
     arrays.assertHaveAtLeast(info, actual, times, condition);
     return myself;

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -309,6 +309,13 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
   S areExactly(int n, Condition<? super T> condition);
 
   /**
+   * This method is an alias for {@code haveAtLeast(1, condition)}.
+   *
+   * @see #haveAtLeast(int, Condition)
+   */
+  S haveAtLeastOne(Condition<? super T> condition);
+
+  /**
    * This method is an alias for {@link #areAtLeast(int, Condition)}.
    */
   S haveAtLeast(int n, Condition<? super T> condition);

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_haveAtLeastOne_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_haveAtLeastOne_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Created on August 28, 2014
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2014 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.IterableAssertBaseTest;
+import org.assertj.core.api.TestCondition;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#haveAtLeastOne(org.assertj.core.api.Condition)}</code>.
+ *
+ * @author Adam Ruka
+ */
+public class IterableAssert_haveAtLeastOne_Test extends IterableAssertBaseTest {
+  private static final Condition<Object> condition = new TestCondition<Object>();
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.haveAtLeastOne(condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertHaveAtLeast(getInfo(assertions), getActual(assertions), 1, condition);
+  }
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_haveAtLeastOne_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_haveAtLeastOne_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Created on August 28, 2014
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2014 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.mockito.Mockito.*;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+import org.assertj.core.api.TestCondition;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ObjectArrayAssert#haveAtLeastOne(org.assertj.core.api.Condition)}</code>.
+ *
+ * @author Adam Ruka
+ */
+public class ObjectArrayAssert_haveAtLeastOne_Test extends ObjectArrayAssertBaseTest {
+  private static final Condition<Object> condition = new TestCondition<Object>();
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.haveAtLeastOne(condition);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHaveAtLeast(getInfo(assertions), getActual(assertions), 1, condition);
+  }
+}


### PR DESCRIPTION
...haveAtLeast(1, condition) - fixes #185
