### PR TITLE
Add JDK 9 collection factories

### DIFF
--- a/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
+++ b/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
@@ -1,28 +1,15 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
+ * Copyright 2012-2021 the original author or authors.
  */
-
 package org.assertj.core.test.jdk11;
 
 import java.io.IOException;
@@ -50,6 +37,8 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 /**
+ * Copied from {@code java.util.ImmutableCollections}.
+ * 
  * Container class for immutable collections. Not part of the public API.
  * Mainly for namespace management and shared infrastructure.
  *
@@ -121,6 +110,16 @@ class ImmutableCollections {
   }
 
   // ---------- List Implementations ----------
+
+  // make a copy, short-circuiting based on implementation class
+  @SuppressWarnings("unchecked")
+  static <E> List<E> listCopy(Collection<? extends E> coll) {
+    if (coll instanceof AbstractImmutableList && coll.getClass() != SubList.class) {
+      return (List<E>) coll;
+    } else {
+      return (List<E>) Jdk11.List.of(coll.toArray());
+    }
+  }
 
   @SuppressWarnings("unchecked")
   static <E> List<E> emptyList() {
@@ -460,7 +459,7 @@ class ImmutableCollections {
     static List<?> EMPTY_LIST;
 
     static {
-//      VM.initializeFromArchive(ListN.class);
+      // VM.initializeFromArchive(ListN.class);
       if (EMPTY_LIST == null) {
         EMPTY_LIST = new ListN<>();
       }
@@ -623,7 +622,7 @@ class ImmutableCollections {
     static Set<?> EMPTY_SET;
 
     static {
-//      VM.initializeFromArchive(SetN.class);
+      // VM.initializeFromArchive(SetN.class);
       if (EMPTY_SET == null) {
         EMPTY_SET = new SetN<>();
       }
@@ -888,10 +887,8 @@ class ImmutableCollections {
     static Map<?, ?> EMPTY_MAP;
 
     static {
-//      VM.initializeFromArchive(MapN.class);
-      if (EMPTY_MAP == null) {
-        EMPTY_MAP = new MapN<>();
-      }
+      // VM.initializeFromArchive(MapN.class);
+      EMPTY_MAP = new MapN<>();
     }
 
     final Object[] table; // pairs of key, value
@@ -1076,6 +1073,8 @@ class ImmutableCollections {
 // ---------- Serialization Proxy ----------
 
 /**
+ * Copied from {@code java.util.CollSer}.
+ * 
  * A unified serialization proxy class for the immutable collections.
  *
  * @serial
@@ -1150,7 +1149,7 @@ final class CollSer implements Serializable {
       throw new InvalidObjectException("negative length " + len);
     }
 
-//    SharedSecrets.getJavaObjectInputStreamAccess().checkArray(ois, Object[].class, len);
+    // SharedSecrets.getJavaObjectInputStreamAccess().checkArray(ois, Object[].class, len);
     Object[] a = new Object[len];
     for (int i = 0; i < len; i++) {
       a[i] = ois.readObject();

--- a/src/test/java/org/assertj/core/test/jdk11/Jdk11.java
+++ b/src/test/java/org/assertj/core/test/jdk11/Jdk11.java
@@ -1,4 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
 package org.assertj.core.test.jdk11;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashSet;
 
 public final class Jdk11 {
 
@@ -127,7 +143,7 @@ public final class Jdk11 {
      */
     static <E> java.util.Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
       return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
-        e6);
+                                             e6);
     }
 
     /**
@@ -150,7 +166,7 @@ public final class Jdk11 {
      */
     static <E> java.util.Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
       return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
-        e6, e7);
+                                             e6, e7);
     }
 
     /**
@@ -174,7 +190,7 @@ public final class Jdk11 {
      */
     static <E> java.util.Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
       return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8);
+                                             e6, e7, e8);
     }
 
     /**
@@ -199,7 +215,7 @@ public final class Jdk11 {
      */
     static <E> java.util.Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
       return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8, e9);
+                                             e6, e7, e8, e9);
     }
 
     /**
@@ -225,7 +241,7 @@ public final class Jdk11 {
      */
     static <E> java.util.Set<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
       return new ImmutableCollections.SetN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8, e9, e10);
