### PR TITLE
Fixes #264 : Skip unexpected elements when there are none

### DIFF
--- a/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
+++ b/src/main/java/org/assertj/core/error/BasicErrorMessageFactory.java
@@ -43,6 +43,10 @@ public class BasicErrorMessageFactory implements ErrorMessageFactory {
   @VisibleForTesting
   MessageFormatter formatter = MessageFormatter.instance();
 
+  protected static boolean isEmpty(Iterable<?> notExpected) {
+    return notExpected != null && !notExpected.iterator().hasNext();
+  }
+
   /**
    * To avoid quoted String in message format.
    */

--- a/src/main/java/org/assertj/core/error/ShouldContainExactly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainExactly.java
@@ -42,6 +42,25 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
 
   /**
    * Creates a new </code>{@link ShouldContainExactly}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainExactly(Object actual, Object expected, Object notFound,
+                                                         Iterable<?> notExpected, ComparisonStrategy comparisonStrategy) {
+    if (isEmpty(notExpected)) {
+      return new ShouldContainExactly(actual, expected, notFound, comparisonStrategy);
+    }
+
+    return new ShouldContainExactly(actual, expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new </code>{@link ShouldContainExactly}</code>.
    * 
    * @param actual the actual value in the failed assertion.
    * @param expected values expected to be contained in {@code actual}.
@@ -54,11 +73,31 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
     return new ShouldContainExactly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new </code>{@link ShouldContainExactly}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainExactly(Object actual, Object expected, Object notFound,
+                                                         Iterable<?> notExpected) {
+
+    return shouldContainExactly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+  }
+
   private ShouldContainExactly(Object actual, Object expected, Object notFound, Object notExpected,
-      ComparisonStrategy comparisonStrategy) {
-    super(
-        "\nExpecting:\n <%s>\nto contain exactly (and in same order):\n <%s>\nbut some elements were not found:\n <%s>\nand others were not expected:\n <%s>\n%s",
-        actual, expected, notFound, notExpected, comparisonStrategy);
+                               ComparisonStrategy comparisonStrategy) {
+    super("\nExpecting:\n <%s>\nto contain exactly (and in same order):\n <%s>\nbut some elements were not found:\n <%s>\n"
+          + "and others were not expected:\n <%s>\n%s",
+          actual, expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  private ShouldContainExactly(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
+    super("\nExpecting:\n <%s>\nto contain exactly (and in same order):\n <%s>\nbut could not find the following elements:\n <%s>\n%s",
+          actual, expected, notFound, comparisonStrategy);
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/ShouldContainOnly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnly.java
@@ -46,16 +46,53 @@ public class ShouldContainOnly extends BasicErrorMessageFactory {
    * @param expected values expected to be contained in {@code actual}.
    * @param notFound values in {@code expected} not found in {@code actual}.
    * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Object notFound,
+                                                      Iterable<?> notExpected, ComparisonStrategy comparisonStrategy) {
+    if (isEmpty(notExpected)) {
+      return new ShouldContainOnly(actual, expected, notFound, comparisonStrategy);
+    }
+
+    return new ShouldContainOnly(actual, expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new </code>{@link ShouldContainOnly}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
   public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Object notFound, Object notExpected) {
-    return new ShouldContainOnly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+    return shouldContainOnly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+  }
+
+  /**
+   * Creates a new </code>{@link ShouldContainOnly}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainOnly(Object actual, Object expected, Object notFound,
+                                                      Iterable<?> notExpected) {
+    return shouldContainOnly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
   }
 
   private ShouldContainOnly(Object actual, Object expected, Object notFound, Object notExpected,
       ComparisonStrategy comparisonStrategy) {
     super("\nExpecting:\n <%s>\nto contain only:\n <%s>\nelements not found:\n <%s>\nand elements not expected:\n <%s>\n%s", actual,
         expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  private ShouldContainOnly(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
+    super("\nExpecting:\n <%s>\nto contain only:\n <%s>\nbut could not find the following elements:\n"
+          + " <%s>\n%s",
+          actual, expected, notFound, comparisonStrategy);
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldContainOnlyKeys.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainOnlyKeys.java
@@ -37,10 +37,31 @@ public class ShouldContainOnlyKeys extends BasicErrorMessageFactory {
     return new ShouldContainOnlyKeys(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new </code>{@link ShouldContainOnlyKeys}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainOnlyKeys(Object actual, Object expected, Object notFound,
+                                                          Iterable<?> notExpected) {
+    if (isEmpty(notExpected)) {
+      return new ShouldContainOnlyKeys(actual, expected, notFound, StandardComparisonStrategy.instance());
+    }
+    return new ShouldContainOnlyKeys(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+  }
+
   private ShouldContainOnlyKeys(Object actual, Object expected, Object notFound, Object notExpected,
       ComparisonStrategy comparisonStrategy) {
     super("\nExpecting:\n  <%s>\nto contain only following keys:\n  <%s>\nkeys not found:\n  <%s>\nand keys not expected:\n  <%s>\n%s", actual,
         expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  private ShouldContainOnlyKeys(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
+    super("\nExpecting:\n  <%s>\nto contain only following keys:\n  <%s>\nbut could not find the following keys:\n  <%s>\n%s",
+          actual, expected, notFound, comparisonStrategy);
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
@@ -27,6 +27,7 @@ import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 
 /**
  * Tests for <code>{@link ShouldContainExactly#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
@@ -35,38 +36,63 @@ import org.junit.Test;
  */
 public class ShouldContainExactly_create_Test {
 
-  private ErrorMessageFactory factory;
-
-  @Before
-  public void setUp() {
-    factory = shouldContainExactly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"), newLinkedHashSet("Luke"),
-        newLinkedHashSet("Han"));
-  }
-
   @Test
   public void should_create_error_message() {
+    ErrorMessageFactory factory = shouldContainExactly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"),
+                                                       newLinkedHashSet("Luke"), newLinkedHashSet("Han"));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-    assertEquals(
-        "[Test] \nExpecting:\n <[\"Yoda\", \"Han\"]>\nto contain exactly (and in same order):\n"
-            + " <[\"Luke\", \"Yoda\"]>\nbut some elements were not found:\n <[\"Luke\"]>\nand others were not expected:\n <[\"Han\"]>\n",
-        message);
+
+    assertEquals("[Test] \nExpecting:\n <[\"Yoda\", \"Han\"]>\nto contain exactly (and in same order):\n"
+                 + " <[\"Luke\", \"Yoda\"]>\nbut some elements were not found:\n <[\"Luke\"]>\nand others were not "
+                 + "expected:\n <[\"Han\"]>\n",
+                 message);
   }
 
   @Test
   public void should_create_error_message_with_custom_comparison_strategy() {
     ErrorMessageFactory factory = shouldContainExactly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"),
-        newLinkedHashSet("Luke"), newLinkedHashSet("Han"), new ComparatorBasedComparisonStrategy(
-            CaseInsensitiveStringComparator.instance));
+                                                       newLinkedHashSet("Luke"), newLinkedHashSet("Han"),
+                                                       new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals("[Test] \nExpecting:\n <[\"Yoda\", \"Han\"]>\nto contain exactly (and in same order):\n"
         + " <[\"Luke\", \"Yoda\"]>\nbut some elements were not found:\n <[\"Luke\"]>\nand others were not expected:\n"
         + " <[\"Han\"]>\nwhen comparing values using 'CaseInsensitiveStringComparator'", message);
   }
 
   @Test
