### PR TITLE
Add AbstractThrowableAssert#causesChain to simplify performing assertions on a chain of throwables

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -204,6 +204,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Returns a new list assertion of every cause in the chain of causes.
+   * The list is ordered from the current {@link Throwable} up to the root cause.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Throwable rootCause = new JdbcException("invalid query");
+   * Throwable cause =  new RuntimeException("some failure", rootCause);
+   * Throwable throwable = new Exception("boom!", cause);
+   *
+   * // typical use:
+   * assertThat(throwable).asCausesChain()
+   *                      .extracting(Throwable::getMessage)
+   *                      .anyMatch("some failure");</code></pre>
+   *
+   * @return a new assertion object
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the actual {@code Throwable} does not have a cause.
+   *
+   * @since 3.16.0
+   */
+  public ListAssert<Throwable> asCausesChain() {
+    throwables.assertHasCause(info, actual);
+    return AssertionsForInterfaceTypes.assertThat(org.assertj.core.util.Throwables.getCausesChain(actual));
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} starts with the given description.
    * <p>
    * Examples:

--- a/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -15,7 +15,9 @@ package org.assertj.core.api;
 import static java.lang.String.format;
 import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 
+import java.util.ArrayList;
 import java.util.IllegalFormatException;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
@@ -204,8 +206,8 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
-   * Returns a new list assertion of every cause in the chain of causes.
-   * The list is ordered from the current {@link Throwable} up to the root cause.
+   * Returns a new list assertion of every cause from the current {@link Throwable} down to the root cause.
+   * The list is empty if there is no cause.
    * <p>
    * Examples:
    * <pre><code class='java'> Throwable rootCause = new JdbcException("invalid query");
@@ -213,19 +215,31 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    * Throwable throwable = new Exception("boom!", cause);
    *
    * // typical use:
-   * assertThat(throwable).asCausesChain()
+   * assertThat(throwable).causesChain()
    *                      .extracting(Throwable::getMessage)
    *                      .anyMatch("some failure");</code></pre>
    *
    * @return a new assertion object
    * @throws AssertionError if the actual {@code Throwable} is {@code null}.
-   * @throws AssertionError if the actual {@code Throwable} does not have a cause.
    *
    * @since 3.16.0
    */
-  public ListAssert<Throwable> asCausesChain() {
-    throwables.assertHasCause(info, actual);
-    return AssertionsForInterfaceTypes.assertThat(org.assertj.core.util.Throwables.getCausesChain(actual));
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public AbstractListAssert<?, List<Throwable>, Throwable, ? extends AbstractThrowableAssert<?, Throwable>> causesChain() {
+    isNotNull();
+    return (AbstractListAssert) AssertionsForInterfaceTypes.assertThat(getCausesChain(actual));
+  }
+
+  /**
+   * Get the causes chain of a {@link Throwable}.
+   */
+  private static List<Throwable> getCausesChain(Throwable throwable) {
+    List<Throwable> throwables = new ArrayList<>();
+    while (throwable != null) {
+      throwables.add(throwable);
+      throwable = throwable.getCause();
+    }
+    return throwables;
   }
 
   /**

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -151,21 +151,6 @@ public final class Throwables {
   }
 
   /**
-   * Get the causes chain of a {@link Throwable}.
-   *
-   * @param throwable the {@code Throwable} to get causes chain from.
-   * @return the causes chain, including the {@link Throwable} provided as parameter.
-   */
-  public static List<Throwable> getCausesChain(Throwable throwable) {
-    List<Throwable> throwables = new ArrayList<>();
-    while (throwable != null) {
-      throwables.add(throwable);
-      throwable = throwable.getCause();
-    }
-    return throwables;
-  }
-
-  /**
    * Get the stack trace from a {@link Throwable} as a {@link String}.
    *
    * <p>

--- a/src/main/java/org/assertj/core/util/Throwables.java
+++ b/src/main/java/org/assertj/core/util/Throwables.java
@@ -21,8 +21,10 @@ import static org.assertj.core.util.Lists.newArrayList;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Utility methods related to <code>{@link Throwable}</code>s.
@@ -146,6 +148,21 @@ public final class Throwables {
     while ((cause = throwable.getCause()) != null)
       throwable = cause;
     return throwable;
+  }
+
+  /**
+   * Get the causes chain of a {@link Throwable}.
+   *
+   * @param throwable the {@code Throwable} to get causes chain from.
+   * @return the causes chain, including the {@link Throwable} provided as parameter.
+   */
+  public static List<Throwable> getCausesChain(Throwable throwable) {
+    List<Throwable> throwables = new ArrayList<>();
+    while (throwable != null) {
+      throwables.add(throwable);
+      throwable = throwable.getCause();
+    }
+    return throwables;
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_asCausesChain_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_asCausesChain_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api.throwable;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -29,7 +30,7 @@ class ThrowableAssert_asCausesChain_Test {
     // GIVEN
     Throwable throwable = new Throwable("initial", intermediateCause);
     // WHEN/THEN
-    assertThat(throwable).asCausesChain()
+    assertThat(throwable).causesChain()
                          .containsExactly(throwable, intermediateCause, rootCause);
   }
 
@@ -38,9 +39,9 @@ class ThrowableAssert_asCausesChain_Test {
     // GIVEN
     Throwable actual = new Throwable();
     // WHEN
-    AssertionError error = expectAssertionError(() -> assertThat(actual).asCausesChain());
+    AssertionError error = expectAssertionError(() -> assertThat(actual).causesChain());
     // THEN
-    assertThat(error).hasMessage(shouldHaveCause(actual).create());
+    then(error).hasMessage(shouldHaveCause(actual).create());
   }
 
   @Test
@@ -48,9 +49,9 @@ class ThrowableAssert_asCausesChain_Test {
     // GIVEN
     Throwable actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> assertThat(actual).asCausesChain());
+    AssertionError error = expectAssertionError(() -> assertThat(actual).causesChain());
     // THEN
-    assertThat(error).hasMessage(actualIsNull());
+    then(error).hasMessage(actualIsNull());
   }
 
 }

--- a/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_asCausesChain_Test.java
+++ b/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_asCausesChain_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.junit.jupiter.api.Test;
+
+class ThrowableAssert_asCausesChain_Test {
+
+  private final Throwable rootCause = new NullPointerException("root");
+  private final Throwable intermediateCause = new IllegalStateException("intermediate", rootCause);
+
+  @Test
+  void should_return_throwable_chain_assertion() {
+    // GIVEN
+    Throwable throwable = new Throwable("initial", intermediateCause);
+    // WHEN/THEN
+    assertThat(throwable).asCausesChain()
+                         .containsExactly(throwable, intermediateCause, rootCause);
+  }
+
+  @Test
+  void should_fail_if_actual_has_no_cause() {
+    // GIVEN
+    Throwable actual = new Throwable();
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThat(actual).asCausesChain());
+    // THEN
+    assertThat(error).hasMessage(shouldHaveCause(actual).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Throwable actual = null;
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThat(actual).asCausesChain());
+    // THEN
+    assertThat(error).hasMessage(actualIsNull());
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #1147 (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