+                                             e6, e7, e8, e9, e10);
     }
 
     /**
@@ -258,14 +274,40 @@ public final class Jdk11 {
     @SuppressWarnings("varargs")
     static <E> java.util.Set<E> of(E... elements) {
       switch (elements.length) { // implicit null check of elements
-        case 0:
-          return ImmutableCollections.emptySet();
-        case 1:
-          return new ImmutableCollections.Set12<>(elements[0]);
-        case 2:
-          return new ImmutableCollections.Set12<>(elements[0], elements[1]);
-        default:
-          return new ImmutableCollections.SetN<>(elements);
+      case 0:
+        return ImmutableCollections.emptySet();
+      case 1:
+        return new ImmutableCollections.Set12<>(elements[0]);
+      case 2:
+        return new ImmutableCollections.Set12<>(elements[0], elements[1]);
+      default:
+        return new ImmutableCollections.SetN<>(elements);
+      }
+    }
+
+    /**
+     * Returns an <a href="#unmodifiable">unmodifiable Set</a> containing the elements
+     * of the given Collection. The given Collection must not be null, and it must not
+     * contain any null elements. If the given Collection contains duplicate elements,
+     * an arbitrary element of the duplicates is preserved. If the given Collection is
+     * subsequently modified, the returned Set will not reflect such modifications.
+     *
+     * @implNote
+     * If the given Collection is an <a href="#unmodifiable">unmodifiable Set</a>,
+     * calling copyOf will generally not create a copy.
+     *
+     * @param <E> the {@code Set}'s element type
+     * @param coll a {@code Collection} from which elements are drawn, must be non-null
+     * @return a {@code Set} containing the elements of the given {@code Collection}
+     * @throws NullPointerException if coll is null, or if it contains any nulls
+     * @since 10
+     */
+    @SuppressWarnings("unchecked")
+    static <E> java.util.Set<E> copyOf(Collection<? extends E> coll) {
+      if (coll instanceof ImmutableCollections.AbstractImmutableSet) {
+        return (java.util.Set<E>) coll;
+      } else {
+        return (java.util.Set<E>) Set.of(new HashSet<>(coll).toArray());
       }
     }
 
@@ -396,7 +438,7 @@ public final class Jdk11 {
      */
     static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6) {
       return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-        e6);
+                                              e6);
     }
 
     /**
@@ -419,7 +461,7 @@ public final class Jdk11 {
      */
     static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7) {
       return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-        e6, e7);
+                                              e6, e7);
     }
 
     /**
@@ -443,7 +485,7 @@ public final class Jdk11 {
      */
     static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8) {
       return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8);
+                                              e6, e7, e8);
     }
 
     /**
@@ -468,7 +510,7 @@ public final class Jdk11 {
      */
     static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9) {
       return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8, e9);
+                                              e6, e7, e8, e9);
     }
 
     /**
@@ -494,7 +536,7 @@ public final class Jdk11 {
      */
     static <E> java.util.List<E> of(E e1, E e2, E e3, E e4, E e5, E e6, E e7, E e8, E e9, E e10) {
       return new ImmutableCollections.ListN<>(e1, e2, e3, e4, e5,
-        e6, e7, e8, e9, e10);
+                                              e6, e7, e8, e9, e10);
     }
 
     /**
@@ -526,15 +568,35 @@ public final class Jdk11 {
     @SuppressWarnings("varargs")
     static <E> java.util.List<E> of(E... elements) {
       switch (elements.length) { // implicit null check of elements
-        case 0:
-          return ImmutableCollections.emptyList();
-        case 1:
-          return new ImmutableCollections.List12<>(elements[0]);
-        case 2:
-          return new ImmutableCollections.List12<>(elements[0], elements[1]);
-        default:
-          return new ImmutableCollections.ListN<>(elements);
+      case 0:
+        return ImmutableCollections.emptyList();
+      case 1:
+        return new ImmutableCollections.List12<>(elements[0]);
+      case 2:
+        return new ImmutableCollections.List12<>(elements[0], elements[1]);
+      default:
+        return new ImmutableCollections.ListN<>(elements);
       }
+    }
+
+    /**
+     * Returns an <a href="#unmodifiable">unmodifiable List</a> containing the elements of
+     * the given Collection, in its iteration order. The given Collection must not be null,
+     * and it must not contain any null elements. If the given Collection is subsequently
+     * modified, the returned List will not reflect such modifications.
+     *
+     * @implNote
+     * If the given Collection is an <a href="#unmodifiable">unmodifiable List</a>,
+     * calling copyOf will generally not create a copy.
+     *
+     * @param <E> the {@code List}'s element type
+     * @param coll a {@code Collection} from which elements are drawn, must be non-null
+     * @return a {@code List} containing the elements of the given {@code Collection}
+     * @throws NullPointerException if coll is null, or if it contains any nulls
+     * @since 10
+     */
+    static <E> java.util.List<E> copyOf(Collection<? extends E> coll) {
+      return ImmutableCollections.listCopy(coll);
     }
 
   }
