### PR TITLE
Introduce ProxyableObjectChangingMethodTest for soft assertions tests

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -666,7 +666,8 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public AbstractObjectAssert<?, ?> extracting(String propertyOrField) {
-    return super.extracting(propertyOrField, this::newObjectAssert);
+    // eclipse needs the explicit cast or fails to compile :(
+    return super.extracting(propertyOrField, (AssertFactory<Object, AbstractObjectAssert<?, ?>>) this::newObjectAssert);
   }
 
   /**
@@ -712,7 +713,9 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(String propertyOrField,
                                                                  InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    return super.extracting(propertyOrField, this::newObjectAssert).asInstanceOf(assertFactory);
+    // eclipse needs the explicit cast or fails to compile :(
+    return super.extracting(propertyOrField,
+                            (AssertFactory<Object, AbstractAssert<?, ?>>) this::newObjectAssert).asInstanceOf(assertFactory);
   }
 
   /**
@@ -776,9 +779,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @since 3.11.0
    * @see #extracting(Function, InstanceOfAssertFactory)
    */
+  @SuppressWarnings("unchecked")
   @CheckReturnValue
   public <T> AbstractObjectAssert<?, T> extracting(Function<? super ACTUAL, T> extractor) {
-    return super.extracting(extractor, this::newObjectAssert);
+    // eclipse fails to compile return super.extracting(extractor, this::newObjectAssert).asInstanceOf(assertFactory);
+    // adding this crazy cast makes eclipse and maven happy.
+    return (AbstractObjectAssert<?, T>) super.extracting(extractor,
+                                                         (AssertFactory<Object, AbstractObjectAssert<?, Object>>) this::newObjectAssert);
   }
 
   /**
@@ -816,7 +823,9 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   @CheckReturnValue
   public <T, ASSERT extends AbstractAssert<?, ?>> ASSERT extracting(Function<? super ACTUAL, T> extractor,
                                                                     InstanceOfAssertFactory<?, ASSERT> assertFactory) {
-    return super.extracting(extractor, this::newObjectAssert).asInstanceOf(assertFactory);
+    // eclipse needs the explicit cast or fails to compile :(
+    return super.extracting(extractor,
+                            (AssertFactory<Object, AbstractAssert<?, ?>>) this::newObjectAssert).asInstanceOf(assertFactory);
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1536,14 +1536,9 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .isGreaterThan(1000);
     softly.then(map).containsExactlyEntriesOf(mapOf(entry("kl", "KL"), entry("mn", "MN")));
     softly.then(map).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("b", "2")));
-    softly.then(map)
-          .as("extracting(\"a\")")
-          .overridingErrorMessage("error message")
-          .extractingByKey("a")
-          .isEqualTo("456");
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(16);
+    assertThat(errors).hasSize(15);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1560,7 +1555,6 @@ public class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(12)).hasMessage("[size()] error message");
     assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
     assertThat(errors.get(14)).hasMessageContaining("to contain only");
-    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/ObjectChangingMethodTest.java
+++ b/src/test/java/org/assertj/core/api/ObjectChangingMethodTest.java
@@ -22,22 +22,22 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.Test;
 
 /**
- * Base tests for navigation methods which create a new assertion.
+ * Tests for methods which change the object under assertion, providing a new assertion instance.
  *
  * @author Stefano Cordio
  */
