### PR TITLE
GH-2134 avoid a copy in assertContains when actual is already a Collection

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -84,6 +84,7 @@ import static org.assertj.core.util.Streams.stream;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
@@ -339,10 +340,18 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not contain the given values.
    */
   public void assertContains(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    final List<?> actualAsList = newArrayList(actual);
-    if (commonCheckThatIterableAssertionSucceeds(info, actualAsList, values)) return;
+    final Collection<?> actualAsCollection = ensureActualCanBeReadMultipleTimes(actual);
+    if (commonCheckThatIterableAssertionSucceeds(info, actualAsCollection, values)) return;
     // check for elements in values that are missing in actual.
-    assertIterableContainsGivenValues(actual.getClass(), actualAsList, values, info);
+    assertIterableContainsGivenValues(actual.getClass(), actualAsCollection, values, info);
+  }
+
+  private Collection<?> ensureActualCanBeReadMultipleTimes(Iterable<?> actual) {
+    if (actual instanceof Collection<?>) {
+      return (Collection<?>) actual; // Avoid copy when actual is already a Collection.
+    } else {
+      return newArrayList(actual); //ensure the assertion works for non-repeatable iterables
+    }
   }
 
   private void assertIterableContainsGivenValues(@SuppressWarnings("rawtypes") Class<? extends Iterable> clazz,

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
@@ -120,7 +120,7 @@ class Iterables_assertContains_Test extends IterablesBaseTest {
     AssertionError error = expectAssertionError(() -> iterables.assertContains(info, actualSet, expected));
     // THEN
     then(error).hasMessageContaining("Expecting HashSet:");
-    verify(failures).failure(info, shouldContain(HashSet.class, newArrayList(actualSet), expected, newLinkedHashSet("Han"),
+    verify(failures).failure(info, shouldContain(HashSet.class, actualSet, expected, newLinkedHashSet("Han"),
                                                  StandardComparisonStrategy.instance()));
   }
 


### PR DESCRIPTION
#### Check List:
* Fixes #2134
* Unit tests : NA (optimization)
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
