### PR TITLE
Added new assertions for URI and URL for exhaustive parameters check

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -12,10 +12,13 @@
  */
 package org.assertj.core.api;
 
-import java.net.URI;
-
 import org.assertj.core.internal.Uris;
 import org.assertj.core.util.VisibleForTesting;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for all implementations of assertions for {@link URI}s.
@@ -411,6 +414,126 @@ public abstract class AbstractUriAssert<SELF extends AbstractUriAssert<SELF>> ex
    */
   public SELF hasNoParameter(String name, String value) {
     uris.assertHasNoParameter(info, actual, name, value);
+    return myself;
+  }
+
+
+  /**
+   * Verifies that the actual {@code URI} has the parameters exactly same as in given collection.<br>
+   * <br>
+   * <b>Recomended for use when expecting non-repeatable params</b> e.g.:<br>
+   *  <pre><code class='java'>
+   *  Collection&lt;MapEntry&lt;String, String&gt;&gt; expectedParams = Map.of(
+   *     "a", "v1",
+   *     "b", "v2",
+   *     "c", "v3"
+   *  ).entrySet();
+   *  </code></pre>
+   * But collection can also contains more entries with same key, will be merged to multivalue map e.g.:<br>
+   *  <pre><code class='java'>
+   *  List.of(
+   *     Map.entry("a", "v1"),
+   *     Map.entry("a", "v2"),
+   *     Map.entry("b", "v1")
+   *  );
+   *  </code></pre>
+   * will represent expected params:
+   *  <pre>
+   *  a = {v1, v2},
+   *  b = {v1}
+   *  </pre>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // These assertions succeed:
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(List.of(
+   *       new AbstractMap.SimpleEntry&lt;&gt;("firstName", "Andrew"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("lastName", "Sneck"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("option", null)
+   *    )
+   * );
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first")).containsExactlyParameters(Map.of(
+   *        "firstName", "Andrew",
+   *        "lastName", "Sneck",
+   *        "option", "v3"
+   *     ).entrySet()
+   * );
+   *
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first")).containsExactlyParameters(List.of(
+   *       new AbstractMap.SimpleEntry&lt;&gt;("firstName", "Andrew"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("lastName", "Sneck"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("option", null)
+   *    )
+   * );
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *        "firstName", "Andrew",
+   *        "lastName", "Sneck",
+   *        "option", "v3"
+   *     ).entrySet()
+   * );
+   * </code></pre>
+   *
+   * @param expectedParameters collection of map entries which each represent paramName-paramValue
+   * @return {@code this} assertion object.
+   * @throws AssertionError           if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public SELF containsExactlyParameters(Collection<Map.Entry<String, String>> expectedParameters) {
+    uris.assertContainsExactlyParameters(info, actual, expectedParameters);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URI} has the parameters exactly same as in given multi-value map.<br>
+   * <br>
+   * <b>Recomended for use when expecting repeatable params</b> e.g.:<br>
+   *  <pre><code class='java'>
+   *  MapEntry&lt;String, List&lt;String&gt;&gt; expectedParams = Map.of(
+   *     "a", List.of("v1","v2),
+   *     "b", List.of("v2"),
+   *     "c", List.of("v3")
+   *  );
+   *  </code></pre>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // These assertions succeed:
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *       "firstName", List.of("Andrew"),
+   *       "lastName", List.of("Sneck"),
+   *       "option", List.of(null)
+   * ));
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first&amp;option=second")).containsExactlyParameters(Map.of(
+   *        "firstName", List.of("Andrew"),
+   *        "lastName", List.of("Sneck"),
+   *        "option", List.of("first", "second")
+   * ));
+   *
+   * // These assertions fail:
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *       "firstName", List.of("Andrew"),
+   *       "lastName", List.of("Sneck"),
+   *       "option", List.of()
+   * ));
+   * assertThat(new URI("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first&amp;option=second")).containsExactlyParameters(Map.of(
+   *        "firstName", List.of("Andrew"),
+   *        "lastName", List.of("Sneck"),
+   *        "option", List.of("second")
+   * ));
+   * </code></pre>
+   *
+   * @param expectedParameters collection of map entries which each represent paramName-paramValue
+   * @return {@code this} assertion object.
+   * @throws AssertionError           if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public SELF containsExactlyParameters(Map<String, List<String>> expectedParameters) {
+    uris.assertContainsExactlyParameters(info, actual, expectedParameters);
     return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -12,10 +12,13 @@
  */
 package org.assertj.core.api;
 
