### PR TITLE
Use platform-specific newlines when verifying error messages

### DIFF
--- a/src/test/java/org/assertj/core/error/ShouldHaveAtLeastOneElementOfType_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveAtLeastOneElementOfType_create_Test.java
@@ -30,24 +30,24 @@ public class ShouldHaveAtLeastOneElementOfType_create_Test {
   public void should_create_error_message_for_iterable() {
 	ErrorMessageFactory factory = shouldHaveAtLeastOneElementOfType(newArrayList("Yoda", "Luke"), Long.class);
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \n"
-	                              + "Expecting:\n"
-	                              + "  <[\"Yoda\", \"Luke\"]>\n"
-	                              + "to have at least one element of type:\n"
-	                              + "  <java.lang.Long>\n"
-	                              + "but had none.");
+	assertThat(message).isEqualTo(String.format("[Test] %n"
+	                              + "Expecting:%n"
+	                              + "  <[\"Yoda\", \"Luke\"]>%n"
+	                              + "to have at least one element of type:%n"
+	                              + "  <java.lang.Long>%n"
+	                              + "but had none."));
   }
 
   @Test
   public void should_create_error_message_for_array() {
 	ErrorMessageFactory factory = shouldHaveAtLeastOneElementOfType(array("Yoda", "Luke"), Long.class);
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \n"
-	                              + "Expecting:\n"
-	                              + "  <[\"Yoda\", \"Luke\"]>\n"
-	                              + "to have at least one element of type:\n"
-	                              + "  <java.lang.Long>\n"
-	                              + "but had none.");
+	assertThat(message).isEqualTo(String.format("[Test] %n"
+	                              + "Expecting:%n"
+	                              + "  <[\"Yoda\", \"Luke\"]>%n"
+	                              + "to have at least one element of type:%n"
+	                              + "  <java.lang.Long>%n"
+	                              + "but had none."));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveOnlyElementsOfType_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveOnlyElementsOfType_create_Test.java
@@ -34,13 +34,13 @@ public class ShouldHaveOnlyElementsOfType_create_Test {
 	list.add(5L);
 	ErrorMessageFactory factory = shouldHaveOnlyElementsOfType(list, String.class, Long.class);
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \n"
-	                              + "Expecting:\n"
-	                              + "  <[\"Yoda\", 5L]>\n"
-	                              + "to only have elements of type:\n"
-	                              + "  <java.lang.String>\n"
-	                              + "but found:\n"
-	                              + "  <java.lang.Long>");
+	assertThat(message).isEqualTo(String.format("[Test] %n"
+	                              + "Expecting:%n"
+	                              + "  <[\"Yoda\", 5L]>%n"
+	                              + "to only have elements of type:%n"
+	                              + "  <java.lang.String>%n"
+	                              + "but found:%n"
+	                              + "  <java.lang.Long>"));
   }
 
   @Test
@@ -48,13 +48,13 @@ public class ShouldHaveOnlyElementsOfType_create_Test {
 	Object[] array = new Object[] { "Yoda", 5L };
 	ErrorMessageFactory factory = shouldHaveOnlyElementsOfType(array, String.class, Long.class);
 	String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
-	assertThat(message).isEqualTo("[Test] \n"
-	                              + "Expecting:\n"
-	                              + "  <[\"Yoda\", 5L]>\n"
-	                              + "to only have elements of type:\n"
-	                              + "  <java.lang.String>\n"
-	                              + "but found:\n"
-	                              + "  <java.lang.Long>");
+	assertThat(message).isEqualTo(String.format("[Test] %n"
+	                              + "Expecting:%n"
+	                              + "  <[\"Yoda\", 5L]>%n"
+	                              + "to only have elements of type:%n"
+	                              + "  <java.lang.String>%n"
+	                              + "but found:%n"
+	                              + "  <java.lang.Long>"));
   }
 
 }


### PR DESCRIPTION
A few tests were failing on a clean checkout on Windows due to comparing platform-specific newlines from the production code against Unix-style newlines in the test code. I've fixed this by using `String.format` with the `%n` format specifier. This is consistent with other existing tests.
