### PR TITLE
Print offending token in error message from containsSubsequence

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldContainSubsequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainSubsequence.java
@@ -28,6 +28,20 @@ public class ShouldContainSubsequence extends BasicErrorMessageFactory {
    * 
    * @param actual the actual value in the failed assertion.
    * @param subsequence the subsequence of values expected to be in {@code actual}.
+   * @param subsequenceIndex the index of the first token in {@code subsequence} that was not found in {@code actual}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainSubsequence(Iterable<?> actual, Object[] subsequence,
+      int subsequenceIndex, ComparisonStrategy comparisonStrategy) {
+    return new ShouldContainSubsequence(actual, subsequence, subsequenceIndex, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldContainSubsequence}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param subsequence the subsequence of values expected to be in {@code actual}.
    * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
    * @return the created {@code ErrorMessageFactory}.
    */
@@ -47,7 +61,26 @@ public class ShouldContainSubsequence extends BasicErrorMessageFactory {
     return new ShouldContainSubsequence(actual, subsequence, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new <code>{@link ShouldContainSubsequence}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param subsequence the subsequence of values expected to be in {@code actual}.
+   * @param subsequenceIndex the index of the first token in {@code subsequence} that was not found in {@code actual}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainSubsequence(Iterable<?> actual, Object[] subsequence,
+      int subsequenceIndex) {
+    return new ShouldContainSubsequence(actual, subsequence, subsequenceIndex, StandardComparisonStrategy.instance());
+  }
+
   private ShouldContainSubsequence(Object actual, Object subsequence, ComparisonStrategy comparisonStrategy) {
     super("%nExpecting actual:%n  %s%nto contain subsequence:%n  %s%n%s", actual, subsequence, comparisonStrategy);
+  }
+
+  private ShouldContainSubsequence(Iterable<?> actual, Object[] subsequence, int subsequenceIndex,
+      ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual to contain the specified subsequence but failed to find subsequence element%n  %s%n(at subsequence index %s) in actual:%n  %s%nThe subsequence was:%n  %s%n%s",
+        subsequence[subsequenceIndex], subsequenceIndex, actual, subsequence, comparisonStrategy);
   }
 }

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -558,7 +558,9 @@ public class Iterables {
       if (areEqual(actualNext, subsequenceNext)) subsequenceIndex++;
     }
 
-    if (subsequenceIndex < subsequence.length) throw actualDoesNotContainSubsequence(info, actual, subsequence);
+    if (subsequenceIndex < subsequence.length) {
+      throw actualDoesNotContainSubsequence(info, actual, subsequence, subsequenceIndex);
+    }
   }
 
   public void assertContainsSubsequence(AssertionInfo info, Iterable<?> actual, List<?> subsequence) {
@@ -649,8 +651,9 @@ public class Iterables {
     return failures.failure(info, shouldNotContainSequence(actual, sequence, index, comparisonStrategy));
   }
 
-  private AssertionError actualDoesNotContainSubsequence(AssertionInfo info, Iterable<?> actual, Object[] subsequence) {
-    return failures.failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
+  private AssertionError actualDoesNotContainSubsequence(AssertionInfo info, Iterable<?> actual, Object[] subsequence,
+                                                         int subsequenceIndex) {
+    return failures.failure(info, shouldContainSubsequence(actual, subsequence, subsequenceIndex, comparisonStrategy));
   }
 
   private AssertionError actualContainsSubsequence(AssertionInfo info, Iterable<?> actual, Object[] subsequence,

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
@@ -25,17 +25,17 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
-import java.util.Collection;
-
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Iterables;
 import org.assertj.core.internal.IterablesBaseTest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+
 /**
- * Tests for <code>{@link Iterables#assertContainsSubsequence(AssertionInfo, Collection, Object[])}</code>.
- * 
+ * Tests for <code>{@link Iterables#assertContainsSubsequence(AssertionInfo, Iterable, Object[])}</code>.
+ *
  * @author Marcin Mikosik
  */
 class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
@@ -80,7 +80,28 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence, 3);
+  }
+
+  @Test
+  void should_fail_if_subsequence_is_bigger_than_actual_real_message() {
+    AssertionInfo info = someInfo();
+    Object[] subsequence = { "Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin" };
+
+    String message = Assertions.assertThrows(AssertionError.class,
+        () -> iterables.assertContainsSubsequence(info, actual, subsequence))
+      .getMessage();
+
+    Assertions.assertArrayEquals(new String[]{
+      "",
+      "Expecting actual to contain the specified subsequence but failed to find subsequence element",
+      "  \"Han\"",
+      "(at subsequence index 3) in actual:",
+      "  [\"Yoda\", \"Luke\", \"Leia\", \"Obi-Wan\"]",
+      "The subsequence was:",
+      "  [\"Luke\", \"Leia\", \"Obi-Wan\", \"Han\", \"C-3PO\", \"R2-D2\", \"Anakin\"]",
+      ""
+    }, message.split("\\R", -1));
   }
 
   @Test
@@ -91,7 +112,7 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence, 0);
   }
 
   @Test
@@ -102,11 +123,11 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterables.assertContainsSubsequence(info, actual, subsequence));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence);
+    verifyFailureThrownWhenSubsequenceNotFound(info, subsequence, 2);
   }
 
-  private void verifyFailureThrownWhenSubsequenceNotFound(AssertionInfo info, Object[] subsequence) {
-    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence));
+  private void verifyFailureThrownWhenSubsequenceNotFound(AssertionInfo info, Object[] subsequence, int subsequenceIndex) {
+    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, subsequenceIndex));
   }
 
   @Test
@@ -150,7 +171,7 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
+    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, 0, comparisonStrategy));
   }
 
   @Test
@@ -161,7 +182,7 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(info, actual, subsequence));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, comparisonStrategy));
+    verify(failures).failure(info, shouldContainSubsequence(actual, subsequence, 2, comparisonStrategy));
   }
 
   @Test


### PR DESCRIPTION
Fix #2395

Added two lines to the error message from `containsSubsequence`.

Only in `Iterables.containsSubsequence`.

`Arrays.containsSubsequence` is working with `Object` and that would be more work.

New error message looks like this:

```
Failed to find token at subsequence index 3 in actual:
 "Han"
Expecting actual:
  ["Yoda", "Luke", "Leia", "Obi-Wan"]
to contain subsequence:
  ["Luke", "Leia", "Obi-Wan", "Han", "C-3PO", "R2-D2", "Anakin"]
```