### PR TITLE
Add "it" infrastructure for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: 11
       - name: Test
-        run: ./mvnw -V --no-transfer-progress clean verify javadoc:javadoc
+        run: ./mvnw -V --no-transfer-progress -P run-its clean verify javadoc:javadoc
 
   sonar:
     name: Sonar code analysis

--- a/pom.xml
+++ b/pom.xml
@@ -556,5 +556,49 @@
         <javadocAdditionalOptions>-html5 --allow-script-in-comments</javadocAdditionalOptions>
       </properties>
     </profile>
+    <profile>
+      <id>run-its</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <version>3.2.1</version>
+            <configuration>
+              <debug>true</debug>
+              <addTestClassPath>true</addTestClassPath>
+              <cloneClean>true</cloneClean>
+              <cloneAllFiles>true</cloneAllFiles>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <pomIncludes>
+                <!-- "All in!" -->
+                <pomInclude>*</pomInclude>
+                <!-- Select a few... -->
+                <!--<pomInclude>basic</pomInclude>-->
+                <!--<pomInclude>testing-in-the-modular-world</pomInclude>-->
+              </pomIncludes>
+              <pomExcludes>
+                <!-- None, B. -->
+              </pomExcludes>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <goals>
+                <goal>test</goal>
+              </goals>
+            </configuration>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/it/basic/pom.xml
+++ b/src/it/basic/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>basic</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/src/it/setup/invoker.properties
+++ b/src/it/setup/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = install

--- a/src/it/setup/pom.xml
+++ b/src/it/setup/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>it</groupId>
+  <artifactId>setup</artifactId>
+  <version>0</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- versions -->
+    <junit.platform.version>1.6.0</junit.platform.version>
+    <junit.jupiter.version>5.6.0</junit.jupiter.version>
+    <junit.vintage.version>5.6.0</junit.vintage.version>
+    <!-- shared build and compiler settings -->
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/setup/pom.xml
+++ b/src/it/setup/pom.xml
@@ -28,6 +28,17 @@
             <release>11</release>
           </configuration>
         </plugin>
+<!--        <plugin>-->
+<!--          <groupId>org.apache.maven.plugins</groupId>-->
+<!--          <artifactId>maven-surefire-plugin</artifactId>-->
+<!--          <version>3.0.0-M4</version>-->
+<!--        </plugin>-->
+        <plugin>
+          <groupId>de.sormuras.junit</groupId>
+          <artifactId>junit-platform-maven-plugin</artifactId>
+          <version>1.0.0-M5</version>
+          <extensions>true</extensions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/src/it/testing-in-the-modular-world/pom.xml
+++ b/src/it/testing-in-the-modular-world/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>it</groupId>
+    <artifactId>setup</artifactId>
+    <version>0</version>
+  </parent>
+
+  <artifactId>testing-in-the-modular-world</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>de.sormuras.junit</groupId>
+        <artifactId>junit-platform-maven-plugin</artifactId>
+        <configuration>
+          <executor>JAVA</executor>
+          <javaOptions>
+            <additionalOptions>
+              <additionalOption>--show-version</additionalOption>
+              <additionalOption>--show-module-resolution</additionalOption>
+            </additionalOptions>
+          </javaOptions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/testing-in-the-modular-world/pom.xml
+++ b/src/it/testing-in-the-modular-world/pom.xml
@@ -38,6 +38,10 @@
             <additionalOptions>
               <additionalOption>--show-version</additionalOption>
               <additionalOption>--show-module-resolution</additionalOption>
+              <additionalOption>--add-modules</additionalOption>
+              <additionalOption>java.instrument</additionalOption>
+              <additionalOption>--add-reads</additionalOption>
+              <additionalOption>org.assertj.core=java.instrument</additionalOption>
             </additionalOptions>
           </javaOptions>
         </configuration>

--- a/src/it/testing-in-the-modular-world/pom.xml
+++ b/src/it/testing-in-the-modular-world/pom.xml
@@ -38,10 +38,6 @@
             <additionalOptions>
               <additionalOption>--show-version</additionalOption>
               <additionalOption>--show-module-resolution</additionalOption>
-              <additionalOption>--add-modules</additionalOption>
-              <additionalOption>java.instrument</additionalOption>
-              <additionalOption>--add-reads</additionalOption>
-              <additionalOption>org.assertj.core=java.instrument</additionalOption>
             </additionalOptions>
           </javaOptions>
         </configuration>

--- a/src/it/testing-in-the-modular-world/src/test/java/foo/TestingInTheModularWorldTests.java
+++ b/src/it/testing-in-the-modular-world/src/test/java/foo/TestingInTheModularWorldTests.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package foo;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+class TestingInTheModularWorldTests {
+
+  @Test
+  void test() {
+    var object = new Object();
+    SoftAssertions.assertSoftly(softly -> {
+      softly.assertThat(object.toString()).isNotNull();
+    });
+  }
+}

--- a/src/it/testing-in-the-modular-world/src/test/java/module-info.java
+++ b/src/it/testing-in-the-modular-world/src/test/java/module-info.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+open module foo {
+  requires org.assertj.core;
+  requires org.junit.jupiter.api;
+}


### PR DESCRIPTION
This PR adds an optional [maven-invoker-plugin](https://maven.apache.org/plugins/maven-invoker-plugin/) based profile to the build configuration that builds a set of Maven projects located in the newly added `"src/it"` directory.

No dedicated verification script is evaluated after such an `"it"` project build for the time being. A successful build is considered as successful test case.
