### PR TITLE
Add modular integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,31 @@
             </plugin>
           </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <version>3.2.1</version>
+            <configuration>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+              <goals>
+                <goal>clean</goal>
+                <goal>test</goal>
+              </goals>
+            </configuration>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
     <profile>

--- a/src/it/modular-tests/pom.xml
+++ b/src/it/modular-tests/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it</groupId>
+  <artifactId>modular-tests</artifactId>
+  <version>0</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>9</maven.compiler.release>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>@junit-jupiter.version@</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>3.14.0</version> <!-- FIXME should be @ project.version @ -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>@maven-compiler-plugin.version@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>@maven-surefire-plugin.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/src/it/modular-tests/src/test/java/black/box/BlackBoxTest.java
+++ b/src/it/modular-tests/src/test/java/black/box/BlackBoxTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+package black.box;
+
+import org.assertj.core.util.Closeables;
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+class BlackBoxTest {
+
+  @Test
+  void issue_1656() {
+    // GIVEN
+    Closeable closeable = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> Closeables.closeQuietly(closeable));
+    // THEN
+    then(thrown).isNull();
+  }
+
+}

--- a/src/it/modular-tests/src/test/java/module-info.java
+++ b/src/it/modular-tests/src/test/java/module-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2019 the original author or authors.
+ */
+open module black.box {
+  // under test
+  requires org.assertj.core;
+
+  // test framework api
+  requires org.junit.jupiter.api;
+}

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
Related to #1711, this introduces a skeleton for modular integration testing based on the `maven-invoker-plugin`. As an initial test case I chose the issue reported in #1656: it fails correctly when the test runs in the IDE, but it doesn't fail when executed by the invoker plugin.

Open points:
- [ ] Understand why `issue_1656()` doesn't fail under `maven-invoker-plugin`
- [ ] Allow the IDE to automatically detect the project generated by the plugin, maybe `build-helper-maven-plugin`? (for now I manually added `assertj-core/target/it/modular-tests` to the project modules)
- [ ] Replace AssertJ 3.14.0 version with `@project.version@` in the integration test POM (the IDE is currently not able to detect the AssertJ module with the parameterized version and the test build fails -- I still need to try if the changes in #1711 can help)
 
@sormuras please check it! This follows more your [Testing In The Modular World](https://sormuras.github.io/blog/2018-09-11-testing-in-the-modular-world.html) rather than the [mainrunner](https://github.com/sormuras/mainrunner)+[Bach](https://github.com/sormuras/bach) combo you suggested in #1711, I need a bit more time to understand how the latter works 😅 