-import java.net.URL;
-
 import org.assertj.core.internal.Urls;
 import org.assertj.core.util.VisibleForTesting;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for all implementations of assertions for {@link URL}s.
@@ -446,4 +449,124 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
     urls.assertIsEqualToWithSortedQueryParameters(info, actual, expected);
     return myself;
   }
+
+  /**
+   * Verifies that the actual {@code URL} has the parameters exactly same as in given collection.<br>
+   * <br>
+   * <b>Recomended for use when expecting non-repeatable params</b> e.g.:<br>
+   *  <pre><code class='java'>
+   *  Collection&lt;MapEntry&lt;String, String&gt;&gt; expectedParams = Map.of(
+   *     "a", "v1",
+   *     "b", "v2",
+   *     "c", "v3"
+   *  ).entrySet();
+   *  </code></pre>
+   * But collection can also contains more entries with same key, will be merged to multivalue map e.g.:<br>
+   *  <pre><code class='java'>
+   *  List.of(
+   *     Map.entry("a", "v1"),
+   *     Map.entry("a", "v2"),
+   *     Map.entry("b", "v1")
+   *  );
+   *  </code></pre>
+   * will represent expected params:
+   *  <pre>
+   *  a = {v1, v2},
+   *  b = {v1}
+   *  </pre>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // These assertions succeed:
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(List.of(
+   *       new AbstractMap.SimpleEntry&lt;&gt;("firstName", "Andrew"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("lastName", "Sneck"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("option", null)
+   *    )
+   * );
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first")).containsExactlyParameters(Map.of(
+   *        "firstName", "Andrew",
+   *        "lastName", "Sneck",
+   *        "option", "v3"
+   *     ).entrySet()
+   * );
+   *
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first")).containsExactlyParameters(List.of(
+   *       new AbstractMap.SimpleEntry&lt;&gt;("firstName", "Andrew"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("lastName", "Sneck"),
+   *       new AbstractMap.SimpleEntry&lt;&gt;("option", null)
+   *    )
+   * );
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *        "firstName", "Andrew",
+   *        "lastName", "Sneck",
+   *        "option", "v3"
+   *     ).entrySet()
+   * );
+   * </code></pre>
+   *
+   * @param expectedParameters collection of map entries which each represent paramName-paramValue
+   * @return {@code this} assertion object.
+   * @throws AssertionError           if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public SELF containsExactlyParameters(Collection<Map.Entry<String, String>> expectedParameters) {
+    urls.assertContainsExactlyParameters(info, actual, expectedParameters);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code URL} has the parameters exactly same as in given multi-value map.<br>
+   * <br>
+   * <b>Recomended for use when expecting repeatable params</b> e.g.:<br>
+   *  <pre><code class='java'>
+   *  MapEntry&lt;String, List&lt;String&gt;&gt; expectedParams = Map.of(
+   *     "a", List.of("v1","v2),
+   *     "b", List.of("v2"),
+   *     "c", List.of("v3")
+   *  );
+   *  </code></pre>
+   * Use {@code null} to indicate an absent value (e.g. {@code foo&bar}) as opposed to an empty value (e.g.
+   * {@code foo=&bar=}).
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // These assertions succeed:
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *       "firstName", List.of("Andrew"),
+   *       "lastName", List.of("Sneck"),
+   *       "option", List.of(null)
+   * ));
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first&amp;option=second")).containsExactlyParameters(Map.of(
+   *        "firstName", List.of("Andrew"),
+   *        "lastName", List.of("Sneck"),
+   *        "option", List.of("first", "second")
+   * ));
+   *
+   * // These assertions fail:
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option")).containsExactlyParameters(Map.of(
+   *       "firstName", List.of("Andrew"),
+   *       "lastName", List.of("Sneck"),
+   *       "option", List.of()
+   * ));
+   * assertThat(new URL("http://www.helloworld.org/index.html?firstName=Andrew&amp;lastName=Schrek&amp;option=first&amp;option=second")).containsExactlyParameters(Map.of(
+   *        "firstName", List.of("Andrew"),
+   *        "lastName", List.of("Sneck"),
+   *        "option", List.of("second")
+   * ));
+   * </code></pre>
+   *
+   * @param expectedParameters collection of map entries which each represent paramName-paramValue
+   * @return {@code this} assertion object.
+   * @throws AssertionError           if the actual does not have the expected parameter.
+   * @throws IllegalArgumentException if the query string contains an invalid escape sequence.
+   */
+  public SELF containsExactlyParameters(Map<String, List<String>> expectedParameters) {
+    urls.assertContainsExactlyParameters(info, actual, expectedParameters);
+    return myself;
+  }
+
 }

