### PR TITLE
fix: Avoid `InputStream` manipulation when `mark` / `reset` are supported

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -120,8 +120,8 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
   /**
    * Verifies that the content of the actual {@code InputStream} is empty.
    * <p>
-   * <b>Warning: this will consume the first byte of the {@code InputStream}.</b>
-   * <p>
+   * <b>Warning: this will consume the first byte of the {@code InputStream} if the underlying implementation does
+   * not support {@link InputStream#markSupported() marking}.</b>
    * Example:
    * <pre><code class='java'> // assertion will pass
    * assertThat(new ByteArrayInputStream(new byte[] {})).isEmpty());
@@ -136,7 +136,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.17.0
    */
   public SELF isEmpty() {
-    inputStreams.assertIsEmpty(info, actual);
+    tryStreamReset(() -> inputStreams.assertIsEmpty(info, actual);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -113,7 +113,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @throws InputStreamsException if an I/O error occurs.
    */
   public SELF hasSameContentAs(InputStream expected) {
-    tryStreamReset(() -> inputStreams.assertSameContentAs(info, actual, expected));
+    inputStreams.assertSameContentAs(info, actual, expected);
     return myself;
   }
 
@@ -136,7 +136,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.17.0
    */
   public SELF isEmpty() {
-    tryStreamReset(() -> inputStreams.assertIsEmpty(info, actual));
+    inputStreams.assertIsEmpty(info, actual);
     return myself;
   }
 
@@ -160,7 +160,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.17.0
    */
   public SELF isNotEmpty() {
-    tryStreamReset(() -> inputStreams.assertIsNotEmpty(info, actual));
+    inputStreams.assertIsNotEmpty(info, actual);
     return myself;
   }
 
@@ -210,7 +210,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.16.0
    */
   public SELF hasBinaryContent(byte[] expected) {
-    tryStreamReset(() -> inputStreams.assertHasBinaryContent(info, actual, expected));
+    inputStreams.assertHasBinaryContent(info, actual, expected);
     return myself;
   }
 
@@ -241,7 +241,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(MessageDigest digest, byte[] expected) {
-    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, digest, expected));
+    inputStreams.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
@@ -272,7 +272,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(MessageDigest digest, String expected) {
-    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, digest, expected));
+    inputStreams.assertHasDigest(info, actual, digest, expected);
     return myself;
   }
 
@@ -303,7 +303,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(String algorithm, byte[] expected) {
-    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, algorithm, expected));
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
     return myself;
   }
 
@@ -334,23 +334,8 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(String algorithm, String expected) {
-    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, algorithm, expected));
+    inputStreams.assertHasDigest(info, actual, algorithm, expected);
     return myself;