-public interface NavigationMethodBaseTest<ASSERT extends AbstractAssert<ASSERT, ?>> {
+public interface ObjectChangingMethodTest<ASSERT extends AbstractAssert<ASSERT, ?>> {
 
   ASSERT getAssertion();
 
-  AbstractAssert<?, ?> invoke_navigation_method(ASSERT assertion);
+  AbstractAssert<?, ?> invoke_object_changing_method(ASSERT assertion);
 
   @Test
   default void should_honor_registered_comparator() {
     // GIVEN
     ASSERT assertion = getAssertion().usingComparator(ALWAY_EQUALS);
     // WHEN
-    AbstractAssert<?, ?> result = invoke_navigation_method(assertion);
+    AbstractAssert<?, ?> result = invoke_object_changing_method(assertion);
     // THEN
     result.isEqualTo(UUID.randomUUID()); // random value to avoid false positives
   }
@@ -50,7 +50,7 @@ public interface NavigationMethodBaseTest<ASSERT extends AbstractAssert<ASSERT, 
                                      .withRepresentation(UNICODE_REPRESENTATION)
                                      .usingComparator(ALWAY_EQUALS);
     // WHEN
-    AbstractAssert<?, ?> result = invoke_navigation_method(assertion);
+    AbstractAssert<?, ?> result = invoke_object_changing_method(assertion);
     // THEN
     then(result).hasFieldOrPropertyWithValue("objects", extractObjectField(assertion))
                 .extracting(AbstractAssert::getWritableAssertionInfo)

--- a/src/test/java/org/assertj/core/api/ProxyableObjectChangingMethodTest.java
+++ b/src/test/java/org/assertj/core/api/ProxyableObjectChangingMethodTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for proxyable methods which change the object under assertion, providing a new assertion instance.
+ *
+ * @author Stefano Cordio
+ */
+public interface ProxyableObjectChangingMethodTest<ASSERT extends AbstractAssert<ASSERT, ?>>
+    extends ObjectChangingMethodTest<ASSERT> {
+
+  ASSERT getSoftAssertion(AbstractSoftAssertions softly);
+
+  @ParameterizedTest
+  @MethodSource("softAssertions")
+  default void soft_assertions_should_succeed_after_changing_the_object_under_test(AbstractSoftAssertions softly) {
+    // GIVEN
+    ASSERT softAssertion1 = getSoftAssertion(softly);
+    ASSERT softAssertion2 = getSoftAssertion(softly);
+    // WHEN
+    invoke_object_changing_method(softAssertion1).isNotEqualTo(UUID.randomUUID()); // should always succeed
+    invoke_object_changing_method(softAssertion2).isNotSameAs(UUID.randomUUID()); // should always succeed
+    // THEN
+    softly.assertAll();
+  }
+
+  @ParameterizedTest
+  @MethodSource("softAssertions")
+  default void soft_assertions_should_collect_errors_after_changing_the_object_under_test(AbstractSoftAssertions softly) {
+    // GIVEN
+    ASSERT softAssertion1 = getSoftAssertion(softly).as("assertion 1")
+                                                    .overridingErrorMessage("error message 1");
+    ASSERT softAssertion2 = getSoftAssertion(softly).as("assertion 2")
+                                                    .overridingErrorMessage("error message 2");
+    // WHEN
+    invoke_object_changing_method(softAssertion1).isEqualTo(UUID.randomUUID()); // should always fail
+    invoke_object_changing_method(softAssertion2).isSameAs(UUID.randomUUID()); // should always fail
+    // THEN
+    then(softly.errorsCollected()).extracting(Throwable::getMessage)
+                                  .containsExactly("[assertion 1] error message 1", "[assertion 2] error message 2");
+  }
+
+  static Stream<AbstractSoftAssertions> softAssertions() {
+    return Stream.of(new SoftAssertions(), new BDDSoftAssertions());
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.not;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -572,12 +571,6 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .extractingByKeys("name", "age")
           .contains("kawhi", 25);
     softly.assertThat(map)
-          .extractingByKey("name")
-          .isEqualTo("kawhi");
-    softly.assertThat(map)
-          .extractingByKey("name", as(STRING))
-          .startsWith("kaw");
-    softly.assertThat(map)
           .extractingFromEntries(Map.Entry::getKey, Map.Entry::getValue)
           .contains(tuple("name", "kawhi"), tuple("age", 25));
     softly.assertThat(map)
@@ -878,12 +871,6 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(optional)
           .map(String::length)
           .contains(7);
-    softly.assertThat(optional)
-          .get()
-          .isEqualTo("Gandalf");
-    softly.assertThat(optional)
-          .get(as(STRING))
-          .startsWith("Gan");
     // THEN
     softly.assertAll();
   }
@@ -1801,19 +1788,9 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .isGreaterThan(1000);
     softly.assertThat(map).containsExactlyEntriesOf(mapOf(entry("kl", "KL"), entry("mn", "MN")));
     softly.assertThat(map).containsExactlyInAnyOrderEntriesOf(mapOf(entry("a", "1"), entry("b", "2")));
-    softly.assertThat(map)
-          .as("extracting(\"a\")")
-          .overridingErrorMessage("error message")
-          .extractingByKey("a")
-          .isEqualTo("456");
-    softly.assertThat(map)
-          .as("extracting(\"a\") as string")
-          .overridingErrorMessage("error message")
-          .extractingByKey("a", as(STRING))
-          .startsWith("456");
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(17);
+    assertThat(errors).hasSize(15);
     assertThat(errors.get(0)).hasMessageContaining("MapEntry[key=\"abc\", value=\"ABC\"]");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1830,8 +1807,6 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(12)).hasMessage("[size()] error message");
     assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
     assertThat(errors.get(14)).hasMessageContaining("to contain only");
-    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
-    assertThat(errors.get(16)).hasMessage("[extracting(\"a\") as string] error message");
   }
 
   @Test
@@ -1905,55 +1880,14 @@ public class SoftAssertionsTest extends BaseAssertionsTest {
           .map(String::length)
           .hasValue(4)
           .hasValue(888); // fail
-    softly.assertThat(optional)
-          .as("get()")
-          .overridingErrorMessage("error message")
-          .get()
-          .isEqualTo("Yoda")
-          .isEqualTo("Luke"); // fail
-    softly.assertThat(optional)
-          .as("get(as(STRING))")
-          .overridingErrorMessage("error message")
-          .get(as(STRING))
-          .startsWith("Yo")
-          .startsWith("Lu"); // fail
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(5);
+    assertThat(errorsCollected).hasSize(3);
     assertThat(errorsCollected.get(0)).hasMessage("[map(String::length)] error message");
     assertThat(errorsCollected.get(1)).hasMessageContaining("flatMap(upperCaseOptional)")
                                       .hasMessageContaining("yoda");
     assertThat(errorsCollected.get(2)).hasMessageContaining("map(String::length) after flatMap(upperCaseOptional)")
                                       .hasMessageContaining("888");
-    assertThat(errorsCollected.get(3)).hasMessage("[get()] error message");
-    assertThat(errorsCollected.get(4)).hasMessage("[get(as(STRING))] error message");
-  }
-
-  @Test
-  void string_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
-    // GIVEN
-    String base64String = "QXNzZXJ0Sg==";
-    // WHEN
-    softly.assertThat(base64String)
-          .as("decodedAsBase64()")
-          .overridingErrorMessage("error message 1")
-          .decodedAsBase64()
-          .isEmpty();
-    // THEN
-    then(softly.errorsCollected()).extracting(Throwable::getMessage)
-                                  .containsExactly("[decodedAsBase64()] error message 1");
-  }
-
-  @Test
-  void should_work_with_string() {
-    // GIVEN
-    String base64String = "QXNzZXJ0Sg==";
-    // WHEN
-    softly.assertThat(base64String)
-          .decodedAsBase64()
-          .containsExactly("AssertJ".getBytes());
-    // THEN
-    softly.assertAll();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/SoftAssertions_combined_with_asInstanceOf_Test.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertions_combined_with_asInstanceOf_Test.java
@@ -14,7 +14,6 @@ package org.assertj.core.api;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_BOOLEAN;
 import static org.assertj.core.api.InstanceOfAssertFactories.ATOMIC_INTEGER;
@@ -102,7 +101,6 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -132,7 +130,6 @@ import java.util.stream.Stream;
 
 import org.assertj.core.data.TolkienCharacter;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -145,21 +142,6 @@ public class SoftAssertions_combined_with_asInstanceOf_Test extends BaseAssertio
   public void setup() {
     Assertions.setRemoveAssertJRelatedElementsFromStackTrace(false);
     softly = new SoftAssertions();
-  }
-
-  @Test
-  public void soft_assertions_should_work() {
-    // GIVEN
-    Object value = "abc";
-    // WHEN
-    softly.assertThat(value)
-          .as("startsWith")
-          .asInstanceOf(STRING)
-          .startsWith("b");
-    // THEN
-    List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(1);
-    assertThat(errorsCollected.get(0)).hasMessageContaining("[startsWith]");
   }
 
   @ParameterizedTest(name = "with {1}")

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test.java
@@ -21,9 +21,10 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractAssertBaseTest;
 import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.ConcreteAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,7 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("AbstractAssert asInstanceOf(InstanceOfAssertFactory)")
 class AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test extends AbstractAssertBaseTest
-    implements NavigationMethodBaseTest<ConcreteAssert> {
+    implements ProxyableObjectChangingMethodTest<ConcreteAssert> {
 
   @Override
   protected ConcreteAssert invoke_api_method() {
@@ -58,7 +59,12 @@ class AbstractAssert_asInstanceOf_with_InstanceOfAssertFactory_Test extends Abst
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(ConcreteAssert assertion) {
+  public ConcreteAssert getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(ConcreteAssert.class, Object.class, getActual(assertions));
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(ConcreteAssert assertion) {
     return assertion.asInstanceOf(LONG);
   }
 

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
@@ -25,11 +25,10 @@ import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AssertFactory;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.ObjectChangingMethodTest;
 import org.assertj.core.api.abstract_.AbstractAssert_extracting_with_Function_and_AssertFactory_Test.TestAssert;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,15 +38,10 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("AbstractAssert extracting(Function, AssertFactory)")
-class AbstractAssert_extracting_with_Function_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
+class AbstractAssert_extracting_with_Function_and_AssertFactory_Test implements ObjectChangingMethodTest<TestAssert> {
 
-  private TestAssert underTest;
-
-  @BeforeEach
-  void setup() {
-    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
-    underTest = new TestAssert(luke);
-  }
+  private final Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+  private final TestAssert underTest = new TestAssert(luke);
 
   @Test
   void should_throw_npe_if_the_given_extractor_is_null() {
@@ -124,7 +118,7 @@ class AbstractAssert_extracting_with_Function_and_AssertFactory_Test implements 
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(TestAssert assertion) {
+  public AbstractAssert<?, ?> invoke_object_changing_method(TestAssert assertion) {
     return assertion.extracting(Employee::getAge, Assertions::assertThat);
   }
 

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
@@ -22,12 +22,11 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AssertFactory;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.ObjectChangingMethodTest;
 import org.assertj.core.api.abstract_.AbstractAssert_extracting_with_String_and_AssertFactory_Test.TestAssert;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
 import org.assertj.core.util.introspection.IntrospectionError;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -37,15 +36,10 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("AbstractAssert extracting(String, AssertFactory)")
-class AbstractAssert_extracting_with_String_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
+class AbstractAssert_extracting_with_String_and_AssertFactory_Test implements ObjectChangingMethodTest<TestAssert> {
 
-  private TestAssert underTest;
-
-  @BeforeEach
-  void setup() {
-    Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
-    underTest = new TestAssert(luke);
-  }
+  private final Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
+  private final TestAssert underTest = new TestAssert(luke);;
 
   @Test
   void should_throw_npe_if_the_given_propertyOrField_is_null() {
@@ -115,7 +109,7 @@ class AbstractAssert_extracting_with_String_and_AssertFactory_Test implements Na
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(TestAssert assertion) {
+  public AbstractAssert<?, ?> invoke_object_changing_method(TestAssert assertion) {
     return assertion.extracting("age", Assertions::assertThat);
   }
 

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_Test.java
@@ -22,8 +22,9 @@ import java.util.Map;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.MapAssert;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("MapAssert extractingByKey(KEY)")
-class MapAssert_extractingByKey_with_Key_Test implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
+class MapAssert_extractingByKey_with_Key_Test implements ProxyableObjectChangingMethodTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -95,7 +96,13 @@ class MapAssert_extractingByKey_with_Key_Test implements NavigationMethodBaseTes
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+  @SuppressWarnings("unchecked")
+  public MapAssert<Object, Object> getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(MapAssert.class, Map.class, map);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(MapAssert<Object, Object> assertion) {
     return assertion.extractingByKey(NAME);
   }
 

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test.java
@@ -26,10 +26,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.MapAssert;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("MapAssert extractingByKey(KEY, InstanceOfAssertFactory)")
 class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test
-    implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
+    implements ProxyableObjectChangingMethodTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -110,7 +111,13 @@ class MapAssert_extractingByKey_with_Key_and_InstanceOfAssertFactory_Test
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+  @SuppressWarnings("unchecked")
+  public MapAssert<Object, Object> getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(MapAssert.class, Map.class, map);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(MapAssert<Object, Object> assertion) {
     return assertion.extractingByKey(NAME, as(STRING));
   }
 

--- a/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKeys_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_extractingByKeys_Test.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.MapAssert;
-import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ObjectChangingMethodTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("MapAssert extractingByKeys(KEY...)")
-class MapAssert_extractingByKeys_Test implements NavigationMethodBaseTest<MapAssert<Object, Object>> {
+class MapAssert_extractingByKeys_Test implements ObjectChangingMethodTest<MapAssert<Object, Object>> {
 
   private static final Object NAME = "name";
   private Map<Object, Object> map;
@@ -96,7 +96,7 @@ class MapAssert_extractingByKeys_Test implements NavigationMethodBaseTest<MapAss
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(MapAssert<Object, Object> assertion) {
+  public AbstractAssert<?, ?> invoke_object_changing_method(MapAssert<Object, Object> assertion) {
     return assertion.extractingByKeys(NAME, "age");
   }
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
@@ -28,11 +28,10 @@ import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ObjectChangingMethodTest;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,16 +42,11 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("ObjectAssert extracting(Function, InstanceOfAssertFactory)")
 class ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test
-    implements NavigationMethodBaseTest<ObjectAssert<Employee>> {
-
-  private Employee luke;
+    implements ObjectChangingMethodTest<ObjectAssert<Employee>> {
 
   private static final Function<Employee, String> FIRST_NAME = employee -> employee.getName().getFirst();
 
-  @BeforeEach
-  void setUp() {
-    luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
-  }
+  private final Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
 
   @Test
   void should_throw_npe_if_the_given_extractor_is_null() {
@@ -134,7 +128,7 @@ class ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(ObjectAssert<Employee> assertion) {
+  public AbstractAssert<?, ?> invoke_object_changing_method(ObjectAssert<Employee> assertion) {
     return assertion.extracting(Employee::getAge, INTEGER);
   }
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
@@ -30,12 +30,11 @@ import org.assertj.core.api.AbstractBigDecimalAssert;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ObjectChangingMethodTest;
 import org.assertj.core.test.Employee;
 import org.assertj.core.test.Name;
 import org.assertj.core.util.introspection.IntrospectionError;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -46,14 +45,9 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("ObjectAssert extracting(String, InstanceOfAssertFactory)")
 class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
-    implements NavigationMethodBaseTest<ObjectAssert<Employee>> {
+    implements ObjectChangingMethodTest<ObjectAssert<Employee>> {
 
-  private Employee luke;
-
-  @BeforeEach
-  void setup() {
-    luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);
-  }
+  private final Employee luke = new Employee(2L, new Name("Luke", "Skywalker"), 26);;
 
   @Test
   void should_throw_npe_if_the_given_assert_factory_is_null() {
@@ -129,7 +123,7 @@ class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(ObjectAssert<Employee> assertion) {
+  public AbstractAssert<?, ?> invoke_object_changing_method(ObjectAssert<Employee> assertion) {
     return assertion.extracting("name.first", STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_Test.java
@@ -22,8 +22,9 @@ import java.util.Optional;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractObjectAssert;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.OptionalAssert;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ import org.junit.jupiter.api.Test;
  * @author Filip Hrisafov
  */
 @DisplayName("OptionalAssert get")
-class OptionalAssert_get_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
+class OptionalAssert_get_Test implements ProxyableObjectChangingMethodTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");
 
@@ -71,7 +72,13 @@ class OptionalAssert_get_Test implements NavigationMethodBaseTest<OptionalAssert
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(OptionalAssert<String> assertion) {
+  @SuppressWarnings("unchecked")
+  public OptionalAssert<String> getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(OptionalAssert.class, Optional.class, optional);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(OptionalAssert<String> assertion) {
     return assertion.get();
   }
 

--- a/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
+++ b/src/test/java/org/assertj/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
@@ -25,10 +25,11 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import java.util.Optional;
 
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.OptionalAssert;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("OptionalAssert get(InstanceOfAssertFactory)")
-class OptionalAssert_get_with_InstanceOfAssertFactory_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
+class OptionalAssert_get_with_InstanceOfAssertFactory_Test implements ProxyableObjectChangingMethodTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");
 
@@ -93,7 +94,13 @@ class OptionalAssert_get_with_InstanceOfAssertFactory_Test implements Navigation
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(OptionalAssert<String> assertion) {
+  @SuppressWarnings("unchecked")
+  public OptionalAssert<String> getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(OptionalAssert.class, Optional.class, optional);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(OptionalAssert<String> assertion) {
     return assertion.get(STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/string_/StringAssert_decodedAsBase64_Test.java
+++ b/src/test/java/org/assertj/core/api/string_/StringAssert_decodedAsBase64_Test.java
@@ -17,7 +17,8 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractByteArrayAssert;
-import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.AbstractSoftAssertions;
+import org.assertj.core.api.ProxyableObjectChangingMethodTest;
 import org.assertj.core.api.StringAssert;
 import org.assertj.core.api.StringAssertBaseTest;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Stefano Cordio
  */
 @DisplayName("StringAssert decodedAsBase64")
-class StringAssert_decodedAsBase64_Test extends StringAssertBaseTest implements NavigationMethodBaseTest<StringAssert> {
+class StringAssert_decodedAsBase64_Test extends StringAssertBaseTest implements ProxyableObjectChangingMethodTest<StringAssert> {
 
   @Override
   protected StringAssert invoke_api_method() {
@@ -53,7 +54,12 @@ class StringAssert_decodedAsBase64_Test extends StringAssertBaseTest implements 
   }
 
   @Override
-  public AbstractAssert<?, ?> invoke_navigation_method(StringAssert assertion) {
+  public StringAssert getSoftAssertion(AbstractSoftAssertions softly) {
+    return softly.proxy(StringAssert.class, String.class, getActual(assertions));
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_object_changing_method(StringAssert assertion) {
     return assertion.decodedAsBase64();
   }
 

--- a/src/test/java/org/example/test/CustomSoftAssertionsLineNumberTest.java
+++ b/src/test/java/org/example/test/CustomSoftAssertionsLineNumberTest.java
@@ -32,7 +32,7 @@ class CustomSoftAssertionsLineNumberTest {
     AssertionError error = catchThrowableOfType(softly::assertAll, AssertionError.class);
     // THEN
     // does not check the exact line number because it can vary (for example when Jacoco injects fields to check code coverage)
-    assertThat(error).hasStackTraceContaining​​("CustomSoftAssertionsLineNumberTest.should_print_line_numbers_of_failed_assertions_even_if_custom_assertion_in_non_assertj_package(CustomSoftAssertionsLineNumberTest.java:3");
+    assertThat(error).hasStackTraceContaining("CustomSoftAssertionsLineNumberTest.should_print_line_numbers_of_failed_assertions_even_if_custom_assertion_in_non_assertj_package(CustomSoftAssertionsLineNumberTest.java:3");
   }
 
 }


### PR DESCRIPTION
First try to break down `SoftAssertionTests`. The idea is to enhance the test classes of single methods with some centralized tests, avoiding the repetitive writing every time a new assertion method is added.

* `ProxyableObjectChangingMethodTest`: for public methods which change the object under test and are proxied according to [`SoftProxies`](https://github.com/joel-costigliola/assertj-core/blob/master/src/main/java/org/assertj/core/api/SoftProxies.java#L42)
* `ObjectChangingMethodTest`: for non-public methods like [`AbstractAssert#extracting`](https://github.com/joel-costigliola/assertj-core/blob/master/src/main/java/org/assertj/core/api/AbstractAssert.java#L877-L931) which change the method under assertion but are not proxied

As demonstration, just few tests have been moved to the new setup, but more should be refactored.

Open issues with `ProxyableObjectChangingMethodTest`:

- [ ] When applied to:
  * `ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test`
  * `ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test`

  as:
  ```java
  implements ProxyableObjectChangingMethodTest<ObjectAssert<Employee>>
  ```

  and providing the soft assertions as:

  ```java
  @Override
  public ObjectAssert<Employee> getSoftAssertion(AbstractSoftAssertions softly) {
    return softly.proxy(ObjectAssert.class, Employee.class, luke);
  }
  ``` 
  it fails with:

  ```
  java.lang.RuntimeException: java.lang.NoSuchMethodException: org.assertj.core.api.ObjectAssert$ByteBuddy$it09GaKX.<init>(org.assertj.core.test.Employee)

	at org.assertj.core.api.SoftProxies.createSoftAssertionProxy(SoftProxies.java:121)
	at org.assertj.core.api.AbstractSoftAssertions.proxy(AbstractSoftAssertions.java:43)
	at org.assertj.core.api.object.ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.getSoftAssertion(ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java:128)
	at org.assertj.core.api.object.ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.getSoftAssertion(ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java:47)
	at org.assertj.core.api.ProxyableObjectChangingMethodTest.soft_assertions_should_collect_errors_after_changing_the_object_under_test(ProxyableObjectChangingMethodTest.java:50)
  ```
  This could be caused by the use of `ObjectAssert` instead of `ProxyableObjectAssert`, but at the moment I don't understand the exact cause.

- [ ] When applied to `MapAssert_extractingByKeys_Test` as:
  ```java
  implements ProxyableObjectChangingMethodTest<MapAssert<Object, Object>>
  ```

   and providing the soft assertions as:
  ```java
  @Override
  @SuppressWarnings("unchecked")
  public MapAssert<Object, Object> getSoftAssertion(AbstractSoftAssertions softly) {
    return softly.proxy(MapAssert.class, Map.class, map);
  }
  ```

  it stops at the first assertion error in `soft_assertions_should_collect_errors_after_changing_the_object_under_test`.

  Most likely this is due to `extractingByKeys` being final and an instance of `ProxyableMapAssert` should be used instead, but it would require a separate test class with:
  ```java
  implements ProxyableObjectChangingMethodTest<ProxyableMapAssert<Object, Object>>
  ```