--- a/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldHaveParameter.java
@@ -12,11 +12,14 @@
  */
 package org.assertj.core.error.uri;
 
-import java.util.List;
-import java.util.Set;
-
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ShouldHaveParameter extends BasicErrorMessageFactory {
 
@@ -30,6 +33,10 @@ public class ShouldHaveParameter extends BasicErrorMessageFactory {
 
   private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_HAD_WRONG_VALUE = "%nExpecting actual:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had value:%n  <%s>";
   private static final String SHOULD_HAVE_PARAMETER_VALUE_BUT_HAD_WRONG_VALUES = "%nExpecting actual:%n  <%s>%nto have parameter:%n  <%s>%nwith value:%n  <%s>%nbut had values:%n  <%s>";
+
+  private static final String SHOULD_HAVE_SAME_PARAMETERS = "%nExpecting parameters:%n%s%nbut had:%n%s%nnot expected:%n%s%nmissing:%n%s";
+  private static final String SHOULD_HAVE_SAME_PARAMETERS_EMPTY_NOT_EXPECTED = "%nExpecting parameters:%n%s%nbut had:%n%s%nmissing:%n%s";
+  private static final String SHOULD_HAVE_SAME_PARAMETERS_EMPTY_MISSING = "%nExpecting parameters:%n%s%nbut had:%n%s%nnot expected:%n%s";
 
   private static final String SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_WITHOUT_VALUE = "%nExpecting actual:%n  <%s>%nnot to have parameter:%n  <%s>%nbut parameter was present with no value";
   private static final String SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_VALUE = "%nExpecting actual:%n  <%s>%nnot to have parameter:%n  <%s>%nbut parameter was present with value:%n  <%s>";
@@ -48,33 +55,63 @@ public class ShouldHaveParameter extends BasicErrorMessageFactory {
     if (expectedValue == null)
       return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_WITHOUT_VALUE_BUT_PARAMETER_WAS_MISSING, actual, name);
     return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_WITH_VALUE_BUT_PARAMETER_WAS_MISSING, actual, name,
-                                   expectedValue);
+      expectedValue);
   }
 
   public static ErrorMessageFactory shouldHaveParameter(Object actual, String name, String expectedValue,
                                                         List<String> actualValues) {
     if (expectedValue == null)
       return new ShouldHaveParameter(multipleValues(actualValues) ? SHOULD_HAVE_PARAMETER_WITHOUT_VALUE_BUT_HAD_VALUES
-          : SHOULD_HAVE_PARAMETER_WITHOUT_VALUE_BUT_HAD_VALUE, actual, name, valueDescription(actualValues));
+        : SHOULD_HAVE_PARAMETER_WITHOUT_VALUE_BUT_HAD_VALUE, actual, name, valueDescription(actualValues));
 
     if (noValueIn(actualValues))
       return new ShouldHaveParameter(SHOULD_HAVE_PARAMETER_WITH_VALUE_BUT_HAD_NO_VALUE, actual, name, expectedValue);
 
     return new ShouldHaveParameter(multipleValues(actualValues) ? SHOULD_HAVE_PARAMETER_VALUE_BUT_HAD_WRONG_VALUES
-        : SHOULD_HAVE_PARAMETER_VALUE_BUT_HAD_WRONG_VALUE, actual, name, expectedValue, valueDescription(actualValues));
+      : SHOULD_HAVE_PARAMETER_VALUE_BUT_HAD_WRONG_VALUE, actual, name, expectedValue, valueDescription(actualValues));
+  }
+
+  public static ErrorMessageFactory shouldHaveSameParameters(Map<String, List<String>> actualParameters, Map<String, List<String>> expectedParameters, Map<String, List<String>> missing, Map<String, List<String>> notExpected) {
+    Function<Map<String, List<String>>, String> formatter = map -> map.entrySet().stream()
+      .map(it -> String.format("%s=%s", it.getKey(), it.getValue()))
+      .sorted()
+      .collect(Collectors.joining(",\n"));
+
+    if (notExpected.isEmpty()) {
+      return new ShouldHaveParameter(SHOULD_HAVE_SAME_PARAMETERS_EMPTY_NOT_EXPECTED,
+        formatter.apply(expectedParameters),
+        formatter.apply(actualParameters),
+        formatter.apply(missing)
+      );
+    }
+
+    if (missing.isEmpty()) {
+      return new ShouldHaveParameter(SHOULD_HAVE_SAME_PARAMETERS_EMPTY_MISSING,
+        formatter.apply(expectedParameters),
+        formatter.apply(actualParameters),
+        formatter.apply(notExpected)
+      );
+    }
+
+    return new ShouldHaveParameter(SHOULD_HAVE_SAME_PARAMETERS,
+      formatter.apply(expectedParameters),
+      formatter.apply(actualParameters),
+      formatter.apply(notExpected),
+      formatter.apply(missing)
+    );
   }
 
   public static ErrorMessageFactory shouldHaveNoParameters(Object actual, Set<String> parameterNames) {
     String parametersDescription = parameterNames.size() == 1 ? parameterNames.iterator().next()
-        : parameterNames.toString();
+      : parameterNames.toString();
     return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETERS, actual, parametersDescription);
   }
 
   public static ErrorMessageFactory shouldHaveNoParameter(Object actual, String name, List<String> actualValues) {
     return noValueIn(actualValues)
-        ? new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_WITHOUT_VALUE, actual, name)
-        : new ShouldHaveParameter(multipleValues(actualValues) ? SHOULD_HAVE_NO_PARAMETER_BUT_HAD_MULTIPLE_VALUES
-            : SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_VALUE, actual, name, valueDescription(actualValues));
+      ? new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_WITHOUT_VALUE, actual, name)
+      : new ShouldHaveParameter(multipleValues(actualValues) ? SHOULD_HAVE_NO_PARAMETER_BUT_HAD_MULTIPLE_VALUES
+      : SHOULD_HAVE_NO_PARAMETER_BUT_HAD_ONE_VALUE, actual, name, valueDescription(actualValues));
   }
 
   public static ErrorMessageFactory shouldHaveNoParameter(Object actual, String name, String unwantedValue,
@@ -83,7 +120,7 @@ public class ShouldHaveParameter extends BasicErrorMessageFactory {
       return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_WITHOUT_VALUE_BUT_FOUND_ONE, actual, name);
 
     return new ShouldHaveParameter(SHOULD_HAVE_NO_PARAMETER_WITH_GIVEN_VALUE_BUT_FOUND_ONE, actual, name,
-                                   unwantedValue);
+      unwantedValue);
   }
 
   private static boolean noValueIn(List<String> actualValues) {

--- a/src/main/java/org/assertj/core/internal/ErrorMessages.java
+++ b/src/main/java/org/assertj/core/internal/ErrorMessages.java
@@ -59,6 +59,10 @@ public final class ErrorMessages {
     return "The map of entries to look for should not be null";
   }
 
+  public static String setOfEntriesToLookForIsNull() {
+    return "The set of entries to look for should not be null";
+  }
+
   public static String entryToLookForIsNull() {
     return "Entries to look for should not be null";
   }

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -12,7 +12,23 @@
  */
 package org.assertj.core.internal;
 
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 import static java.util.Objects.deepEquals;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
@@ -20,6 +36,7 @@ import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveSameParameters;
 import static org.assertj.core.error.uri.ShouldHavePath.shouldHavePath;
 import static org.assertj.core.error.uri.ShouldHavePort.shouldHavePort;
 import static org.assertj.core.error.uri.ShouldHaveProtocol.shouldHaveProtocol;
@@ -28,15 +45,6 @@ import static org.assertj.core.error.uri.ShouldHaveUserInfo.shouldHaveUserInfo;
 import static org.assertj.core.internal.Comparables.assertNotNull;
 import static org.assertj.core.internal.Uris.getParameters;
 import static org.assertj.core.util.Preconditions.checkArgument;
-
-import java.net.URL;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.util.VisibleForTesting;
 
 public class Urls {
 
@@ -49,7 +57,8 @@ public class Urls {
     return INSTANCE;
   }
 
-  Urls() {}
+  Urls() {
+  }
 
   private static String extractNonQueryParams(URL url) {
     String queryPart = url.getQuery() == null ? "" : url.getQuery();
@@ -158,5 +167,57 @@ public class Urls {
     boolean differentSortedQueryParams = !deepEquals(extractSortedQueryParams(expected), extractSortedQueryParams(actual));
     if (differentNonQueryParams || differentSortedQueryParams)
       throw failures.failure(info, shouldBeEqualToWithSortedQueryParameters(actual, expected));
+  }
+
+  public final void assertContainsExactlyParameters(AssertionInfo info, URL actual, Collection<Map.Entry<String, String>> expectedParameters) {
+    requireNonNull(expectedParameters, ErrorMessages.setOfEntriesToLookForIsNull());
+
+    final HashMap<String, List<String>> multiValueMap = new HashMap<>();
+
+    expectedParameters.forEach(param ->
+      multiValueMap.compute(param.getKey(), (key, values) -> {
+        if (values == null) values = new ArrayList<>();
+        values.add(param.getValue());
+        return values;
+      })
+    );
+
+    assertContainsExactlyParameters(info, actual, multiValueMap);
+  }
+
+  public void assertContainsExactlyParameters(AssertionInfo info, URL actual, Map<String, List<String>> expectedParameters) {
+    assertNotNull(info, actual);
+    requireNonNull(expectedParameters, ErrorMessages.mapOfEntriesToLookForIsNull());
+
+    Map<String, List<String>> urlParameters = getParameters(actual.getQuery());
+
+    Map<String, List<String>> notExpectedInUrl = new LinkedHashMap<>();
+    urlParameters.forEach((key, value) -> notExpectedInUrl.put(key, new ArrayList<>(value)));
+
+    Map<String, List<String>> missingInUrl = new LinkedHashMap<>();
+    expectedParameters.forEach((key, value) -> missingInUrl.put(key, new ArrayList<>(value)));
+
+    expectedParameters.forEach((parameterKey, parameterValue) -> {
+      final List<String> missingValues = missingInUrl.getOrDefault(parameterKey, Collections.emptyList());
+      final List<String> nonExpectedValues = notExpectedInUrl.getOrDefault(parameterKey, Collections.emptyList());
+
+      final List<String> forDeleteFromNonExpectedValues = nonExpectedValues.stream()
+        .filter(missingValues::contains)
+        .collect(Collectors.toList());
+
+      final List<String> forDeleteFromMissingValues = missingValues.stream()
+        .filter(nonExpectedValues::contains)
+        .collect(Collectors.toList());
+
+      nonExpectedValues.removeAll(forDeleteFromNonExpectedValues);
+      missingValues.removeAll(forDeleteFromMissingValues);
+
+      if (nonExpectedValues.isEmpty()) notExpectedInUrl.remove(parameterKey);
+      if (missingValues.isEmpty()) missingInUrl.remove(parameterKey);
+    });
+
+    if (!notExpectedInUrl.isEmpty() || !missingInUrl.isEmpty()) {
+      throw failures.failure(info, shouldHaveSameParameters(urlParameters, expectedParameters, missingInUrl, notExpectedInUrl));
+    }
   }
 }

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_containsExactlyParameters_Entries_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_containsExactlyParameters_Entries_Test.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+
+@DisplayName("UriAssert containsExactlyParameters")
+class UriAssert_containsExactlyParameters_Entries_Test extends UriAssertBaseTest {
+
+  private final Collection<Map.Entry<String, String>> expected = Lists.newArrayList(
+    new AbstractMap.SimpleEntry<>("a", "v1"),
+    new AbstractMap.SimpleEntry<>("a", "v2"),
+    new AbstractMap.SimpleEntry<>("b", "v1")
+  );
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.containsExactlyParameters(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertContainsExactlyParameters(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_containsExactlyParameters_Map_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_containsExactlyParameters_Map_Test.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("UriAssert containsExactlyParameters")
+class UriAssert_containsExactlyParameters_Map_Test extends UriAssertBaseTest {
+
+  private final Map<String, List<String>> expected = Maps.mapOf(
+    MapEntry.entry("a", Lists.list("v1", "v2")),
+    MapEntry.entry("b", Lists.list("v1"))
+  );
+
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.containsExactlyParameters(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertContainsExactlyParameters(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_containsExactlyParameters_Entries_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_containsExactlyParameters_Entries_Test.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+
+@DisplayName("UrlAssert containsExactlyParameters")
+class UrlAssert_containsExactlyParameters_Entries_Test extends UrlAssertBaseTest {
+
+  private final Collection<Map.Entry<String, String>> expected = Lists.newArrayList(
+    new AbstractMap.SimpleEntry<>("a", "v1"),
+    new AbstractMap.SimpleEntry<>("a", "v2"),
+    new AbstractMap.SimpleEntry<>("b", "v1")
+  );
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.containsExactlyParameters(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertContainsExactlyParameters(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_containsExactlyParameters_Map_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_containsExactlyParameters_Map_Test.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("UrlAssert containsExactlyParameters")
+class UrlAssert_containsExactlyParameters_Map_Test extends UrlAssertBaseTest {
+
+  private final Map<String, List<String>> expected = Maps.mapOf(
+    MapEntry.entry("a", Lists.list("v1", "v2")),
+    MapEntry.entry("b", Lists.list("v1"))
+  );
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.containsExactlyParameters(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertContainsExactlyParameters(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/urls/Uris_containsExactlyParameters_Entries_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_containsExactlyParameters_Entries_Test.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.internal.UrisBaseTest;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveSameParameters;
+import static org.assertj.core.internal.ErrorMessages.setOfEntriesToLookForIsNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Uris_containsExactlyParameters_Entries_Test extends UrisBaseTest {
+
+  @Test
+  void should_pass_if_parameters_are_same() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_no_value_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_null() throws  URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a&a=v1&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+
+  @Test
+  void should_pass_if_input_is_empty() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList();
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_fail_if_input_is_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1");
+
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() ->
+      uris.assertContainsExactlyParameters(info, URI, (Collection<Map.Entry<String, String>>) null)
+    ).withMessage(setOfEntriesToLookForIsNull());
+  }
+
+  @Test
+  void should_fail_if_parameter_missing_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_parameter_has_value_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_value_missing() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_missing() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param_value() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1, v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+}
+

--- a/src/test/java/org/assertj/core/internal/urls/Uris_containsExactlyParameters_Map_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_containsExactlyParameters_Map_Test.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.internal.UrisBaseTest;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveSameParameters;
+import static org.assertj.core.internal.ErrorMessages.mapOfEntriesToLookForIsNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Uris_containsExactlyParameters_Map_Test extends UrisBaseTest {
+
+  @Test
+  void should_pass_if_parameters_are_same() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_no_value_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a&a=v1&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_list_with_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_fail_if_parameter_has_empty_value_and_expected_is_empty_list() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String)null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?a&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList()),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+
+  }
+
+  @Test
+  void should_pass_if_input_is_empty() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf();
+
+    // WHEN/THEN
+    uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT);
+  }
+
+
+  @Test
+  void should_fail_if_input_is_null() throws URISyntaxException {
+    // GIVEN
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1");
+
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() ->
+      uris.assertContainsExactlyParameters(info, URI, (Map<String, List<String>>) null)
+    ).withMessage(mapOfEntriesToLookForIsNull());
+  }
+
+  @Test
+  void should_fail_if_parameter_missing_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_parameter_has_value_and_expected_is_null() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+
+  @Test
+  void should_fail_if_expected_param_value_missing() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_missing() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URI URI = new URI("http://assertj.org?b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param_value() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param() throws URISyntaxException {
+    // GIVEN
+    final Map<String, List<String>> URI_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URI URI = new URI("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertContainsExactlyParameters(info, URI, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1, v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URI_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+}
+

--- a/src/test/java/org/assertj/core/internal/urls/Urls_containsExactlyParameters_Entries_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_containsExactlyParameters_Entries_Test.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.internal.UrlsBaseTest;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveSameParameters;
+import static org.assertj.core.internal.ErrorMessages.setOfEntriesToLookForIsNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Urls_containsExactlyParameters_Entries_Test extends UrlsBaseTest {
+
+  @Test
+  void should_pass_if_parameters_are_same() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_no_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a&a=v1&b=v1");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+
+  @Test
+  void should_pass_if_input_is_empty() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org");
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList();
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_fail_if_input_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1");
+
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() ->
+      urls.assertContainsExactlyParameters(info, URL, (Collection<Map.Entry<String, String>>) null)
+    ).withMessage(setOfEntriesToLookForIsNull());
+  }
+
+  @Test
+  void should_fail_if_parameter_missing_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_parameter_has_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", null),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_value_missing() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_missing() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?b=v1");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param_value() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2"),
+      new AbstractMap.SimpleEntry<>("b", "v1")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    final Map<String, List<String>> EXPECTED_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+    Collection<Map.Entry<String, String>> EXPECTATION_INPUT = Lists.newArrayList(
+      new AbstractMap.SimpleEntry<>("a", "v1"),
+      new AbstractMap.SimpleEntry<>("a", "v2")
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1, v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTED_PARAMS, MISSING, NOT_EXPECTED).create());
+  }
+
+}
+

--- a/src/test/java/org/assertj/core/internal/urls/Urls_containsExactlyParameters_Map_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_containsExactlyParameters_Map_Test.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import org.assertj.core.data.MapEntry;
+import org.assertj.core.internal.UrlsBaseTest;
+import org.assertj.core.test.Maps;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveSameParameters;
+import static org.assertj.core.internal.ErrorMessages.mapOfEntriesToLookForIsNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Urls_containsExactlyParameters_Map_Test extends UrlsBaseTest {
+
+  @Test
+  void should_pass_if_parameters_are_same() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_no_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a&a=v1&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_pass_if_parameter_has_empty_value_and_expected_is_list_with_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a&b=v1");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+  @Test
+  void should_fail_if_parameter_has_empty_value_and_expected_is_empty_list() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String)null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?a&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList()),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+
+  }
+
+  @Test
+  void should_pass_if_input_is_empty() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org");
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf();
+
+    // WHEN/THEN
+    urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT);
+  }
+
+
+  @Test
+  void should_fail_if_input_is_null() throws MalformedURLException {
+    // GIVEN
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1");
+
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() ->
+      urls.assertContainsExactlyParameters(info, URL, (Map<String, List<String>>) null)
+    ).withMessage(mapOfEntriesToLookForIsNull());
+  }
+
+  @Test
+  void should_fail_if_parameter_missing_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_parameter_has_value_and_expected_is_null() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null)),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList((String) null))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+
+  @Test
+  void should_fail_if_expected_param_value_missing() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_expected_param_missing() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+    URL URL = new URL("http://assertj.org?b=v1");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf();
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param_value() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+  @Test
+  void should_fail_if_contains_unexpected_param() throws MalformedURLException {
+    // GIVEN
+    final Map<String, List<String>> URL_PARAMS = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2")),
+      MapEntry.entry("b", Lists.newArrayList("v1", "v2"))
+    );
+    URL URL = new URL("http://assertj.org?a=v1&a=v2&b=v1&b=v2");
+
+    Map<String, List<String>> EXPECTATION_INPUT = Maps.mapOf(
+      MapEntry.entry("a", Lists.newArrayList("v1", "v2"))
+    );
+
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertContainsExactlyParameters(info, URL, EXPECTATION_INPUT));
+
+    // THEN
+    final Map<String, List<String>> MISSING = Maps.mapOf();
+
+    final Map<String, List<String>> NOT_EXPECTED = Maps.mapOf(
+      MapEntry.entry("b", Lists.newArrayList("v1, v2"))
+    );
+
+    then(assertionError).hasMessage(shouldHaveSameParameters(URL_PARAMS, EXPECTATION_INPUT, MISSING, NOT_EXPECTED).create());
+  }
+
+}
+


### PR DESCRIPTION
Added new assertions for URI and URL for exhaustive parameters check

#### Check List:
* Fixes #2153
* Unit tests : YES
* Javadoc with a code example (on API only) : YES