### PR TITLE
Fix #2217

### DIFF
--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_hasNoNullFieldsOrProperties_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_hasNoNullFieldsOrProperties_Test.java
@@ -102,11 +102,11 @@ class ObjectAssert_hasNoNullFieldsOrProperties_Test extends ObjectAssertBaseTest
     Jedi jedi = new Jedi("Yoda", "Blue");
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedi).hasNoNullFieldsOrPropertiesExcept("father"))
                                                    .withMessage(format("%n"
-                                                                       + "Expecting%n" +
-                                                                       "  org.assertj.core.test.Jedi%n" +
-                                                                       "to have the following declared fields:%n" +
-                                                                       "  [\"father\"]%n" +
-                                                                       "but it doesn't have:%n" +
-                                                                       "  [\"father\"]"));
+                                                                       + "Expecting%n"
+                                                                       + "  org.assertj.core.test.Jedi%n"
+                                                                       + "to have the following declared fields:%n"
+                                                                       + "  [\"father\"]%n"
+                                                                       + "but it doesn't have:%n"
+                                                                       + "  [\"father\"]"));
   }
 }

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_hasNoNullFieldsOrProperties_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_hasNoNullFieldsOrProperties_Test.java
@@ -96,4 +96,17 @@ class ObjectAssert_hasNoNullFieldsOrProperties_Test extends ObjectAssertBaseTest
     Jedi jedi = new Jedi("Yoda", null);
     assertThat(jedi).hasNoNullFieldsOrPropertiesExcept("lightSaberColor", "strangeNotReadablePrivateField");
   }
+
+  @Test
+  public void should_fail_if_a_field_does_not_exist() {
+    Jedi jedi = new Jedi("Yoda", "Blue");
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedi).hasNoNullFieldsOrPropertiesExcept("father"))
+                                                   .withMessage(format("%n"
+                                                                       + "Expecting%n" +
+                                                                       "  org.assertj.core.test.Jedi%n" +
+                                                                       "to have the following declared fields:%n" +
+                                                                       "  [\"father\"]%n" +
+                                                                       "but it doesn't have:%n" +
+                                                                       "  [\"father\"]"));
+  }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2217 
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Implemented what's suggested in #2217. Check for field existence in `assertHasNoNullFieldsOrPropertiesExcept`. A `shouldHaveDeclaredFields` error is thrown if any of the fields does not exist.