-  public void should_create_error_message_when_only_elements_order_differs() {
-    factory = shouldContainExactly("Luke", "Han", 1);
+  public void should_not_display_unexpected_elements_when_there_are_none() {
+    ErrorMessageFactory factory = shouldContainExactly(newArrayList("Yoda"), newArrayList("Luke", "Yoda"),
+                                                       newLinkedHashSet("Luke"), Collections.emptySet());
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertEquals("[Test] \nExpecting:\n <[\"Yoda\"]>\nto contain exactly (and in same order):\n"
+                 + " <[\"Luke\", \"Yoda\"]>\nbut could not find the following elements:\n <[\"Luke\"]>\n",
+                 message);
+  }
+
+  @Test
+  public void should_not_display_unexpected_elements_when_there_are_none_with_custom_comparison_strategy() {
+    ErrorMessageFactory factory = shouldContainExactly(newArrayList("Yoda"), newArrayList("Luke", "Yoda"),
+                                                       newLinkedHashSet("Luke"), Collections.emptySet(),
+                                                       new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertEquals("[Test] \nExpecting:\n <[\"Yoda\"]>\nto contain exactly (and in same order):\n"
+                 + " <[\"Luke\", \"Yoda\"]>\nbut could not find the following elements:\n <[\"Luke\"]>\n"
+                 + "when comparing values using 'CaseInsensitiveStringComparator'", message);
+  }
+
+  @Test
+  public void should_create_error_message_when_only_elements_order_differs() {
+    ErrorMessageFactory factory = shouldContainExactly("Luke", "Han", 1);
+
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals(
         "[Test] \nActual and expected have the same elements but not in the same order, at index 1 actual element was:\n"
             + " <\"Luke\">\nwhereas expected element was:\n <\"Han\">\n", message);
@@ -74,9 +100,11 @@ public class ShouldContainExactly_create_Test {
 
   @Test
   public void should_create_error_message_when_only_elements_order_differs_according_to_custom_comparison_strategy() {
-    factory = shouldContainExactly("Luke", "Han", 1, new ComparatorBasedComparisonStrategy(
-        CaseInsensitiveStringComparator.instance));
+    ErrorMessageFactory factory = shouldContainExactly("Luke", "Han", 1,
+                                                       new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals(
         "[Test] \nActual and expected have the same elements but not in the same order, at index 1 actual element was:\n"
             + " <\"Luke\">\nwhereas expected element was:\n <\"Han\">\nwhen comparing values using 'CaseInsensitiveStringComparator'",

--- a/src/test/java/org/assertj/core/error/ShouldContainOnlyKeys_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnlyKeys_create_Test.java
@@ -21,6 +21,7 @@ import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.assertj.core.description.TextDescription;
@@ -37,28 +38,39 @@ import org.junit.Test;
  */
 public class ShouldContainOnlyKeys_create_Test {
 
-  private ErrorMessageFactory factory;
-
-  @SuppressWarnings("unchecked")
-  @Before
-  public void setUp() {
-    factory = shouldContainOnlyKeys((Map<String, String>) mapOf(entry("name", "Yoda"), entry("color", "green")),
-                                    newArrayList("jedi", "color"),
-                                    newLinkedHashSet("name"),
-                                    newLinkedHashSet("jedi"));
-  }
-
   @Test
   public void should_create_error_message() {
+    ErrorMessageFactory factory = shouldContainOnlyKeys(mapOf(entry("name", "Yoda"), entry("color", "green")),
+                                                        newArrayList("jedi", "color"), newLinkedHashSet("jedi"),
+                                                        newLinkedHashSet("name"));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals("[Test] \n"
                  + "Expecting:\n"
                  + "  <{\"name\"=\"Yoda\", \"color\"=\"green\"}>\n"
                  + "to contain only following keys:\n"
                  + "  <[\"jedi\", \"color\"]>\n"
                  + "keys not found:\n"
-                 + "  <[\"name\"]>\n"
+                 + "  <[\"jedi\"]>\n"
                  + "and keys not expected:\n"
+                 + "  <[\"name\"]>\n", message);
+  }
+
+  @Test
+  public void should_not_display_unexpected_elements_when_there_are_none() {
+    ErrorMessageFactory factory = shouldContainOnlyKeys(mapOf(entry("color", "green")),
+                                                        newArrayList("jedi", "color"), newLinkedHashSet("jedi"),
+                                                        Collections.emptySet());
+
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertEquals("[Test] \n"
+                 + "Expecting:\n"
+                 + "  <{\"color\"=\"green\"}>\n"
+                 + "to contain only following keys:\n"
+                 + "  <[\"jedi\", \"color\"]>\n"
+                 + "but could not find the following keys:\n"
                  + "  <[\"jedi\"]>\n", message);
   }
 

--- a/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainOnly_create_Test.java
@@ -27,6 +27,8 @@ import org.assertj.core.util.CaseInsensitiveStringComparator;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 /**
  * Tests for <code>{@link ShouldContainOnly#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
  * 
@@ -36,27 +38,51 @@ import org.junit.Test;
  */
 public class ShouldContainOnly_create_Test {
 
-  private ErrorMessageFactory factory;
-
-  @Before
-  public void setUp() {
-    factory = shouldContainOnly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"), newLinkedHashSet("Luke"), newLinkedHashSet("Han"));
-  }
-
   @Test
   public void should_create_error_message() {
+    ErrorMessageFactory factory = shouldContainOnly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"),
+                                                    newLinkedHashSet("Luke"), newLinkedHashSet("Han"));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals("[Test] \nExpecting:\n <[\"Yoda\", \"Han\"]>\nto contain only:\n <[\"Luke\", \"Yoda\"]>\n"
         + "elements not found:\n <[\"Luke\"]>\nand elements not expected:\n <[\"Han\"]>\n", message);
   }
 
   @Test
   public void should_create_error_message_with_custom_comparison_strategy() {
-    ErrorMessageFactory factory = shouldContainOnly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"), newLinkedHashSet("Luke"), newLinkedHashSet("Han"),
-        new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    ErrorMessageFactory factory = shouldContainOnly(newArrayList("Yoda", "Han"), newArrayList("Luke", "Yoda"),
+                                                    newLinkedHashSet("Luke"), newLinkedHashSet("Han"),
+                                                    new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
     assertEquals("[Test] \nExpecting:\n <[\"Yoda\", \"Han\"]>\nto contain only:\n <[\"Luke\", \"Yoda\"]>\n"
         + "elements not found:\n <[\"Luke\"]>\nand elements not expected:\n <[\"Han\"]>\n"
         + "when comparing values using 'CaseInsensitiveStringComparator'", message);
+  }
+
+  @Test
+  public void should_not_display_unexpected_elements_when_there_are_none() {
+    ErrorMessageFactory factory = shouldContainOnly(newArrayList("Yoda"), newArrayList("Luke", "Yoda"),
+                                                    newLinkedHashSet("Luke"), Collections.emptySet());
+
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertEquals("[Test] \nExpecting:\n <[\"Yoda\"]>\nto contain only:\n <[\"Luke\", \"Yoda\"]>\n"
+                 + "but could not find the following elements:\n <[\"Luke\"]>\n", message);
+  }
+
+  @Test
+  public void should_not_display_unexpected_elements_when_there_are_none_with_custom_comparison_strategy() {
+    ErrorMessageFactory factory = shouldContainOnly(newArrayList("Yoda"), newArrayList("Luke", "Yoda"),
+                                                    newLinkedHashSet("Luke"), Collections.emptySet(),
+                                                    new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    assertEquals("[Test] \nExpecting:\n <[\"Yoda\"]>\nto contain only:\n <[\"Luke\", \"Yoda\"]>\n"
+                 + "but could not find the following elements:\n <[\"Luke\"]>\n"
+                 + "when comparing values using 'CaseInsensitiveStringComparator'", message);
   }
 }


### PR DESCRIPTION
This applies to the following methods :
- containsOnly
- containsOnlyKeys
- containsExactly