@@ -691,7 +753,7 @@ public final class Jdk11 {
     static <K, V> java.util.Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                          K k6, V v6) {
       return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
-        k6, v6);
+                                             k6, v6);
     }
 
     /**
@@ -723,7 +785,7 @@ public final class Jdk11 {
     static <K, V> java.util.Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                          K k6, V v6, K k7, V v7) {
       return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
-        k6, v6, k7, v7);
+                                             k6, v6, k7, v7);
     }
 
     /**
@@ -757,7 +819,7 @@ public final class Jdk11 {
     static <K, V> java.util.Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                          K k6, V v6, K k7, V v7, K k8, V v8) {
       return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
-        k6, v6, k7, v7, k8, v8);
+                                             k6, v6, k7, v7, k8, v8);
     }
 
     /**
@@ -793,7 +855,7 @@ public final class Jdk11 {
     static <K, V> java.util.Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                          K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9) {
       return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
-        k6, v6, k7, v7, k8, v8, k9, v9);
+                                             k6, v6, k7, v7, k8, v8, k9, v9);
     }
 
     /**
@@ -831,7 +893,123 @@ public final class Jdk11 {
     static <K, V> java.util.Map<K, V> of(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5,
                                          K k6, V v6, K k7, V v7, K k8, V v8, K k9, V v9, K k10, V v10) {
       return new ImmutableCollections.MapN<>(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5,
-        k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
+                                             k6, v6, k7, v7, k8, v8, k9, v9, k10, v10);
+    }
+
+    /**
+     * Returns an unmodifiable map containing keys and values extracted from the given entries.
+     * The entries themselves are not stored in the map.
+     * See <a href="#unmodifiable">Unmodifiable Maps</a> for details.
+     *
+     * @apiNote
+     * It is convenient to create the map entries using the {@link java.util.Map#entry Map.entry()} method.
+     * For example,
+     *
+     * <pre>{@code
+     *     import static java.util.Map.entry;
+     *
+     *     Map<Integer,String> map = Map.ofEntries(
+     *         entry(1, "a"),
+     *         entry(2, "b"),
+     *         entry(3, "c"),
+     *         ...
+     *         entry(26, "z"));
+     * }</pre>
+     *
+     * @param <K> the {@code Map}'s key type
+     * @param <V> the {@code Map}'s value type
+     * @param entries {@code Map.Entry}s containing the keys and values from which the map is populated
+     * @return a {@code Map} containing the specified mappings
+     * @throws IllegalArgumentException if there are any duplicate keys
+     * @throws NullPointerException if any entry, key, or value is {@code null}, or if
+     *         the {@code entries} array is {@code null}
+     *
+     * @see java.util.Map#entry Map.entry()
+     * @since 9
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static <K, V> java.util.Map<K, V> ofEntries(java.util.Map.Entry<? extends K, ? extends V>... entries) {
+      if (entries.length == 0) { // implicit null check of entries array
+        return ImmutableCollections.emptyMap();
+      } else if (entries.length == 1) {
+        // implicit null check of the array slot
+        return new ImmutableCollections.Map1<>(entries[0].getKey(),
+                                               entries[0].getValue());
+      } else {
+        Object[] kva = new Object[entries.length << 1];
+        int a = 0;
+        for (java.util.Map.Entry<? extends K, ? extends V> entry : entries) {
+          // implicit null checks of each array slot
+          kva[a++] = entry.getKey();
+          kva[a++] = entry.getValue();
+        }
+        return new ImmutableCollections.MapN<>(kva);
+      }
+    }
+
+    /**
+     * Returns an unmodifiable {@link java.util.Map.Entry} containing the given key and value.
+     * These entries are suitable for populating {@code Map} instances using the
+     * {@link java.util.Map#ofEntries Map.ofEntries()} method.
+     * The {@code Entry} instances created by this method have the following characteristics:
+     *
+     * <ul>
+     * <li>They disallow {@code null} keys and values. Attempts to create them using a {@code null}
+     * key or value result in {@code NullPointerException}.
+     * <li>They are unmodifiable. Calls to {@link java.util.Map.Entry#setValue Entry.setValue()}
+     * on a returned {@code Entry} result in {@code UnsupportedOperationException}.
+     * <li>They are not serializable.
+     * <li>They are <a href="../lang/doc-files/ValueBased.html">value-based</a>.
+     * Callers should make no assumptions about the identity of the returned instances.
+     * This method is free to create new instances or reuse existing ones. Therefore,
+     * identity-sensitive operations on these instances (reference equality ({@code ==}),
+     * identity hash code, and synchronization) are unreliable and should be avoided.
+     * </ul>
+     *
+     * @apiNote
+     * For a serializable {@code Entry}, see {@link AbstractMap.SimpleEntry} or
+     * {@link AbstractMap.SimpleImmutableEntry}.
+     *
+     * @param <K> the key's type
+     * @param <V> the value's type
+     * @param k the key
+     * @param v the value
+     * @return an {@code Entry} containing the specified key and value
+     * @throws NullPointerException if the key or value is {@code null}
+     *
+     * @see java.util.Map#ofEntries Map.ofEntries()
+     * @since 9
+     */
+    static <K, V> java.util.Map.Entry<K, V> entry(K k, V v) {
+      // KeyValueHolder checks for nulls
+      return new KeyValueHolder<>(k, v);
+    }
+
+    /**
+     * Returns an <a href="#unmodifiable">unmodifiable Map</a> containing the entries
+     * of the given Map. The given Map must not be null, and it must not contain any
+     * null keys or values. If the given Map is subsequently modified, the returned
+     * Map will not reflect such modifications.
+     *
+     * @implNote
+     * If the given Map is an <a href="#unmodifiable">unmodifiable Map</a>,
+     * calling copyOf will generally not create a copy.
+     *
+     * @param <K> the {@code Map}'s key type
+     * @param <V> the {@code Map}'s value type
+     * @param map a {@code Map} from which entries are drawn, must be non-null
+     * @return a {@code Map} containing the entries of the given {@code Map}
+     * @throws NullPointerException if map is null, or if it contains any null keys or values
+     * @since 10
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    static <K, V> java.util.Map<K, V> copyOf(java.util.Map<? extends K, ? extends V> map) {
+      if (map instanceof ImmutableCollections.AbstractImmutableMap) {
+        return (java.util.Map<K, V>) map;
+      } else {
+        return Map.ofEntries(map.entrySet().toArray(new java.util.Map.Entry[0]));
+      }
     }
 
   }

--- a/src/test/java/org/assertj/core/test/jdk11/KeyValueHolder.java
+++ b/src/test/java/org/assertj/core/test/jdk11/KeyValueHolder.java
@@ -1,34 +1,23 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
+ * Copyright 2012-2021 the original author or authors.
  */
