### PR TITLE
Make MapEntry generic in <? extends K, ? extends V>, and update tests to match

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -40,7 +40,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author dorzey
  */
 public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>, A extends Map<K, V>, K, V>
-    extends AbstractAssert<S, A> implements EnumerableAssert<S, MapEntry> {
+    extends AbstractAssert<S, A> implements EnumerableAssert<S, MapEntry<? extends K, ? extends V>> {
 
   @VisibleForTesting
   Maps maps = Maps.instance();
@@ -132,7 +132,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map does not contain the given entries.
    */
-  public S contains(MapEntry... entries) {
+  public S contains(MapEntry<? extends K, ? extends V>... entries) {
 	maps.assertContains(info, actual, entries);
 	return myself;
   }
@@ -179,7 +179,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map contains any of the given entries.
    */
-  public S doesNotContain(MapEntry... entries) {
+  public S doesNotContain(MapEntry<? extends K, ? extends V>... entries) {
 	maps.assertDoesNotContain(info, actual, entries);
 	return myself;
   }
@@ -399,7 +399,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    * @throws AssertionError if the actual map does not contain the given entries, i.e. the actual map contains some or
    *           none of the given entries, or the actual map contains more entries than the given ones.
    */
-  public S containsOnly(MapEntry... entries) {
+  public S containsOnly(MapEntry<? extends K, ? extends V>... entries) {
 	maps.assertContainsOnly(info, actual, entries);
 	return myself;
   }
@@ -430,7 +430,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    *           contains some or none of the given entries, or the actual map contains more entries than the given ones
    *           or entries are the same but the order is not.
    */
-  public S containsExactly(MapEntry... entries) {
+  public S containsExactly(MapEntry<? extends K, ? extends V>... entries) {
 	maps.assertContainsExactly(info, actual, entries);
 	return myself;
   }
@@ -443,7 +443,7 @@ public abstract class AbstractMapAssert<S extends AbstractMapAssert<S, A, K, V>,
    */
   @Override
   @Deprecated
-  public final S usingElementComparator(Comparator<? super MapEntry> customComparator) {
+  public final S usingElementComparator(Comparator<? super MapEntry<? extends K, ? extends V>> customComparator) {
 	throw new UnsupportedOperationException("custom element Comparator is not supported for MapEntry comparison");
   }
 

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -712,7 +712,7 @@ public class Assertions {
    * assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));
    * </code></pre>
    */
-  public static MapEntry entry(Object key, Object value) {
+  public static <K, V> MapEntry<K, V> entry(K key, V value) {
 	return MapEntry.entry(key, value);
   }
 

--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -22,10 +22,10 @@ import java.util.Map;
  *
  * @author Yvonne Wang
  */
-public class MapEntry {
-  public final Object key;
+public class MapEntry<K, V> {
+  public final K key;
 
-  public final Object value;
+  public final V value;
 
   /**
    * Creates a new {@link MapEntry}.
@@ -34,11 +34,11 @@ public class MapEntry {
    * @param value the value of the entry to create.
    * @return the created {@code MapEntry}.
    */
-  public static MapEntry entry(Object key, Object value) {
-    return new MapEntry(key, value);
+  public static <K,V> MapEntry<K, V> entry(K key, V value) {
+    return new MapEntry<K, V>(key, value);
   }
 
-  private MapEntry(Object key, Object value) {
+  private MapEntry(K key, V value) {
     this.key = key;
     this.value = value;
   }

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -186,15 +186,15 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} is {@code null}.
    * @throws AssertionError if the given {@code Map} does not contain the given entries.
    */
-  public void assertContains(AssertionInfo info, Map<?, ?> actual, MapEntry[] entries) {
+  public <K, V> void assertContains(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>[] entries) {
 	failIfNull(entries);
 	assertNotNull(info, actual);
 	// if both actual and values are empty, then assertion passes.
 	if (actual.isEmpty() && entries.length == 0)
 	  return;
 	failIfEmptySinceActualIsNotEmpty(entries);
-	Set<MapEntry> notFound = new LinkedHashSet<MapEntry>();
-	for (MapEntry entry : entries) {
+	Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
+	for (MapEntry<? extends K, ? extends V> entry : entries) {
 	  if (!containsEntry(actual, entry)) {
 		notFound.add(entry);
 	  }
@@ -217,11 +217,11 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} is {@code null}.
    * @throws AssertionError if the given {@code Map} contains any of the given entries.
    */
-  public void assertDoesNotContain(AssertionInfo info, Map<?, ?> actual, MapEntry[] entries) {
+  public <K, V> void assertDoesNotContain(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>[] entries) {
 	failIfNullOrEmpty(entries);
 	assertNotNull(info, actual);
-	Set<MapEntry> found = new LinkedHashSet<MapEntry>();
-	for (MapEntry entry : entries) {
+	Set<MapEntry<? extends K, ? extends V>> found = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
+	for (MapEntry<? extends K, ? extends V> entry : entries) {
 	  if (containsEntry(actual, entry)) {
 		found.add(entry);
 	  }
@@ -397,15 +397,15 @@ public class Maps {
    * @throws AssertionError if the actual map does not contain the given entries, i.e. the actual map contains some or
    *           none of the given entries, or the actual map contains more entries than the given ones.
    */
-  public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual, MapEntry... entries) {
+  public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>... entries) {
 	doCommonContainsCheck(info, actual, entries);
 	if (actual.isEmpty() && entries.length == 0) {
 	  return;
 	}
 	failIfEmpty(entries);
 
-	Set<MapEntry> notFound = new LinkedHashSet<MapEntry>();
-	Set<MapEntry> notExpected = new LinkedHashSet<MapEntry>();
+	Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
+	Set<MapEntry<? extends K, ? extends V>> notExpected = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
 
 	compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
@@ -431,7 +431,7 @@ public class Maps {
    *           contains some or none of the given entries, or the actual map contains more entries than the given ones
    *           or entries are the same but the order is not.
    */
-  public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual, MapEntry... entries) {
+  public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>... entries) {
 	doCommonContainsCheck(info, actual, entries);
 	if (actual.isEmpty() && entries.length == 0) {
 	  return;
@@ -439,8 +439,8 @@ public class Maps {
 	failIfEmpty(entries);
 	assertHasSameSizeAs(info, actual, entries);
 
-	Set<MapEntry> notFound = new LinkedHashSet<MapEntry>();
-	Set<MapEntry> notExpected = new LinkedHashSet<MapEntry>();
+	Set<MapEntry<? extends K, ? extends V>> notFound = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
+	Set<MapEntry<? extends K, ? extends V>> notExpected = new LinkedHashSet<MapEntry<? extends K, ? extends V>>();
 
 	compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
@@ -481,8 +481,9 @@ public class Maps {
 	}
   }
 
-  private <K, V> void compareActualMapAndExpectedEntries(Map<K, V> actual, MapEntry[] entries,
-	                                                     Set<MapEntry> notExpected, Set<MapEntry> notFound) {
+  private <K, V> void compareActualMapAndExpectedEntries(Map<K, V> actual, MapEntry<? extends K, ? extends V>[] entries,
+	                                                     Set<MapEntry<? extends K, ? extends V>> notExpected,
+	                                                     Set<MapEntry<? extends K, ? extends V>> notFound) {
 
 	Map<K, V> expectedEntries = entriesToMap(entries);
 	Map<K, V> actualEntries = new LinkedHashMap<K, V>(actual);
@@ -503,16 +504,16 @@ public class Maps {
 	}
   }
 
-  private <K, V> void doCommonContainsCheck(AssertionInfo info, Map<K, V> actual, MapEntry[] entries) {
+  private <K, V> void doCommonContainsCheck(AssertionInfo info, Map<K, V> actual, MapEntry<? extends K, ? extends V>[] entries) {
 	assertNotNull(info, actual);
 	failIfNull(entries);
   }
 
   @SuppressWarnings("unchecked")
-  private static <K, V> Map<K, V> entriesToMap(MapEntry[] entries) {
+  private static <K, V> Map<K, V> entriesToMap(MapEntry<? extends K, ? extends V>[] entries) {
 	Map<K, V> expectedEntries = new LinkedHashMap<K, V>();
-	for (MapEntry entry : entries) {
-	  expectedEntries.put((K) entry.key, (V) entry.value);
+	for (MapEntry<? extends K, ? extends V> entry : entries) {
+	  expectedEntries.put(entry.key, entry.value);
 	}
 	return expectedEntries;
   }
@@ -546,7 +547,7 @@ public class Maps {
 	}
   }
 
-  private boolean containsEntry(Map<?, ?> actual, MapEntry entry) {
+  private <K, V> boolean containsEntry(Map<K, V> actual, MapEntry<? extends K, ? extends V> entry) {
 	if (entry == null) {
 	  throw new NullPointerException("Entries to look for should not be null");
 	}

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsEntry_Test.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
  */
 public class MapAssert_containsEntry_Test extends MapAssertBaseTest {
 
-  final MapEntry[] entries = array(entry("key1", "value1"));
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactly_Test.java
@@ -27,7 +27,7 @@ import org.assertj.core.data.MapEntry;
  */
 public class MapAssert_containsExactly_Test extends MapAssertBaseTest {
 
-  final MapEntry[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsOnly_Test.java
@@ -27,7 +27,7 @@ import org.assertj.core.data.MapEntry;
  */
 public class MapAssert_containsOnly_Test extends MapAssertBaseTest {
 
-  final MapEntry[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/map/MapAssert_contains_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_contains_Test.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verify;
  */
 public class MapAssert_contains_Test extends MapAssertBaseTest {
 
-  final MapEntry[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainEntry_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainEntry_Test.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
  */
 public class MapAssert_doesNotContainEntry_Test extends MapAssertBaseTest {
 
-  final MapEntry[] entries = array(entry("key1", "value1"));
+  final MapEntry<String, String>[] entries = array(entry("key1", "value1"));
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContain_Test.java
@@ -37,7 +37,7 @@ public class MapAssert_doesNotContain_Test extends MapAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    MapEntry[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
+    MapEntry<String, String>[] entries = array(entry("key1", "value1"), entry("key2", "value2"));
     verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
   }
 }

--- a/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_equals_hashCode_Test.java
@@ -26,7 +26,7 @@ import org.junit.*;
  * @author Alex Ruiz
  */
 public class MapEntry_equals_hashCode_Test {
-  private static MapEntry entry;
+  private static MapEntry<String, String> entry;
 
   @BeforeClass
   public static void setUpOnce() {

--- a/src/test/java/org/assertj/core/data/MapEntry_toString_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_toString_Test.java
@@ -24,7 +24,7 @@ import org.junit.*;
  * @author Alex Ruiz
  */
 public class MapEntry_toString_Test {
-  private static MapEntry entry;
+  private static MapEntry<String, String> entry;
 
   @BeforeClass
   public static void setUpOnce() {

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
@@ -96,7 +96,7 @@ public class Maps_assertContainsExactly_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_and_expected_entries_have_different_size() throws Exception {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda") };
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda")};
     try {
       maps.assertContainsExactly(info, linkedActual, expected);
     } catch (AssertionError e) {
@@ -110,8 +110,8 @@ public class Maps_assertContainsExactly_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contains_every_expected_entries_and_contains_unexpected_one()
       throws Exception {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda"), entry("color", "green") };
-    Map<?, ?> underTest = newLinkedHashMap(entry("name", "Yoda"), entry("job", "Jedi"));
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda"), entry("color", "green")};
+    Map<String, String> underTest = newLinkedHashMap(entry("name", "Yoda"), entry("job", "Jedi"));
     try {
       maps.assertContainsExactly(info, underTest, expected);
     } catch (AssertionError e) {
@@ -128,7 +128,7 @@ public class Maps_assertContainsExactly_Test extends MapsBaseTest {
   public void should_fail_if_actual_contains_entry_key_with_different_value() throws Exception {
 
     AssertionInfo info = someInfo();
-    MapEntry[] expectedEntries = { entry("name", "Yoda"), entry("color", "yellow") };
+    MapEntry<String, String>[] expectedEntries = new MapEntry[]{entry("name", "Yoda"), entry("color", "yellow")};
     try {
       maps.assertContainsExactly(info, actual, expectedEntries);
     } catch (AssertionError e) {
@@ -141,16 +141,16 @@ public class Maps_assertContainsExactly_Test extends MapsBaseTest {
     shouldHaveThrown(AssertionError.class);
   }
 
-  private static Map<String, String> newLinkedHashMap(MapEntry... entries) {
+  private static Map<String, String> newLinkedHashMap(MapEntry<String, String>... entries) {
     LinkedHashMap<String, String> result = new LinkedHashMap<String, String>();
-    for (MapEntry entry : entries) {
-      result.put((String) entry.key, (String) entry.value);
+    for (MapEntry<String, String> entry : entries) {
+      result.put(entry.key, entry.value);
     }
     return result;
   }
 
-  private static Set<MapEntry> newHashSet(MapEntry entry) {
-    LinkedHashSet<MapEntry> result = new LinkedHashSet<MapEntry>();
+  private static <K, V> Set<MapEntry<K, V>> newHashSet(MapEntry<K, V> entry) {
+    LinkedHashSet<MapEntry<K, V>> result = new LinkedHashSet<MapEntry<K, V>>();
     result.add(entry);
     return result;
   }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
@@ -43,7 +43,7 @@ public class Maps_assertContainsKey_Test extends MapsBaseTest {
   @Before
   public void setUp() {
     super.setUp();
-    actual = (Map<String, String>) mapOf(entry("name", "Yoda"), entry("color", "green"), entry(null, null));
+    actual = mapOf(entry("name", "Yoda"), entry("color", "green"), entry((String) null, (String) null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_Test.java
@@ -42,7 +42,7 @@ public class Maps_assertContainsKeys_Test extends MapsBaseTest {
   @Before
   public void setUp() {
     super.setUp();
-    actual = (Map<String, String>) mapOf(entry("name", "Yoda"), entry("color", "green"), entry(null, null));
+    actual = mapOf(entry("name", "Yoda"), entry("color", "green"), entry((String) null, (String) null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -72,7 +72,7 @@ public class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_contains_unexpected_entry() throws Exception {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda") };
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda")};
     try {
       maps.assertContainsOnly(info, actual, expected);
     } catch (AssertionError e) {
@@ -86,8 +86,8 @@ public class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contains_every_expected_entries() throws Exception {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda"), entry("color", "green") };
-    Map<?, ?> underTest = Maps.mapOf(entry("name", "Yoda"));
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda"), entry("color", "green")};
+    Map<String, String> underTest = Maps.mapOf(entry("name", "Yoda"));
     try {
       maps.assertContainsOnly(info, underTest, expected);
     } catch (AssertionError e) {
@@ -102,8 +102,8 @@ public class Maps_assertContainsOnly_Test extends MapsBaseTest {
   public void should_fail_if_actual_does_not_contains_every_expected_entries_and_contains_unexpected_one()
       throws Exception {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda"), entry("color", "green") };
-    Map<?, ?> underTest = Maps.mapOf(entry("name", "Yoda"), entry("job", "Jedi"));
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda"), entry("color", "green")};
+    Map<String, String> underTest = Maps.mapOf(entry("name", "Yoda"), entry("job", "Jedi"));
     try {
       maps.assertContainsOnly(info, underTest, expected);
     } catch (AssertionError e) {
@@ -121,7 +121,7 @@ public class Maps_assertContainsOnly_Test extends MapsBaseTest {
   public void should_fail_if_actual_contains_entry_key_with_different_value() throws Exception {
 
     AssertionInfo info = someInfo();
-    MapEntry[] expectedEntries = { entry("name", "Yoda"), entry("color", "yellow") };
+    MapEntry<String, String>[] expectedEntries = new MapEntry[]{entry("name", "Yoda"), entry("color", "yellow")};
     try {
       maps.assertContainsOnly(info, actual, expectedEntries);
     } catch (AssertionError e) {
@@ -134,8 +134,8 @@ public class Maps_assertContainsOnly_Test extends MapsBaseTest {
     shouldHaveThrown(AssertionError.class);
   }
 
-  private static HashSet<MapEntry> newHashSet(MapEntry entry) {
-    HashSet<MapEntry> notExpected = new HashSet<MapEntry>();
+  private static <K, V> HashSet<MapEntry<K, V>> newHashSet(MapEntry<K, V> entry) {
+    HashSet<MapEntry<K, V>> notExpected = new HashSet<MapEntry<K, V>>();
     notExpected.add(entry);
     return notExpected;
   }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValue_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValue_Test.java
@@ -39,12 +39,11 @@ import org.junit.Test;
  */
 public class Maps_assertContainsValue_Test extends MapsBaseTest {
 
-  @SuppressWarnings("unchecked")
   @Override
   @Before
   public void setUp() {
     super.setUp();
-    actual = (Map<String, String>) mapOf(entry("name", "Yoda"), entry("color", "green"), entry(null, null));
+    actual = mapOf(entry("name", "Yoda"), entry("color", "green"), entry((String) null, (String) null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_Test.java
@@ -43,7 +43,7 @@ public class Maps_assertContainsValues_Test extends MapsBaseTest {
   @Before
   public void setUp() {
     super.setUp();
-    actual = (Map<String, String>) mapOf(entry("name", "Yoda"), entry("type", "Jedi"), entry("color", "green"), entry(null, null));
+    actual = mapOf(entry("name", "Yoda"), entry("type", "Jedi"), entry("color", "green"), entry((String) null, (String) null));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContains_Test.java
@@ -78,7 +78,7 @@ public class Maps_assertContains_Test extends MapsBaseTest {
 
   @Test
   public void should_throw_error_if_entry_is_null() {
-    MapEntry[] entries = { null };
+    MapEntry<String, String>[] entries = new MapEntry[]{null};
     thrown.expectNullPointerException(entryToLookForIsNull());
     maps.assertContains(someInfo(), actual, entries);
   }
@@ -92,7 +92,7 @@ public class Maps_assertContains_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_does_not_contain_entries() {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda"), entry("job", "Jedi") };
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda"), entry("job", "Jedi")};
     try {
       maps.assertContains(info, actual, expected);
     } catch (AssertionError e) {

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContain_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContain_Test.java
@@ -67,7 +67,7 @@ public class Maps_assertDoesNotContain_Test extends MapsBaseTest {
   @Test
   public void should_fail_if_actual_contains_given_values() {
     AssertionInfo info = someInfo();
-    MapEntry[] expected = { entry("name", "Yoda"), entry("job", "Jedi") };
+    MapEntry<String, String>[] expected = new MapEntry[]{entry("name", "Yoda"), entry("job", "Jedi")};
     try {
       maps.assertDoesNotContain(info, actual, expected);
     } catch (AssertionError e) {

--- a/src/test/java/org/assertj/core/test/Maps.java
+++ b/src/test/java/org/assertj/core/test/Maps.java
@@ -22,10 +22,11 @@ import org.assertj.core.data.MapEntry;
  * @author Alex Ruiz
  */
 public final class Maps {
-  public static Map<?, ?> mapOf(MapEntry... entries) {
-    Map<Object, Object> map = new LinkedHashMap<Object, Object>();
-    for (MapEntry entry : entries)
+  public static <K, V> Map<K, V> mapOf(MapEntry<K, V>... entries) {
+    Map<K, V> map = new LinkedHashMap<K, V>();
+    for (MapEntry<K, V> entry : entries) {
       map.put(entry.key, entry.value);
+    }
     return map;
   }
 


### PR DESCRIPTION
This makes MapEntry generic (as in #24), along with updating every example in the tests to explicitly use those generics.
