### PR TITLE
Consistency: isEmpty and isNullOrEmpty should return the assertion object.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractBooleanArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractBooleanArrayAssert.java
@@ -18,14 +18,16 @@ public abstract class AbstractBooleanArrayAssert<S extends AbstractBooleanArrayA
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, boolean[], Boolean> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, boolean[], Boolean> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractByteArrayAssert<S extends AbstractByteArrayAssert<
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, byte[], Byte> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, byte[], Byte> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractCharArrayAssert<S extends AbstractCharArrayAssert<
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, char[], Character> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, char[], Character> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -70,8 +70,9 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * @throws AssertionError if the actual {@code CharSequence} has a non-zero length.
    */
   @Override
-  public void isNullOrEmpty() {
+  public S isNullOrEmpty() {
     strings.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /**
@@ -97,8 +98,9 @@ public abstract class AbstractCharSequenceAssert<S extends AbstractCharSequenceA
    * @throws AssertionError if the actual {@code CharSequence} has a non-zero length or is null.
    */
   @Override
-  public void isEmpty() {
+  public S isEmpty() {
     strings.assertEmpty(info, actual);
+    return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractDoubleArrayAssert<S extends AbstractDoubleArrayAss
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, double[], Double> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, double[], Double> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractFloatArrayAssert<S extends AbstractFloatArrayAsser
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, float[], Float> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, float[], Float> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIntArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractIntArrayAssert<S extends AbstractIntArrayAssert<S>
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, int[], Integer> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, int[], Integer> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -71,16 +71,18 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * {@inheritDoc}
    */
   @Override
-  public void isNullOrEmpty() {
-	iterables.assertNullOrEmpty(info, actual);
+  public S isNullOrEmpty() {
+    iterables.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public void isEmpty() {
-	iterables.assertEmpty(info, actual);
+  public S isEmpty() {
+    iterables.assertEmpty(info, actual);
+    return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractLongArrayAssert<S extends AbstractLongArrayAssert<
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, long[], Long> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, long[], Long> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -52,14 +52,16 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
-	maps.assertNullOrEmpty(info, actual);
+  public S isNullOrEmpty() {
+    maps.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
-	maps.assertEmpty(info, actual);
+  public S isEmpty() {
+    maps.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -65,8 +65,9 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * @throws AssertionError {@inheritDoc}
    */
   @Override
-  public void isNullOrEmpty() {
-	arrays.assertNullOrEmpty(info, actual);
+  public AbstractObjectArrayAssert<S, T> isNullOrEmpty() {
+    arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /**
@@ -75,8 +76,9 @@ public abstract class AbstractObjectArrayAssert<S extends AbstractObjectArrayAss
    * @throws AssertionError {@inheritDoc}
    */
   @Override
-  public void isEmpty() {
-	arrays.assertEmpty(info, actual);
+  public AbstractObjectArrayAssert<S, T> isEmpty() {
+    arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractShortArrayAssert.java
@@ -19,14 +19,16 @@ public abstract class AbstractShortArrayAssert<S extends AbstractShortArrayAsser
 
   /** {@inheritDoc} */
   @Override
-  public void isNullOrEmpty() {
+  public AbstractEnumerableAssert<S, short[], Short> isNullOrEmpty() {
     arrays.assertNullOrEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */
   @Override
-  public void isEmpty() {
+  public AbstractEnumerableAssert<S, short[], Short> isEmpty() {
     arrays.assertEmpty(info, actual);
+    return myself;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/org/assertj/core/api/EnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/EnumerableAssert.java
@@ -33,13 +33,13 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, E>, E> {
    * Verifies that the actual group of values is {@code null} or empty.
    * @throws AssertionError if the actual group of values is not {@code null} or not empty.
    */
-  void isNullOrEmpty();
+  S isNullOrEmpty();
 
   /**
    * Verifies that the actual group of values is empty.
    * @throws AssertionError if the actual group of values is not empty.
    */
-  void isEmpty();
+  S isEmpty();
 
   /**
    * Verifies that the actual group of values is not empty.


### PR DESCRIPTION
- Right now there is an inconsistency between all other "asserts" and
  `isEmpty` and `isNullOrEmpty`.
- I like the assertions to be in front of a potential description so I like to write:

```
  assertThat(fellowshipOfTheRing)
    .isNotEmpty()
    .contains(bilbo)
    .as("Expected Bilbo to be part of the fellowship!");
```
- The same style does not work for the reverse:

```
  assertThat(hobbitsToBeRescued)
    .isEmpty() // returns void in 1.7.0!
    .as("Expected that no hobbits are in danger!"); // impossible right now.
```
- This PR just returns `myself` in consistency with all other methods of this group, so
  I am able to append the `describedAs` or `as` methods at the end of the invocation.
- Unfortunately everyone who has implemented `EnumerableAssert` directly would have to
  update her code, so maybe this should be part of version 2.0.

This is the second take, first was #274.
