### PR TITLE
Add `assertThatCode(Callable)`

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -92,7 +92,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   @VisibleForTesting
   static boolean printAssertionsDescription;
 
-  private static Consumer<Description> descriptionConsumer;
+  static Consumer<Description> descriptionConsumer;
 
   // we prefer not to use Class<? extends S> selfType because it would force inherited
   // constructor to cast with a compiler warning
@@ -1036,14 +1036,14 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   SELF withAssertionState(@SuppressWarnings("rawtypes") AbstractAssert assertInstance) {
     this.objects = assertInstance.objects;
-    propagateAssertionInfoFrom(assertInstance);
+    propagateAssertionInfoFrom(assertInstance.info);
     return myself;
   }
 
-  private void propagateAssertionInfoFrom(AbstractAssert<?, ?> assertInstance) {
-    this.info.useRepresentation(assertInstance.info.representation());
-    this.info.description(assertInstance.info.description());
-    this.info.overridingErrorMessage(assertInstance.info.overridingErrorMessage());
+  void propagateAssertionInfoFrom(WritableAssertionInfo source) {
+    this.info.useRepresentation(source.representation());
+    this.info.description(source.description());
+    this.info.overridingErrorMessage(source.overridingErrorMessage());
   }
 
   // this method is meant to be overridden and made public in subclasses that want to expose it

--- a/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
@@ -1,49 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 
 import java.util.concurrent.Callable;
 
-import org.assertj.core.internal.Failures;
+import org.assertj.core.util.CheckReturnValue;
 
 public abstract class AbstractCallableAssert<SELF extends AbstractCallableAssert<SELF, V>, V>
-    extends AbstractAssert<SELF, Callable<V>> {
+    extends AbstractThrowingExecutableAssert<SELF, Callable<V>> {
 
-  private V result;
-  private Throwable thrown;
+  protected V result;
 
   protected AbstractCallableAssert(Callable<V> actual, Class<?> selfType) {
     super(actual, selfType);
-
-    try {
-      result = actual.call();
-    } catch (Throwable e) {
-      thrown = e;
-    }
   }
 
-  public SELF doesNotThrowAnyException() {
-    if (thrown != null) throw Failures.instance().failure(info, shouldNotHaveThrown(thrown));
-    return myself;
+  @Override
+  protected void execute(Callable<V> actual) throws Exception {
+    result = actual.call();
   }
 
+  @CheckReturnValue
   public AbstractObjectAssert<?, V> result() {
     return internalResult();
   }
 
+  @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT result(InstanceOfAssertFactory<?, ASSERT> assertFactory) {
     return internalResult().asInstanceOf(assertFactory);
   }
 
   private AbstractObjectAssert<?, V> internalResult() {
-    doesNotThrowAnyException(); // FIXME enough? better error message?
-    return assertThat(result).withAssertionState(myself);
-  }
-
-  public ThrowableAssertAlternative<Throwable> hasThrownException() {
-    if (thrown == null) throw Failures.instance().expectedThrowableNotThrown(Throwable.class);
-    return new ThrowableAssertAlternative<>(thrown).withAssertionState(myself);
+    doesNotThrowAnyException();
+    ObjectAssert<V> objectAssert = assertThat(result);
+    objectAssert.propagateAssertionInfoFrom(info);
+    return objectAssert;
   }
 
 }

--- a/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
@@ -1,0 +1,49 @@
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+
+import java.util.concurrent.Callable;
+
+import org.assertj.core.internal.Failures;
+
+public abstract class AbstractCallableAssert<SELF extends AbstractCallableAssert<SELF, V>, V>
+    extends AbstractAssert<SELF, Callable<V>> {
+
+  private V result;
+  private Throwable thrown;
+
+  protected AbstractCallableAssert(Callable<V> actual, Class<?> selfType) {
+    super(actual, selfType);
+
+    try {
+      result = actual.call();
+    } catch (Throwable e) {
+      thrown = e;
+    }
+  }
+
+  public SELF doesNotThrowAnyException() {
+    if (thrown != null) throw Failures.instance().failure(info, shouldNotHaveThrown(thrown));
+    return myself;
+  }
+
+  public AbstractObjectAssert<?, V> result() {
+    return internalResult();
+  }
+
+  public <ASSERT extends AbstractAssert<?, ?>> ASSERT result(InstanceOfAssertFactory<?, ASSERT> assertFactory) {
+    return internalResult().asInstanceOf(assertFactory);
+  }
+
+  private AbstractObjectAssert<?, V> internalResult() {
+    doesNotThrowAnyException(); // FIXME enough? better error message?
+    return assertThat(result).withAssertionState(myself);
+  }
+
+  public ThrowableAssertAlternative<Throwable> hasThrownException() {
+    if (thrown == null) throw Failures.instance().expectedThrowableNotThrown(Throwable.class);
+    return new ThrowableAssertAlternative<>(thrown).withAssertionState(myself);
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCallableAssert.java
@@ -32,11 +32,19 @@ public abstract class AbstractCallableAssert<SELF extends AbstractCallableAssert
     result = actual.call();
   }
 
+  /**
+   * @return
+   */
   @CheckReturnValue
   public AbstractObjectAssert<?, V> result() {
     return internalResult();
   }
 
+  /**
+   * @param assertFactory
+   * @param <ASSERT>
+   * @return
+   */
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT result(InstanceOfAssertFactory<?, ASSERT> assertFactory) {
     return internalResult().asInstanceOf(assertFactory);

--- a/src/main/java/org/assertj/core/api/AbstractThrowingExecutableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowingExecutableAssert.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.AbstractAssert.customRepresentation;
+import static org.assertj.core.api.AbstractAssert.descriptionConsumer;
+import static org.assertj.core.api.AbstractAssert.printAssertionsDescription;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.util.CheckReturnValue;
+
+public abstract class AbstractThrowingExecutableAssert<SELF extends AbstractThrowingExecutableAssert<SELF, ACTUAL>, ACTUAL>
+    implements ThrowingExecutableAssert<SELF, ACTUAL> {
+
+  protected final SELF myself;
+
+  protected WritableAssertionInfo info;
+  private Throwable thrown;
+
+  @SuppressWarnings("unchecked")
+  protected AbstractThrowingExecutableAssert(ACTUAL actual, Class<?> selfType) {
+    this.myself = (SELF) selfType.cast(this);
+    this.info = new WritableAssertionInfo(customRepresentation);
+
+    try {
+      execute(actual);
+    } catch (Throwable e) {
+      this.thrown = e;
+    }
+  }
+
+  protected abstract void execute(ACTUAL actual) throws Throwable;
+
+  @Override
+  @CheckReturnValue
+  public SELF describedAs(Description description) {
+    info.description(description);
+    if (printAssertionsDescription) printDescriptionText();
+    if (descriptionConsumer != null) descriptionConsumer.accept(description);
+    return myself;
+  }
+
+  private void printDescriptionText() {
+    String descriptionText = info.descriptionText();
+    if (!descriptionText.isEmpty()) System.out.println(descriptionText);
+  }
+
+  public SELF doesNotThrowAnyException() {
+    if (thrown != null) throw Failures.instance().failure(info, shouldNotHaveThrown(thrown));
+    return myself;
+  }
+
+  public ThrowableAssertAlternative<Throwable> hasThrownException() {
+    if (thrown == null) throw Failures.instance().expectedThrowableNotThrown(Throwable.class);
+    ThrowableAssertAlternative<Throwable> newAssert = new ThrowableAssertAlternative<>(thrown);
+    newAssert.propagateAssertionInfoFrom(info);
+    return newAssert;
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/AbstractThrowingExecutableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractThrowingExecutableAssert.java
@@ -17,10 +17,22 @@ import static org.assertj.core.api.AbstractAssert.descriptionConsumer;
 import static org.assertj.core.api.AbstractAssert.printAssertionsDescription;
 import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
 
+import java.util.concurrent.Callable;
+
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.util.CheckReturnValue;
 
+/**
+ * Base class for all assertion types of executable instances, like {@link Runnable} or {@link Callable}.
+ *
+ * @param <SELF>   the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
+ *                 target="_blank">Emulating
+ *                 'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
+ * @param <ACTUAL> the type of the "actual" executable.
+ *
+ * @since 3.23.0
+ */
 public abstract class AbstractThrowingExecutableAssert<SELF extends AbstractThrowingExecutableAssert<SELF, ACTUAL>, ACTUAL>
     implements ThrowingExecutableAssert<SELF, ACTUAL> {
 
@@ -57,11 +69,15 @@ public abstract class AbstractThrowingExecutableAssert<SELF extends AbstractThro
     if (!descriptionText.isEmpty()) System.out.println(descriptionText);
   }
 
+  /** {@inheritDoc} */
+  @Override
   public SELF doesNotThrowAnyException() {
     if (thrown != null) throw Failures.instance().failure(info, shouldNotHaveThrown(thrown));
     return myself;
   }
 
+  /** {@inheritDoc} */
+  @Override
   public ThrowableAssertAlternative<Throwable> hasThrownException() {
     if (thrown == null) throw Failures.instance().expectedThrowableNotThrown(Throwable.class);
     ThrowableAssertAlternative<Throwable> newAssert = new ThrowableAssertAlternative<>(thrown);

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -46,6 +46,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Spliterator;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -1284,6 +1285,10 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return AssertionsForClassTypes.assertThatCode(shouldRaiseOrNotThrowable);
+  }
+
+  public static <V> AbstractCallableAssert<?, V> assertThatCode(Callable<V> callable) {
+    return new CallableAssert<>(callable);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/CallableAssert.java
+++ b/src/main/java/org/assertj/core/api/CallableAssert.java
@@ -1,0 +1,11 @@
+package org.assertj.core.api;
+
+import java.util.concurrent.Callable;
+
+public class CallableAssert<V> extends AbstractCallableAssert<CallableAssert<V>, V> {
+
+  public CallableAssert(Callable<V> actual) {
+    super(actual, CallableAssert.class);
+  }
+
+}

--- a/src/main/java/org/assertj/core/api/ThrowingExecutableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowingExecutableAssert.java
@@ -12,12 +12,11 @@
  */
 package org.assertj.core.api;
 
-import java.util.concurrent.Callable;
+public interface ThrowingExecutableAssert<SELF extends ThrowingExecutableAssert<SELF, ACTUAL>, ACTUAL>
+    extends Descriptable<SELF> {
 
-public class CallableAssert<V> extends AbstractCallableAssert<CallableAssert<V>, V> {
+  SELF doesNotThrowAnyException();
 
-  public CallableAssert(Callable<V> actual) {
-    super(actual, CallableAssert.class);
-  }
+  ThrowableAssertAlternative<Throwable> hasThrownException();
 
 }

--- a/src/main/java/org/assertj/core/api/ThrowingExecutableAssert.java
+++ b/src/main/java/org/assertj/core/api/ThrowingExecutableAssert.java
@@ -12,11 +12,43 @@
  */
 package org.assertj.core.api;
 
+import java.util.concurrent.Callable;
+
+/**
+ * Base contract for all assertion types of executable instances, like {@link Runnable} or {@link Callable}.
+ *
+ * @param <SELF>   the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
+ *                 target="_blank">Emulating
+ *                 'self types' using Java Generics to simplify fluent API implementation</a>&quot; for more details.
+ * @param <ACTUAL> the type of the "actual" executable.
+ *
+ * @since 3.23.0
+ */
 public interface ThrowingExecutableAssert<SELF extends ThrowingExecutableAssert<SELF, ACTUAL>, ACTUAL>
     extends Descriptable<SELF> {
 
+  /**
+   * Verifies that the executable did not raise a throwable.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThatCode(() -&gt; foo.bar()).doesNotThrowAnyException();</code></pre>
+   *
+   * @throws AssertionError if the actual executable raised a {@code Throwable}.
+   * @return {@code this} assertion object.
+   */
   SELF doesNotThrowAnyException();
 
+  /**
+   * Verifies that the executable raised a throwable and returns a {@link ThrowableAssertAlternative} instance for
+   * chaining further assertions on the raised throwable.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThatCode(() -&gt; foo.bar()).hasThrownException()
+   *                            .withNoCause();</code></pre>
+   *
+   * @throws AssertionError if the actual executable did not raise a {@code Throwable}.
+   * @return a new {@code ThrowableAssertAlternative} for chaining further assertions on the raised {@code Throwable}.
+   */
   ThrowableAssertAlternative<Throwable> hasThrownException();
 
 }

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_BDDAssumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_BDDAssumptions_Test.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 
 class Assertions_sync_with_BDDAssumptions_Test extends BaseAssertionsTest {
@@ -40,7 +41,8 @@ class Assertions_sync_with_BDDAssumptions_Test extends BaseAssertionsTest {
 
   @Test
   void code_assertions_and_bdd_assumptions_should_have_the_same_assertions_methods() {
-    Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThatCode", SPECIAL_IGNORED_RETURN_TYPES);
+    Class<?>[] ignoredReturnTypes = ArrayUtils.addAll(SPECIAL_IGNORED_RETURN_TYPES, AbstractCallableAssert.class); // FIXME gh-xxxx
+    Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThatCode", ignoredReturnTypes);
     Method[] givenMethods = findMethodsWithName(BDDAssumptions.class, "givenCode");
 
     assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME)

--- a/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
+++ b/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.Test;
 
-class CallableAssert_Demo_Test {
+class CallableAssert_Demo_Test { // FIXME to be deleted
 
   @Test
   void demo() {

--- a/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
+++ b/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
@@ -1,0 +1,70 @@
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
+
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.Test;
+
+class CallableAssert_Demo_Test {
+
+  @Test
+  void demo() {
+    Callable<Boolean> callable = () -> "value".isEmpty();
+
+    // AbstractCallableAssert
+    assertThatCode(callable).doesNotThrowAnyException()
+                            .result() // returns AbstractObjectAssert
+                            .isEqualTo(false);
+
+    // AbstractCallableAssert
+    assertThatCode(callable).result(BOOLEAN) // implicit doesNotThrowAnyException()
+                            .isFalse();
+
+    // AbstractCallableAssert
+    assertThatCode(() -> "value".isEmpty()).doesNotThrowAnyException()
+                                           .result()
+                                           .isEqualTo(false);
+
+    // AbstractCallableAssert
+    assertThatCode(() -> nonVoidThrowingMethod()).hasThrownException() // returns ThrowableAssertAlternative
+                                                 .withMessage("Boom!")
+                                                 .withNoCause();
+
+    ThrowableAssert.ThrowingCallable assertjThrowingCallable = () -> "value".isEmpty();
+
+    // AbstractThrowableAssert
+    assertThatCode(assertjThrowingCallable).doesNotThrowAnyException();
+
+    // AbstractThrowableAssert
+    assertThatCode(() -> System.out.println("")).doesNotThrowAnyException();
+
+    // AbstractThrowableAssert
+    assertThatCode(() -> voidThrowingMethod()).hasMessage("Boom!");
+  }
+
+  private static Object nonVoidThrowingMethod() {
+    throw new RuntimeException("Boom!");
+  }
+
+  private static void voidThrowingMethod() {
+    throw new RuntimeException("Boom!");
+  }
+
+  @Test
+  public void intendedApi() {
+    assertThatCode(this::doStuff).describedAs("doing things")
+                                 .doesNotThrowAnyException()
+                                 .result() // implicit doesNotThrowAnyException()
+                                 .isEqualTo(3);
+  }
+
+  private int doStuff() throws Exception {
+//    if (new Random().nextBoolean()) {
+//      throw new Exception();
+//    }
+    return 3;
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
+++ b/src/test/java/org/assertj/core/api/CallableAssert_Demo_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
+++ b/src/test/java/org/assertj/core/api/ThrowableAssertAlternative_havingCause_Test.java
@@ -17,10 +17,8 @@ import static org.assertj.core.error.ShouldHaveCause.shouldHaveCause;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("ThrowableAssertAlternative havingCause")
 class ThrowableAssertAlternative_havingCause_Test {
 
   @Test


### PR DESCRIPTION
Usage examples in [`CallableAssert_Demo_Test`](https://github.com/assertj/assertj-core/blob/callable-assert/src%2Ftest%2Fjava%2Forg%2Fassertj%2Fcore%2Fapi%2FCallableAssert_Demo_Test.java).

This introduces a breaking change for all the `assertThatCode()` assertions with a `Callable` that don't call `doesNotThrowAnyException()` but any other method from `AbstractThrowableAssert`.

#### Check List:
* Fixes #1652
* Unit tests : not yet
* Javadoc with a code example (on API only) : not yet