### PR TITLE
Replaces String by CharSequence in textual diff.

### DIFF
--- a/src/main/java/org/assertj/core/error/AbstractShouldHaveTextContent.java
+++ b/src/main/java/org/assertj/core/error/AbstractShouldHaveTextContent.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.core.error;
 
-import static java.util.stream.Collectors.joining;
-
-import java.util.List;
-
 import org.assertj.core.description.Description;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.diff.Delta;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Base class for text content error.
@@ -50,7 +50,7 @@ public class AbstractShouldHaveTextContent extends BasicErrorMessageFactory {
     return super.create(d, representation) + diffs;
   }
 
-  protected static String diffsAsString(List<Delta<String>> diffsList) {
+  protected static String diffsAsString(List<Delta<CharSequence>> diffsList) {
     return diffsList.stream().map(Delta::toString).collect(joining(System.lineSeparator()));
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveContent.java
@@ -12,12 +12,12 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.util.diff.Delta;
+
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
-
-import org.assertj.core.util.diff.Delta;
 
 
 /**
@@ -34,7 +34,7 @@ public class ShouldHaveContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and the expected text that was provided in the assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveContent(File actual, Charset charset, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveContent(File actual, Charset charset, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveContent(actual, charset, diffsAsString(diffs));
   }
   
@@ -45,7 +45,7 @@ public class ShouldHaveContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and the expected text that was provided in the assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveContent(Path actual, Charset charset, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveContent(Path actual, Charset charset, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveContent(actual, charset, diffsAsString(diffs));
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSameContent.java
@@ -13,12 +13,12 @@
 package org.assertj.core.error;
 
 
+import org.assertj.core.util.diff.Delta;
+
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
-
-import org.assertj.core.util.diff.Delta;
 
 /**
  * Creates an error message indicating that an assertion that verifies that two files/inputStreams/paths have same content failed.
@@ -36,7 +36,7 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveSameContent(File actual, File expected, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveSameContent(File actual, File expected, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 
@@ -47,7 +47,7 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, InputStream expected, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, InputStream expected, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 
@@ -58,7 +58,7 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, String expected, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveSameContent(InputStream actual, String expected, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
   
@@ -69,7 +69,7 @@ public class ShouldHaveSameContent extends AbstractShouldHaveTextContent {
    * @param diffs the differences between {@code actual} and {@code expected}.
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static ErrorMessageFactory shouldHaveSameContent(Path actual, Path expected, List<Delta<String>> diffs) {
+  public static ErrorMessageFactory shouldHaveSameContent(Path actual, Path expected, List<Delta<CharSequence>> diffs) {
     return new ShouldHaveSameContent(actual, expected, diffsAsString(diffs));
   }
 

--- a/src/main/java/org/assertj/core/internal/Diff.java
+++ b/src/main/java/org/assertj/core/internal/Diff.java
@@ -12,9 +12,10 @@
  */
 package org.assertj.core.internal;
 
-import static java.nio.file.Files.newBufferedReader;
-import static java.util.Collections.unmodifiableList;
-import static org.assertj.core.util.Closeables.closeQuietly;
+import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.diff.Delta;
+import org.assertj.core.util.diff.DiffUtils;
+import org.assertj.core.util.diff.Patch;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -27,10 +28,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.util.VisibleForTesting;
-import org.assertj.core.util.diff.Delta;
-import org.assertj.core.util.diff.DiffUtils;
-import org.assertj.core.util.diff.Patch;
+import static java.nio.file.Files.newBufferedReader;
+import static java.util.Collections.unmodifiableList;
+import static org.assertj.core.util.Closeables.closeQuietly;
 
 
 /**
@@ -48,32 +48,32 @@ import org.assertj.core.util.diff.Patch;
 public class Diff {
 
   @VisibleForTesting
-  public List<Delta<String>> diff(InputStream actual, InputStream expected) throws IOException {
+  public List<Delta<CharSequence>> diff(InputStream actual, InputStream expected) throws IOException {
     return diff(readerFor(actual), readerFor(expected));
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(InputStream actual, String expected) throws IOException {
+  public List<Delta<CharSequence>> diff(InputStream actual, String expected) throws IOException {
     return diff(readerFor(actual), readerFor(expected));
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(File actual, Charset actualCharset, File expected, Charset expectedCharset) throws IOException {
+  public List<Delta<CharSequence>> diff(File actual, Charset actualCharset, File expected, Charset expectedCharset) throws IOException {
     return diff(actual.toPath(), actualCharset, expected.toPath(), expectedCharset);
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(Path actual, Charset actualCharset, Path expected, Charset expectedCharset) throws IOException {
+  public List<Delta<CharSequence>> diff(Path actual, Charset actualCharset, Path expected, Charset expectedCharset) throws IOException {
     return diff(newBufferedReader(actual, actualCharset), newBufferedReader(expected, expectedCharset));
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(File actual, String expected, Charset charset) throws IOException {
+  public List<Delta<CharSequence>> diff(File actual, String expected, Charset charset) throws IOException {
     return diff(actual.toPath(), expected, charset);
   }
 
   @VisibleForTesting
-  public List<Delta<String>> diff(Path actual, String expected, Charset charset) throws IOException {
+  public List<Delta<CharSequence>> diff(Path actual, String expected, Charset charset) throws IOException {
     return diff(newBufferedReader(actual, charset), readerFor(expected));
   }
 
@@ -85,21 +85,21 @@ public class Diff {
     return new BufferedReader(new StringReader(string));
   }
 
-  private List<Delta<String>> diff(BufferedReader actual, BufferedReader expected) throws IOException {
+  private List<Delta<CharSequence>> diff(BufferedReader actual, BufferedReader expected) throws IOException {
     try {
-      List<String> actualLines = linesFromBufferedReader(actual);
-      List<String> expectedLines = linesFromBufferedReader(expected);
+      List<CharSequence> actualLines = linesFromBufferedReader(actual);
+      List<CharSequence> expectedLines = linesFromBufferedReader(expected);
       
-      Patch<String> patch = DiffUtils.diff(expectedLines, actualLines);
+      Patch<CharSequence> patch = DiffUtils.diff(expectedLines, actualLines);
       return unmodifiableList(patch.getDeltas());
     } finally {
       closeQuietly(actual, expected);
     }
   }
 
-  private List<String> linesFromBufferedReader(BufferedReader reader) throws IOException {
+  private List<CharSequence> linesFromBufferedReader(BufferedReader reader) throws IOException {
     String line;
-    List<String> lines = new ArrayList<>();
+    List<CharSequence> lines = new ArrayList<>();
     while ((line = reader.readLine()) != null) {
       lines.add(line);
     }

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -12,6 +12,22 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.diff.Delta;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.MalformedInputException;
+import java.nio.file.PathMatcher;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.function.Predicate;
+
 import static java.lang.String.format;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Objects.requireNonNull;
@@ -42,22 +58,6 @@ import static org.assertj.core.internal.Digests.digestDiff;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.nio.charset.MalformedInputException;
-import java.nio.file.PathMatcher;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.function.Predicate;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.VisibleForTesting;
-import org.assertj.core.util.diff.Delta;
 
 /**
  * Reusable assertions for <code>{@link File}</code>s.
@@ -115,7 +115,7 @@ public class Files {
     verifyIsFile(expected);
     assertIsFile(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (MalformedInputException e) {
@@ -213,7 +213,7 @@ public class Files {
     requireNonNull(expected, "The text to compare to should not be null");
     assertIsFile(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, expected, charset);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, expected, charset);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveContent(actual, charset, diffs));
     } catch (IOException e) {

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -12,11 +12,9 @@
  */
 package org.assertj.core.internal;
 
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
-import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
-import static org.assertj.core.internal.Digests.digestDiff;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.diff.Delta;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,9 +22,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.VisibleForTesting;
-import org.assertj.core.util.diff.Delta;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
+import static org.assertj.core.internal.Digests.digestDiff;
 
 /**
  * Reusable assertions for <code>{@link InputStream}</code>s.
@@ -68,7 +68,7 @@ public class InputStreams {
     requireNonNull(expected, "The InputStream to compare to should not be null");
     assertNotNull(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, expected);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {
@@ -93,7 +93,7 @@ public class InputStreams {
     assertNotNull(info, actual);
 
     try {
-      List<Delta<String>> diffs = diff.diff(actual, expected);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -12,6 +12,24 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.exception.PathsException;
+import org.assertj.core.util.VisibleForTesting;
+import org.assertj.core.util.diff.Delta;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.DirectoryStream;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.function.Predicate;
+
 import static java.lang.String.format;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Objects.requireNonNull;
@@ -44,24 +62,6 @@ import static org.assertj.core.error.ShouldNotContain.directoryShouldNotContain;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.error.ShouldStartWithPath.shouldStartWith;
 import static org.assertj.core.util.Preconditions.checkArgument;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.nio.file.DirectoryStream;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.function.Predicate;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.exception.PathsException;
-import org.assertj.core.util.VisibleForTesting;
-import org.assertj.core.util.diff.Delta;
 
 /**
  * Core assertion class for {@link Path} assertions
@@ -278,7 +278,7 @@ public class Paths {
     requireNonNull(expected, "The text to compare to should not be null");
     assertIsReadable(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, expected, charset);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, expected, charset);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveContent(actual, charset, diffs));
     } catch (IOException e) {
@@ -320,7 +320,7 @@ public class Paths {
                   expected);
     assertIsReadable(info, actual);
     try {
-      List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
+      List<Delta<CharSequence>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
       if (diffs.isEmpty()) return;
       throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
     } catch (IOException e) {

--- a/src/test/java/org/assertj/core/error/ShouldHaveContent_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveContent_create_Test.java
@@ -12,6 +12,13 @@
  */
 package org.assertj.core.error;
 
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -19,13 +26,6 @@ import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION
 import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import java.util.List;
-
-import org.assertj.core.description.TextDescription;
-import org.assertj.core.util.Lists;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.Test;
 
 public class ShouldHaveContent_create_Test {
 
@@ -35,9 +35,9 @@ public class ShouldHaveContent_create_Test {
   public void should_create_error_message() {
     // GIVEN
     final FakeFile file = new FakeFile("xyz");
-    Delta<String> delta = mock(Delta.class);
+    Delta<CharSequence> delta = mock(Delta.class);
     when(delta.toString()).thenReturn(DIFF);
-    List<Delta<String>> diffs = Lists.list(delta);
+    List<Delta<CharSequence>> diffs = Lists.list(delta);
     ErrorMessageFactory factory = shouldHaveContent(file, defaultCharset(), diffs);
     // WHEN
     String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());

--- a/src/test/java/org/assertj/core/internal/FilesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/FilesBaseTest.java
@@ -12,13 +12,9 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.test.TestData.someInfo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -31,9 +27,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Base class for testing <code>{@link Files}</code>, set up diff and failures attributes (which is why it is in
@@ -50,7 +50,7 @@ public class FilesBaseTest {
   protected Files files;
   protected Files unMockedFiles;
   protected Diff diff;
-  protected Delta<String> delta;
+  protected Delta<CharSequence> delta;
   protected BinaryDiff binaryDiff;
   protected NioFilesWrapper nioFilesWrapper;
 

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
@@ -12,16 +12,6 @@
  */
 package org.assertj.core.internal.files;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Arrays.array;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
 import org.assertj.core.internal.Diff;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.TextFileWriter;
@@ -29,6 +19,16 @@ import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Arrays.array;
 
 /**
  * Tests for <code>{@link Diff#diff(File, String, java.nio.charset.Charset)}</code>.
@@ -59,7 +59,7 @@ public class Diff_diff_File_String_Test {
     String[] content = array("line0", "line1");
     writer.write(actual, content);
     String expected = String.format("line0%nline1");
-    List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).isEmpty();
   }
 
@@ -67,7 +67,7 @@ public class Diff_diff_File_String_Test {
   public void should_return_diffs_if_file_and_string_do_not_have_equal_content() throws IOException {
     writer.write(actual, StandardCharsets.UTF_8, "Touché");
     String expected = "Touché";
-    List<Delta<String>> diffs = diff.diff(actual, expected, StandardCharsets.ISO_8859_1);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected, StandardCharsets.ISO_8859_1);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -80,7 +80,7 @@ public class Diff_diff_File_String_Test {
   public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0");
     String expected = String.format("line_0%nline_1");
-    List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -90,7 +90,7 @@ public class Diff_diff_File_String_Test {
   public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0", "line_1");
     String expected = "line_0";
-    List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));

--- a/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Diff_diff_File_Test.java
@@ -12,15 +12,6 @@
  */
 package org.assertj.core.internal.files;
 
-import static java.lang.String.format;
-import static java.nio.charset.Charset.defaultCharset;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Arrays.array;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
 import org.assertj.core.internal.Diff;
 import org.assertj.core.util.Files;
 import org.assertj.core.util.TextFileWriter;
@@ -28,6 +19,15 @@ import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.nio.charset.Charset.defaultCharset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Arrays.array;
 
 /**
  * Tests for <code>{@link Diff#diff(File, File)}</code>.
@@ -61,7 +61,7 @@ public class Diff_diff_File_Test {
     String[] content = array("line0", "line1");
     writer.write(actual, content);
     writer.write(expected, content);
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).isEmpty();
   }
 
@@ -69,7 +69,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_files_do_not_have_equal_content() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line0", "line1");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -84,7 +84,7 @@ public class Diff_diff_File_Test {
   public void should_return_multiple_diffs_if_files_contain_multiple_differences() throws IOException {
     writer.write(actual, "line_0", "line1", "line_2");
     writer.write(expected, "line0", "line1", "line2");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(2);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
                                                 + "expecting:%n"
@@ -104,7 +104,7 @@ public class Diff_diff_File_Test {
     writer.write(actual,   "line1",                     "line2", "line3", "line4", "line5", "line 9", "line 10", "line 11");
     writer.write(expected, "line1", "line1a", "line1b", "line2", "line3", "line7", "line5");
     // @format:on
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(3);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line1a\",%n"
@@ -124,7 +124,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0");
     writer.write(expected, "line_0", "line_1");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -134,7 +134,7 @@ public class Diff_diff_File_Test {
   public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0", "line_1");
     writer.write(expected, "line_0");
-    List<Delta<String>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
+    List<Delta<CharSequence>> diffs = diff.diff(actual, defaultCharset(), expected, defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));

--- a/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -12,6 +12,21 @@
  */
 package org.assertj.core.internal.files;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Files;
+import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -22,21 +37,6 @@ import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Files;
-import org.assertj.core.internal.FilesBaseTest;
-import org.assertj.core.util.Lists;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link Files#assertHasContent(AssertionInfo, File, String, Charset)}</code>.
@@ -99,7 +99,7 @@ public class Files_assertHasContent_Test extends FilesBaseTest {
 
   @Test
   public void should_fail_if_file_does_not_have_expected_text_content() throws IOException {
-    List<Delta<String>> diffs = Lists.newArrayList(delta);
+    List<Delta<CharSequence>> diffs = Lists.newArrayList(delta);
     when(diff.diff(actual, expected, charset)).thenReturn(diffs);
     AssertionInfo info = someInfo();
 

--- a/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -12,6 +12,23 @@
  */
 package org.assertj.core.internal.files;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.BinaryDiffResult;
+import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.Files;
+import org.assertj.core.util.Lists;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.nio.file.Files.readAllBytes;
@@ -26,23 +43,6 @@ import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.BinaryDiffResult;
-import org.assertj.core.internal.FilesBaseTest;
-import org.assertj.core.util.Files;
-import org.assertj.core.util.Lists;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link org.assertj.core.internal.Files#assertSameContentAs(org.assertj.core.api.AssertionInfo, java.io.File, java.nio.charset.Charset, java.io.File,  java.nio.charset.Charset)}</code>.
@@ -115,7 +115,7 @@ public class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   public void should_fail_if_files_do_not_have_equal_content() throws IOException {
-    List<Delta<String>> diffs = Lists.newArrayList(delta);
+    List<Delta<CharSequence>> diffs = Lists.newArrayList(delta);
     when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenReturn(diffs);
     when(binaryDiff.diff(actual, readAllBytes(expected.toPath()))).thenReturn(new BinaryDiffResult(1, -1, -1));
     AssertionInfo info = someInfo();

--- a/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_String_Test.java
@@ -12,18 +12,18 @@
  */
 package org.assertj.core.internal.inputstreams;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.internal.inputstreams.Diff_diff_InputStream_Test.stream;
+import org.assertj.core.internal.Diff;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.assertj.core.internal.Diff;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.internal.inputstreams.Diff_diff_InputStream_Test.stream;
 
 public class Diff_diff_InputStream_String_Test {
 
@@ -43,7 +43,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("base", "line0", "line1");
     expected = joinLines("base", "line0", "line1");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).isEmpty();
   }
@@ -54,7 +54,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("base", "line_0", "line_1");
     expected = joinLines("base", "line0", "line1");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(1)
                      .first().hasToString(format("Changed content at line 2:%n"
@@ -72,7 +72,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("base", "line_0", "line1", "line_2");
     expected = joinLines("base", "line0", "line1", "line2");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(2);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 2:%n"
@@ -93,7 +93,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("base", "line_0");
     expected = joinLines("base", "line_0", "line_1");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 3:%n"
@@ -106,7 +106,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("base", "line_0", "line_1");
     expected = joinLines("base", "line_0");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 3:%n"
@@ -119,7 +119,7 @@ public class Diff_diff_InputStream_String_Test {
     actual = stream("", "line_0", "line_1", "line_2");
     expected = joinLines("line_0", "line_1", "line_2");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 1:%n"

--- a/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/Diff_diff_InputStream_Test.java
@@ -12,8 +12,10 @@
  */
 package org.assertj.core.internal.inputstreams;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.internal.Diff;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -21,10 +23,8 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 
-import org.assertj.core.internal.Diff;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for <code>{@link Diff#diff(InputStream, InputStream)}</code>.
@@ -52,7 +52,7 @@ public class Diff_diff_InputStream_Test {
   public void should_return_empty_diff_list_if_inputstreams_have_equal_content() throws IOException {
     actual = stream("base", "line0", "line1");
     expected = stream("base", "line0", "line1");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     assertThat(diffs).isEmpty();
   }
 
@@ -62,7 +62,7 @@ public class Diff_diff_InputStream_Test {
     actual = stream("base", "line_0", "line_1");
     expected = stream("base", "line0", "line1");
     // WHEN
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     // THEN
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 2:%n"
@@ -78,7 +78,7 @@ public class Diff_diff_InputStream_Test {
   public void should_return_multiple_diffs_if_inputstreams_contain_multiple_differences() throws IOException {
     actual = stream("base", "line_0", "line1", "line_2");
     expected = stream("base", "line0", "line1", "line2");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     assertThat(diffs).hasSize(2);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 2:%n"
                                                 + "expecting:%n"
@@ -96,7 +96,7 @@ public class Diff_diff_InputStream_Test {
   public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     actual = stream("base", "line_0");
     expected = stream("base", "line_0", "line_1");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 3:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -106,7 +106,7 @@ public class Diff_diff_InputStream_Test {
   public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     actual = stream("base", "line_0", "line_1");
     expected = stream("base", "line_0");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 3:%n"
                                                 + "  [\"line_1\"]%n"));
@@ -116,7 +116,7 @@ public class Diff_diff_InputStream_Test {
   public void should_return_single_diff_line_for_new_line_at_start() throws IOException {
     actual = stream("", "line_0", "line_1", "line_2");
     expected = stream("line_0", "line_1", "line_2");
-    List<Delta<String>> diffs = diff.diff(actual, expected);
+    List<Delta<CharSequence>> diffs = diff.diff(actual, expected);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 1:%n"
                                                 + "  [\"\"]%n"));

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertHasContent_Test.java
@@ -12,6 +12,17 @@
  */
 package org.assertj.core.internal.inputstreams;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.InputStreams;
+import org.assertj.core.internal.InputStreamsBaseTest;
+import org.assertj.core.internal.InputStreamsException;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -24,17 +35,6 @@ import static org.assertj.core.util.Lists.list;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.InputStreams;
-import org.assertj.core.internal.InputStreamsBaseTest;
-import org.assertj.core.internal.InputStreamsException;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link InputStreams#assertHasContent(AssertionInfo, InputStream, String)}</code>.
@@ -78,7 +78,7 @@ public class InputStreams_assertHasContent_Test extends InputStreamsBaseTest {
   @Test
   public void should_fail_if_inputstream_and_string_do_not_have_equal_content() throws IOException {
     // GIVEN
-    List<Delta<String>> diffs = list((Delta<String>) mock(Delta.class));
+    List<Delta<CharSequence>> diffs = list((Delta<CharSequence>) mock(Delta.class));
     given(diff.diff(actual, expectedString)).willReturn(diffs);
     AssertionInfo info = someInfo();
     // WHEN

--- a/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/inputstreams/InputStreams_assertSameContentAs_Test.java
@@ -12,6 +12,18 @@
  */
 package org.assertj.core.internal.inputstreams;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.InputStreams;
+import org.assertj.core.internal.InputStreamsBaseTest;
+import org.assertj.core.internal.InputStreamsException;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -23,18 +35,6 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.InputStreams;
-import org.assertj.core.internal.InputStreamsBaseTest;
-import org.assertj.core.internal.InputStreamsException;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.Test;
 
 
 /**
@@ -75,7 +75,7 @@ public class InputStreams_assertSameContentAs_Test extends InputStreamsBaseTest 
 
   @Test
   public void should_fail_if_inputstreams_do_not_have_equal_content() throws IOException {
-    List<Delta<String>> diffs = newArrayList((Delta<String>) mock(Delta.class));
+    List<Delta<CharSequence>> diffs = newArrayList((Delta<CharSequence>) mock(Delta.class));
     when(diff.diff(actual, expected)).thenReturn(diffs);
     AssertionInfo info = someInfo();
 

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasContent_Test.java
@@ -12,6 +12,22 @@
  */
 package org.assertj.core.internal.paths;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.assertj.core.internal.PathsBaseTest;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -25,22 +41,6 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Paths;
-import org.assertj.core.internal.PathsBaseTest;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link Paths#assertHasContent(AssertionInfo, Path, String, Charset)}</code>.
@@ -126,7 +126,7 @@ public class Paths_assertHasContent_Test extends PathsBaseTest {
   @Test
   public void should_fail_if_path_does_not_have_expected_text_content() throws IOException {
     @SuppressWarnings("unchecked")
-    List<Delta<String>> diffs = newArrayList((Delta<String>) mock(Delta.class));
+    List<Delta<CharSequence>> diffs = newArrayList((Delta<CharSequence>) mock(Delta.class));
     when(diff.diff(path, expected, charset)).thenReturn(diffs);
     when(nioFilesWrapper.exists(path)).thenReturn(true);
     when(nioFilesWrapper.isReadable(path)).thenReturn(true);

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameContentAs_Test.java
@@ -12,6 +12,18 @@
  */
 package org.assertj.core.internal.paths;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.List;
+
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -27,18 +39,6 @@ import static org.assertj.core.util.TempFileUtil.createTempPathWithContent;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.util.List;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Paths;
-import org.assertj.core.util.diff.Delta;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link Paths#assertHasSameContentAs(AssertionInfo, Path, Charset, Path, Charset)}</code>.
@@ -152,7 +152,7 @@ public class Paths_assertHasSameContentAs_Test extends MockPathsBaseTest {
   @Test
   public void should_fail_if_actual_and_given_path_does_not_have_the_same_content() throws IOException {
     // GIVEN
-    List<Delta<String>> diffs = list((Delta<String>) mock(Delta.class));
+    List<Delta<CharSequence>> diffs = list((Delta<CharSequence>) mock(Delta.class));
     given(diff.diff(actual, CHARSET, expected, CHARSET)).willReturn(diffs);
     AssertionInfo info = someInfo();
     // WHEN


### PR DESCRIPTION
#### Check List:
* Extends textual diff to all CharSequence implementations
* Unit tests : NA
* Javadoc with a code example (on API only) : NA