-  }
-
-  // Needs comments
-  private void tryStreamReset(Runnable runnable) {
-    try {
-      if (actual.markSupported()){
-        actual.mark(1);
-        runnable.run();
-        actual.reset();
-      } else {
-        runnable.run();
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
   }
 
   private String readString(Charset charset) {

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -143,7 +143,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
   /**
    * Verifies that the content of the actual {@code InputStream} is not empty.
    * <p>
-   * <b>Warning: this will consume the first byte of the {@code InputStream}.</b>
+   * <b>Warning: this will consume the first byte of the {@code InputStream} if it is not mark-supported.</b>
    * <p>
    * Example:
    * <pre><code class='java'> // assertion will pass
@@ -159,7 +159,17 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.17.0
    */
   public SELF isNotEmpty() {
-    inputStreams.assertIsNotEmpty(info, actual);
+    try {
+      if (actual.markSupported()){
+        actual.mark(1);
+        inputStreams.assertIsNotEmpty(info, actual);
+        actual.reset();
+      } else {
+        inputStreams.assertIsNotEmpty(info, actual);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -113,7 +113,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @throws InputStreamsException if an I/O error occurs.
    */
   public SELF hasSameContentAs(InputStream expected) {
-    inputStreams.assertSameContentAs(info, actual, expected);
+    tryStreamReset(() -> inputStreams.assertSameContentAs(info, actual, expected));
     return myself;
   }
 
@@ -136,7 +136,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.17.0
    */
   public SELF isEmpty() {
-    tryStreamReset(() -> inputStreams.assertIsEmpty(info, actual);
+    tryStreamReset(() -> inputStreams.assertIsEmpty(info, actual));
     return myself;
   }
 
@@ -184,7 +184,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasContent(String expected) {
-    inputStreams.assertHasContent(info, actual, expected);
+    tryStreamReset(() -> inputStreams.assertHasContent(info, actual, expected));
     return myself;
   }
 
@@ -210,7 +210,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.16.0
    */
   public SELF hasBinaryContent(byte[] expected) {
-    inputStreams.assertHasBinaryContent(info, actual, expected);
+    tryStreamReset(() -> inputStreams.assertHasBinaryContent(info, actual, expected));
     return myself;
   }
 
@@ -241,7 +241,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(MessageDigest digest, byte[] expected) {
-    inputStreams.assertHasDigest(info, actual, digest, expected);
+    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, digest, expected));
     return myself;
   }
 
@@ -272,7 +272,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(MessageDigest digest, String expected) {
-    inputStreams.assertHasDigest(info, actual, digest, expected);
+    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, digest, expected));
     return myself;
   }
 
@@ -303,7 +303,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(String algorithm, byte[] expected) {
-    inputStreams.assertHasDigest(info, actual, algorithm, expected);
+    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, algorithm, expected));
     return myself;
   }
 
@@ -334,7 +334,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasDigest(String algorithm, String expected) {
-    inputStreams.assertHasDigest(info, actual, algorithm, expected);
+    tryStreamReset(() -> inputStreams.assertHasDigest(info, actual, algorithm, expected));
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -184,7 +184,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @since 3.11.0
    */
   public SELF hasContent(String expected) {
-    tryStreamReset(() -> inputStreams.assertHasContent(info, actual, expected));
+    inputStreams.assertHasContent(info, actual, expected);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -198,4 +198,18 @@ public class InputStreams {
     requireNonNull(expected, "The string representation of digest to compare to should not be null");
     assertHasDigest(info, actual, algorithm, Digests.fromHex(expected));
   }
+  private void tryStreamReset(InputStream actual, Runnable runnable) {
+    try {
+      if (actual.markSupported()){
+        actual.mark(1);
+        runnable.run();
+        actual.reset();
+      } else {
+        runnable.run();
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
 }
+

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -198,6 +198,8 @@ public class InputStreams {
     requireNonNull(expected, "The string representation of digest to compare to should not be null");
     tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
   }
+
+  // Needs comments
   private void tryStreamReset(Runnable runnable, InputStream actual) {
     try {
       if (actual.markSupported()){

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -194,7 +194,7 @@ public class InputStreams {
     }
   }
 
-  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) {
+  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) throws IOException {
     requireNonNull(expected, "The string representation of digest to compare to should not be null");
     tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
   }
@@ -203,7 +203,7 @@ public class InputStreams {
   private void tryStreamReset(Runnable runnable, InputStream actual) {
     try {
       if (actual.markSupported()){
-        actual.mark(1);
+        actual.mark(actual.available());
         runnable.run();
         actual.reset();
       } else {

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -196,9 +196,9 @@ public class InputStreams {
 
   public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) {
     requireNonNull(expected, "The string representation of digest to compare to should not be null");
-    assertHasDigest(info, actual, algorithm, Digests.fromHex(expected));
+    tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
   }
-  private void tryStreamReset(InputStream actual, Runnable runnable) {
+  private void tryStreamReset(Runnable runnable, InputStream actual) {
     try {
       if (actual.markSupported()){
         actual.mark(1);

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -194,23 +194,23 @@ public class InputStreams {
     }
   }
 
-  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) throws IOException {
-    requireNonNull(expected, "The string representation of digest to compare to should not be null");
-    tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
+  public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) {
+    try {
+      requireNonNull(expected, "The string representation of digest to compare to should not be null");
+      tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
+    } catch (IOException e) {
+      // uh oh...our fault?
+    }
   }
 
   // Needs comments
-  private void tryStreamReset(Runnable runnable, InputStream actual) {
-    try {
-      if (actual.markSupported()){
-        actual.mark(actual.available());
-        runnable.run();
-        actual.reset();
-      } else {
-        runnable.run();
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
+  private void tryStreamReset(Runnable runnable, InputStream actual) throws IOException {
+    if (actual.markSupported()){
+      actual.mark(actual.available());
+      runnable.run();
+      actual.reset();
+    } else {
+      runnable.run();
     }
   }
 }

--- a/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -197,6 +197,8 @@ public class InputStreams {
   public void assertHasDigest(AssertionInfo info, InputStream actual, String algorithm, String expected) {
     try {
       requireNonNull(expected, "The string representation of digest to compare to should not be null");
+      // actual needed to not be null in this function, should it also be written in other hasDigest functions?
+      assertNotNull(info, actual);
       tryStreamReset(() -> assertHasDigest(info, actual, algorithm, Digests.fromHex(expected)), actual);
     } catch (IOException e) {
       // uh oh...our fault?


### PR DESCRIPTION
#### Check List:
* Fixes #2596 
* Unit tests :  NO
* Javadoc with a code example (on API only) : NO
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

This branch is failing tests. The idea for measuring `readLimit` is the `InputStream.available()` but it is causing `AbstractInputStreamAssert.java`'s `hasDigest` method to be unhappy - `Unhandled exception: java.io.IOException`. I am confused since `tryStreamReset` is catching that exception, so I am not sure why it is not bubbling up. I think this issue is probably simple, but any help would be much appreciated :)
