### PR TITLE
Add `asBoolean|Byte|Short|Int|Long|Float|Double` to `String` assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -14,16 +14,22 @@ package org.assertj.core.api;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
 
 import java.util.Base64;
 import java.util.Comparator;
 
+import org.assertj.core.error.ShouldBeNumeric;
 import org.assertj.core.internal.Comparables;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.Failures;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> extends AbstractCharSequenceAssert<SELF, String> {
+
+  @VisibleForTesting
+  Failures failures = Failures.instance();
 
   protected AbstractStringAssert(String actual, Class<?> selfType) {
     super(actual, selfType);
@@ -401,5 +407,197 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
    */
   public SELF isEqualTo(String expected) {
     return super.isEqualTo(expected);
+  }
+
+  /**
+   * Parses the actual value as boolean, the parsed boolean becoming the new value under test.
+   * <p>
+   * Note that only when the string is equal to the string "true", ignoring case, and can have leading and trailing space, the parsed value will be {@code true}.
+   * Otherwise, the value will be {@code false}.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * assertThat(&quot;truE&quot;).asBoolean().isTrue();
+   * assertThat(&quot;false&quot;).asBoolean().isFalse();
+   * assertThat(&quot;foo bar&quot;).asBoolean().isFalse();
+   * assertThat((String) null).asBoolean().isFalse();
+   * </code></pre>
+   *
+   * @return a new {@link BooleanAssert} instance whose value under test is the result of the parse.
+   *
+   * @since 3.25.0
+   */
+  public AbstractBooleanAssert<?> asBoolean() {
+    return InstanceOfAssertFactories.BOOLEAN
+      .createAssert(Boolean.parseBoolean(actual))
+      .withAssertionState(myself);
+  }
+
+  /**
+   * Parses the actual value as byte, using radix 10, the parsed byte becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;127&quot;).asByte().isEqualTo((byte) 127);
+   *
+   * // assertion fails as the actual value is null or not a valid byte
+   * assertThat((String) null).asByte();
+   * assertThat(&quot;1L&quot;).asByte();
+   * </code></pre>
+   *
+   * @return a new {@link ByteAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a valid byte.
+   *
+   * @since 3.25.0
+   */
+  public AbstractByteAssert<?> asByte() {
+    try {
+      return InstanceOfAssertFactories.BYTE
+        .createAssert(Byte.parseByte(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.BYTE));
+    }
+  }
+
+  /**
+   * Parses the actual value as short, using radix 10, the parsed short becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;32767&quot;).asShort().isEqualTo((short) 32767);
+   *
+   * // assertion fails as the actual value is null or not a valid short
+   * assertThat((String) null).asShort();
+   * assertThat(&quot;-32769&quot;).asShort();
+   * </code></pre>
+   *
+   * @return a new {@link ShortAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a valid short.
+   *
+   * @since 3.25.0
+   */
+  public AbstractShortAssert<?> asShort() {
+    try {
+      return InstanceOfAssertFactories.SHORT
+        .createAssert(Short.parseShort(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.SHORT));
+    }
+  }
+
+  /**
+   * Parses the actual value as integer, using radix 10, the parsed integer becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;2147483647&quot;).asInt().isEqualTo(2147483647);
+   *
+   * // assertion fails as the actual value is null or not a valid int
+   * assertThat((String) null).asInt();
+   * assertThat(&quot;1e100&quot;).asInt();
+   * </code></pre>
+   *
+   * @return a new {@link IntegerAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a valid int.
+   *
+   * @since 3.25.0
+   */
+  public AbstractIntegerAssert<?> asInt() {
+    try {
+      return InstanceOfAssertFactories.INTEGER
+        .createAssert(Integer.parseInt(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.INTEGER));
+    }
+  }
+
+  /**
+   * Parses the actual value as long, using radix 10, the parsed long becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;1&quot;).asLong().isEqualTo(1L);
+   *
+   * // assertion fails as the actual value is null or not a long
+   * assertThat((String) null).asLong();
+   * assertThat(&quot;1e100&quot;).asLong();
+   * </code></pre>
+   *
+   * @return a new {@link LongAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a valid long.
+   *
+   * @since 3.25.0
+   */
+  public AbstractLongAssert<?> asLong() {
+    try {
+      return InstanceOfAssertFactories.LONG
+        .createAssert(Long.parseLong(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.LONG));
+    }
+  }
+
+  /**
+   * Parses the actual value as float, the parsed float becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;1.2f&quot;).asFloat().isCloseTo(1.2f, Percentage.withPercentage(0.01));
+   *
+   * // assertion fails as the actual value is null or not a float
+   * assertThat((String) null).asFloat();
+   * assertThat(&quot;foo&quot;).asFloat();
+   * </code></pre>
+   *
+   * @return a new {@link FloatAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a parseable float.
+   *
+   * @since 3.25.0
+   */
+  public AbstractFloatAssert<?> asFloat() {
+    try {
+      return InstanceOfAssertFactories.FLOAT
+        .createAssert(Float.parseFloat(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException | NullPointerException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.FLOAT));
+    }
+  }
+
+  /**
+   * Parses the actual value as double, the parsed double becoming the new value under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'>
+   * // assertion succeeds
+   * assertThat(&quot;1.2e308&quot;).asDouble().isCloseTo(1.2e308, Percentage.withPercentage(0.001));
+   *
+   * // assertion fails as the actual value is null or not a double
+   * assertThat((String) null).asDouble();
+   * assertThat(&quot;foo&quot;).asDouble();
+   * </code></pre>
+   *
+   * @return a new {@link DoubleAssert} instance whose value under test is the result of the parse.
+   * @throws AssertionError if the actual value is null or not a parseable double.
+   *
+   * @since 3.25.0
+   */
+  public AbstractDoubleAssert<?> asDouble() {
+    try {
+      return InstanceOfAssertFactories.DOUBLE
+        .createAssert(Double.parseDouble(actual))
+        .withAssertionState(myself);
+    } catch (NumberFormatException | NullPointerException e) {
+      throw failures.failure(info, shouldBeNumeric(actual, ShouldBeNumeric.NumericType.DOUBLE));
+    }
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNumeric.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNumeric.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.Objects;
+
+/**
+ * Creates an error message that indicates an assertion that cast string
+ * to a number (byte, short, integer, long, float or double) failed.
+ *
+ * @author hezean
+ */
+public class ShouldBeNumeric extends BasicErrorMessageFactory {
+
+  public enum NumericType {
+    BYTE("byte"),
+    SHORT("short"),
+    INTEGER("int"),
+    LONG("long"),
+    FLOAT("float"),
+    DOUBLE("double"),
+    ;
+
+    private final String typeName;
+
+    NumericType(String typeName) {
+      this.typeName = typeName;
+    }
+
+    @Override
+    public String toString() {
+      return typeName;
+    }
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeNumeric}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param type the type expected to cast.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNumeric(String actual, NumericType type) {
+    return new ShouldBeNumeric(actual, type);
+  }
+
+  private ShouldBeNumeric(String actual, NumericType type) {
+    super("%nExpecting %s to be a valid %s", actual, type);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asBoolean_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asBoolean_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asBoolean()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asBoolean_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    assertions.asBoolean();
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asBoolean cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "true", "TruE" })
+  void should_parse_string_as_true_for_true_like_string(String string) {
+    // THEN
+    then(string).asBoolean().isTrue();
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = { " false", "foo bar" })
+  void should_parse_string_as_false_otherwise(String string) {
+    // THEN
+    then(string).asBoolean().isFalse();
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asByte_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asByte_Test.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asByte()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asByte_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asByte cast throws an AssertionError when the assertion's string is not a valid byte.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asByte cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @ParameterizedTest
+  @CsvSource({"127, 127", "-128, -128", "0, 0"})
+  void should_parse_string_as_byte_for_valid_input(String string, byte byte_) {
+    // THEN
+    then(string).asByte().isEqualTo(byte_);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"1024", "1L", "foo"})
+  void should_throw_AssertionError_for_null_or_invalid_string(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asByte());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.BYTE).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asDouble_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asDouble_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asDouble()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asDouble_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asDouble cast throws an AssertionError when the assertion's string is not a valid double.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asDouble cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Test
+  void should_parse_string_as_float_when_parseable() {
+    // GIVEN
+    String string = "1.2e308";
+    // THEN
+    then(string).asDouble().isCloseTo(1.2e308, Percentage.withPercentage(0.001));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"foo", "", "0xffg"})
+  void should_throw_AssertionError_when_null_or_not_numeric(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asDouble());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.DOUBLE).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asFloat_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asFloat_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asFloat()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asFloat_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asFloat cast throws an AssertionError when the assertion's string is not a valid float.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asFloat cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @ParameterizedTest
+  @CsvSource({ "1.2f, 1.2f", "1, 1f", "1e10, 1e10f" })
+  void should_parse_string_as_float_when_parseable(String string, float float_) {
+    // THEN
+    then(string).asFloat().isCloseTo(float_, Percentage.withPercentage(0.01));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = { "foo", "" })
+  void should_throw_AssertionError_when_null_or_not_numeric(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asFloat());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.FLOAT).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asInt_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asInt_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asInt()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asInt_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asInt cast throws an AssertionError when the assertion's string is not a valid integer.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asInt cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Test
+  void should_parse_string_as_integer_for_valid_input() {
+    // GIVEN
+    String string = "-32768";
+    // THEN
+    then(string).asInt().isEqualTo(-32768);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = { "1e100", "foo" })
+  void should_throw_AssertionError_when_null_or_not_a_valid_int(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asInt());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.INTEGER).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asLong_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asLong_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asLong()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asLong_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asLong cast throws an AssertionError when the assertion's string is not a valid long.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asLong cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Test
+  void should_parse_string_as_long_for_valid_input() {
+    // GIVEN
+    String string = Long.toString(Long.MIN_VALUE);
+    // THEN
+    then(string).asLong().isEqualTo(Long.MIN_VALUE);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"1.1", "foo", ""})
+  void should_throw_AssertionError_when_null_or_not_a_valid_long(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asLong());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.LONG).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asShort_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asShort_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.assertj.core.error.ShouldBeNumeric;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link StringAssert#asShort()}</code>.
+ *
+ * @author hezean
+ */
+class StringAssert_asShort_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    // Verify disabled as the asShort cast throws an AssertionError when the assertion's string is not a valid short.
+    // Tested below.
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // Verify disabled as the asShort cast have no internal effect.
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Test
+  void should_parse_string_as_short_for_valid_input() {
+    // GIVEN
+    String string = "32767";
+    // THEN
+    then(string).asShort().isEqualTo((short) 32767);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"3276900", "foo", "1L"})
+  void should_throw_AssertionError_when_null_or_not_a_valid_short(String string) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(string).asShort());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNumeric(string, ShouldBeNumeric.NumericType.SHORT).create());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeNumeric_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeNumeric_create_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNumeric.shouldBeNumeric;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.Representation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ShouldBeNumeric#create(Description, Representation)}</code>.
+ *
+ * @author hezean
+ */
+class ShouldBeNumeric_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldBeNumeric("foo", ShouldBeNumeric.NumericType.INTEGER);
+    // WHEN
+    String message = factory.create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %nExpecting \"foo\" to be a valid int"));
+  }
+}


### PR DESCRIPTION
As [#2509 (comment)](https://github.com/assertj/assertj-core/issues/2509#issuecomment-1057395093) mentioned, several methods are added as the shortcuts for `extracting` boolean and numbers.

#### Check List:
* Closes #2520
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)
