### PR TITLE
Fixed rest of merge conflict in FileAssert license

### DIFF
--- a/src/main/java/org/assertj/core/api/FileAssert.java
+++ b/src/main/java/org/assertj/core/api/FileAssert.java
@@ -10,29 +10,6 @@
  *
  * Copyright 2012-2014 the original author or authors.
  */
-/*
- * Created on Jan 28, 2011
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
-<<<<<<< HEAD
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
- * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- * 
- * Copyright @2011 the original author or authors.
-=======
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- *
- * Copyright @2011-2012 the original author or authors.
->>>>>>> refs/heads/github-71
- */
 package org.assertj.core.api;
 
 import java.io.File;


### PR DESCRIPTION
Hi, while randomly browsing through the source code I noticed that there are remainders of a merge conflict in the license of said file. I've taken the liberty to fix this, the header now looks like on other files in the same directory.
