### PR TITLE
Java 8 - Introspection property support for getter defined as default method

### DIFF
--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -1,15 +1,15 @@
 /*
  * Created on Jun 28, 2010
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * Copyright @2010-2012 the original author or authors.
  */
 package org.assertj.core.util.introspection;
@@ -27,13 +27,13 @@ import java.lang.reflect.Method;
 /**
  * Utility methods related to <a
  * href="http://java.sun.com/docs/books/tutorial/javabeans/introspection/index.html">JavaBeans Introspection</a>.
- * 
+ *
  * @author Alex Ruiz
  */
 public final class Introspection {
   /**
    * Returns a {@link PropertyDescriptor} for a property matching the given name in the given object.
-   * 
+   *
    * @param propertyName the given property name.
    * @param target the given object.
    * @return a {@code PropertyDescriptor} for a property matching the given name in the given object.
@@ -45,8 +45,38 @@ public final class Introspection {
   public static PropertyDescriptor getProperty(String propertyName, Object target) {
     checkNotNullOrEmpty(propertyName);
     checkNotNull(target);
-    BeanInfo beanInfo = null;
+
     Class<?> type = target.getClass();
+    PropertyDescriptor prop = getBeanProperty(type, propertyName);
+    if (prop != null) {
+      return prop;
+    }
+
+    prop = digForDefaultImplementations(type, propertyName);
+
+    if (prop != null) {
+      return prop;
+    }
+    throw new IntrospectionError(propertyNotFoundErrorMessage(propertyName, target));
+  }
+
+  private static PropertyDescriptor digForDefaultImplementations(Class<?> type, String propertyName) {
+    for (Class<?> interfaces : type.getInterfaces()) {
+
+      PropertyDescriptor prop = getBeanProperty(interfaces, propertyName);
+      if (prop != null) {
+        return prop;
+      }
+      if ((prop = digForDefaultImplementations(interfaces, propertyName)) != null) {
+        return prop;
+      }
+    }
+
+    return null;
+  }
+
+  private static PropertyDescriptor getBeanProperty(Class<?> type, String propertyName) {
+    BeanInfo beanInfo;
     try {
       beanInfo = Introspector.getBeanInfo(type);
     } catch (Throwable t) {
@@ -57,7 +87,8 @@ public final class Introspection {
         return descriptor;
       }
     }
-    throw new IntrospectionError(propertyNotFoundErrorMessage(propertyName, target));
+
+    return null;
   }
 
   private static String propertyNotFoundErrorMessage(String propertyName, Object target) {


### PR DESCRIPTION
If in Java 8 a Class implements interface with default methods these are not seen when using Introspections. For example code below doesn't work when getter for defined property exists as default method in Interface.

code:
assertThat(someObject.getCollection())
        .extracting("propertyFromClass", "propertyFromInterfaceWithDefaultImpl")
