### PR TITLE
[soft] Meta-annotate using @ExtendWith

### DIFF
--- a/src/main/java/org/assertj/core/api/junit/jupiter/InjectSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/InjectSoftAssertions.java
@@ -21,13 +21,15 @@ import java.lang.annotation.Target;
 import org.assertj.core.api.BDDSoftAssertions;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.SoftAssertionsProvider;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Annotation used with {@link SoftAssertionsExtension} for specify wich test instance fields should be initialised with
+ * Annotation used with {@link SoftAssertionsExtension} for specify which test instance fields should be initialised with
  * a {@link SoftAssertionsProvider} concrete implementation, for example {@link SoftAssertions}, {@link BDDSoftAssertions} or any
  * custom soft assertions class.
  */
 @Retention(RUNTIME)
 @Target(FIELD)
+@ExtendWith(SoftAssertionsExtension.class)
 public @interface InjectSoftAssertions {
 }

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_ImplicitInjection_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_ImplicitInjection_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.engine.JupiterTestEngine;
+
+// A copy of SoftAssertionsExtension_Injection_Test, but without
+// @ExtendWith annotation to check that the meta-annotation on 
+// @InjectSoftAssertions is working.
+//@ExtendWith(SoftAssertionsExtension.class)
+@DisplayName("SoftAssertionsExtension implicit injection test")
+class SoftAssertionsExtension_ImplicitInjection_Test {
+
+  // use a mix of private and package-private here to test behaviour in the variety of different circumstances.
+  @InjectSoftAssertions
+  SoftAssertions softly;
+
+  @InjectSoftAssertions
+  private BDDSoftAssertions deftly;
+
+  SoftAssertions unannotated;
+
+  @Test
+  void should_pass_if_not_null() {
+    assertThat(softly).isNotNull();
+  }
+
+  @Test
+  void bdd_should_pass_if_not_null() {
+    assertThat(deftly).isNotNull();
+    assertThat(deftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+
+  @Test
+  void should_have_same_collector_as_parameter(CustomSoftAssertions custom) {
+    assertThat(custom.getDelegate().get()).isSameAs(softly.getDelegate().get());
+  }
+
+  @Test
+  void should_not_inject_into_unannotated_field() {
+    assertThat(unannotated).isNull();
+  }
+
+  @Nested
+  @ExtendWith(SoftAssertionsExtension.class)
+  @DisplayName("nested test class without SoftAssertions field")
+  class NestedMethodLifecycle {
+
+    @Test
+    void should_use_parent_SoftAssertions_initialized_field() {
+      assertThat(softly).isNotNull();
+    }
+  }
+
+  @Nested
+  @ExtendWith(SoftAssertionsExtension.class)
+  @DisplayName("nested test class with SoftAssertions field")
+  class SoftlyNestedMethodLifecycle {
+
+    @InjectSoftAssertions
+    SoftAssertions nestedSoftly;
+
+    @Test
+    void should_use_own_SoftAssertions_initialized_field() {
+      assertThat(nestedSoftly).isNotNull();
+      assertThat(nestedSoftly.getDelegate().get()).isSameAs(softly.getDelegate().get());
+    }
+
+  }
+}

--- a/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
+++ b/src/test/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
@@ -117,17 +117,21 @@ public class SoftAssertionsExtension_PER_CLASS_Concurrency_Test {
       if (softly.wasSuccess()) {
         List<AssertionError> collected = collector.assertionErrorsCollected();
         softly.assertThat(collected).as("size").hasSize(3);
-        softly.assertThat(collected.get(0)).as("zero").hasMessageContainingAll("1", "0");
-        softly.assertThat(collected.get(1)).as("one").hasMessageContainingAll("3", "4");
-        softly.assertThat(collected.get(2)).as("two").hasMessageContainingAll("5", "6");
+        if (softly.wasSuccess()) {
+          softly.assertThat(collected.get(0)).as("zero").hasMessageContainingAll("1", "0");
+          softly.assertThat(collected.get(1)).as("one").hasMessageContainingAll("3", "4");
+          softly.assertThat(collected.get(2)).as("two").hasMessageContainingAll("5", "6");
+        }
       }
       collector = ConcurrencyTest.map.get("test2");
       softly.assertThat(collector).as("test2").isNotNull();
       if (softly.wasSuccess()) {
         List<AssertionError> collected = collector.assertionErrorsCollected();
         softly.assertThat(collected).as("size2").hasSize(2);
-        softly.assertThat(collected.get(0)).as("zero2").hasMessageContainingAll("2", "1");
-        softly.assertThat(collected.get(1)).as("one2").hasMessageContainingAll("4", "5");
+        if (softly.wasSuccess()) {
+          softly.assertThat(collected.get(0)).as("zero2").hasMessageContainingAll("2", "1");
+          softly.assertThat(collected.get(1)).as("one2").hasMessageContainingAll("4", "5");
+        }
       }
     }
   }


### PR DESCRIPTION
From Jupiter 5.8 and on, this allows Jupiter soft assertion tests to automatically register the `SoftAssertionsExtension` simply by use of the `@InjectSoftAssertions` field.

At least, that's the theory. The unit test I put in place to test it doesn't seem to be working. Hailing @bjhargrave (who added this feature to [osgi-test](https://github.com/osgi/osgi-test)) to see if he can shed any light on this issue.