-
 package org.assertj.core.test.jdk11;
 
 import java.util.Map;
 import java.util.Objects;
 
 /**
+ * Copied from {@code java.util.KeyValueHolder}.
+ * 
  * An immutable container for a key and a value, suitable for use
  * in creating and populating {@code Map} instances.
  *
@@ -50,80 +39,80 @@ import java.util.Objects;
  * @see Map#ofEntries Map.ofEntries()
  * @since 9
  */
-final class KeyValueHolder<K,V> implements Map.Entry<K,V> {
-    final K key;
-    final V value;
+final class KeyValueHolder<K, V> implements Map.Entry<K, V> {
+  final K key;
+  final V value;
 
-    KeyValueHolder(K k, V v) {
-        key = Objects.requireNonNull(k);
-        value = Objects.requireNonNull(v);
-    }
+  KeyValueHolder(K k, V v) {
+    key = Objects.requireNonNull(k);
+    value = Objects.requireNonNull(v);
+  }
 
-    /**
-     * Gets the key from this holder.
-     *
-     * @return the key
-     */
-    @Override
-    public K getKey() {
-        return key;
-    }
+  /**
+   * Gets the key from this holder.
+   *
+   * @return the key
+   */
+  @Override
+  public K getKey() {
+    return key;
+  }
 
-    /**
-     * Gets the value from this holder.
-     *
-     * @return the value
-     */
-    @Override
-    public V getValue() {
-        return value;
-    }
+  /**
+   * Gets the value from this holder.
+   *
+   * @return the value
+   */
+  @Override
+  public V getValue() {
+    return value;
+  }
 
-    /**
-     * Throws {@link UnsupportedOperationException}.
-     *
-     * @param value ignored
-     * @return never returns normally
-     */
-    @Override
-    public V setValue(V value) {
-        throw new UnsupportedOperationException("not supported");
-    }
+  /**
+   * Throws {@link UnsupportedOperationException}.
+   *
+   * @param value ignored
+   * @return never returns normally
+   */
+  @Override
+  public V setValue(V value) {
+    throw new UnsupportedOperationException("not supported");
+  }
 
-    /**
-     * Compares the specified object with this entry for equality.
-     * Returns {@code true} if the given object is also a map entry and
-     * the two entries' keys and values are equal. Note that key and
-     * value are non-null, so equals() can be called safely on them.
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof Map.Entry))
-            return false;
-        Map.Entry<?,?> e = (Map.Entry<?,?>)o;
-        return key.equals(e.getKey()) && value.equals(e.getValue());
-    }
+  /**
+   * Compares the specified object with this entry for equality.
+   * Returns {@code true} if the given object is also a map entry and
+   * the two entries' keys and values are equal. Note that key and
+   * value are non-null, so equals() can be called safely on them.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof Map.Entry))
+      return false;
+    Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+    return key.equals(e.getKey()) && value.equals(e.getValue());
+  }
 
-    /**
-     * Returns the hash code value for this map entry. The hash code
-     * is {@code key.hashCode() ^ value.hashCode()}. Note that key and
-     * value are non-null, so hashCode() can be called safely on them.
-     */
-    @Override
-    public int hashCode() {
-        return key.hashCode() ^ value.hashCode();
-    }
+  /**
+   * Returns the hash code value for this map entry. The hash code
+   * is {@code key.hashCode() ^ value.hashCode()}. Note that key and
+   * value are non-null, so hashCode() can be called safely on them.
+   */
+  @Override
+  public int hashCode() {
+    return key.hashCode() ^ value.hashCode();
+  }
 
-    /**
-     * Returns a String representation of this map entry.  This
-     * implementation returns the string representation of this
-     * entry's key followed by the equals character ("{@code =}")
-     * followed by the string representation of this entry's value.
-     *
-     * @return a String representation of this map entry
-     */
-    @Override
-    public String toString() {
-        return key + "=" + value;
-    }
+  /**
+   * Returns a String representation of this map entry.  This
+   * implementation returns the string representation of this
+   * entry's key followed by the equals character ("{@code =}")
+   * followed by the string representation of this entry's value.
+   *
+   * @return a String representation of this map entry
+   */
+  @Override
+  public String toString() {
+    return key + "=" + value;
+  }
 }

--- a/src/test/java/org/assertj/core/test/jdk11/package-info.java
+++ b/src/test/java/org/assertj/core/test/jdk11/package-info.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
 /**
  * Cherry-picked implementations taken from the JDK 11.
  * The {@link org.assertj.core.test.jdk11.Jdk11} class should be used as entry point.


### PR DESCRIPTION
More and more there are cases where we want to test assertions against the collection factories introduced with JDK 9.

This PR backports these factories from the source code of JDK 11, so that they can be used in AssertJ test code.

### Usage

```java
Jdk11.List.of("element1", "element2");
Jdk11.Set.of("element1", "element2");
Jdk11.Map.of("key1", "value1", "key2", "value2");
```