### PR TITLE
Add `ignoringFieldsWithAnnotations` for `RecursiveComparisonAssert`

### DIFF
--- a/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -15,6 +15,7 @@ package org.assertj.core.api;
 import static org.assertj.core.error.ShouldBeEqualByComparingFieldByFieldRecursively.shouldBeEqualByComparingFieldByFieldRecursively;
 import static org.assertj.core.error.ShouldNotBeEqualComparingFieldByFieldRecursively.shouldNotBeEqualComparingFieldByFieldRecursively;
 
+import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -558,6 +559,19 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    */
   public RecursiveComparisonAssert<?> ignoringFieldsOfTypes(Class<?>... typesToIgnore) {
     recursiveComparisonConfiguration.ignoreFieldsOfTypes(typesToIgnore);
+    return myself;
+  }
+
+  /**
+   * Makes the recursive comparison to ignore the object under test fields whose annotation match the given ones.
+   * <p>
+   * For custom annotations, @Retention(RetentionPolicy.RUNTIME) is required.
+   * <p>
+   * @param annotationsToIgnore fields with these annotations are ignored in the comparison.
+   * @return this {@link RecursiveComparisonAssert} to chain other methods.
+   */
+  public RecursiveComparisonAssert<?> ignoringFieldsWithAnnotations(Class<?>... annotationsToIgnore) {
+    recursiveComparisonConfiguration.ignoreFieldsWithAnnotations(annotationsToIgnore);
     return myself;
   }
 

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_fluent_API_Test.java
@@ -21,6 +21,8 @@ import static org.assertj.core.test.AlwaysEqualComparator.ALWAYS_EQUALS_STRING;
 import static org.assertj.core.test.AlwaysEqualComparator.ALWAYS_EQUALS_TIMESTAMP;
 import static org.assertj.core.test.AlwaysEqualComparator.alwaysEqual;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.sql.Timestamp;
 import java.util.Comparator;
 import java.util.Date;
@@ -32,6 +34,7 @@ import java.util.regex.Pattern;
 import org.assertj.core.groups.Tuple;
 import org.assertj.core.test.AlwaysDifferentComparator;
 import org.assertj.core.test.AlwaysEqualComparator;
+import org.checkerframework.checker.lock.qual.ReleasesNoLocks;
 import org.junit.jupiter.api.Test;
 
 class RecursiveComparisonAssert_fluent_API_Test {
@@ -51,6 +54,7 @@ class RecursiveComparisonAssert_fluent_API_Test {
     assertThat(recursiveComparisonConfiguration.getIgnoreAllActualNullFields()).isFalse();
     assertThat(recursiveComparisonConfiguration.getIgnoredFields()).isEmpty();
     assertThat(recursiveComparisonConfiguration.getIgnoredTypes()).isEmpty();
+    assertThat(recursiveComparisonConfiguration.getIgnoredAnnotations()).isEmpty();
     assertThat(recursiveComparisonConfiguration.getIgnoredFieldsRegexes()).isEmpty();
     assertThat(recursiveComparisonConfiguration.getIgnoredOverriddenEqualsForFields()).isEmpty();
     assertThat(recursiveComparisonConfiguration.getIgnoredOverriddenEqualsForTypes()).isEmpty();
@@ -139,6 +143,21 @@ class RecursiveComparisonAssert_fluent_API_Test {
                                                                        .getRecursiveComparisonConfiguration();
     // THEN
     assertThat(configuration.getIgnoredTypes()).containsExactly(type1, type2);
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface MyAnnotation {}
+  @Test
+  void should_allow_to_ignore_fields_of_the_given_annotations() {
+    // GIVEN
+    Class<?> annotation1 = Retention.class;
+    Class<?> annotation2 = MyAnnotation.class;
+    // WHEN
+    RecursiveComparisonConfiguration configuration = assertThat(ACTUAL).usingRecursiveComparison()
+                                                                       .ignoringFieldsWithAnnotations(annotation1, annotation2)
+                                                                       .getRecursiveComparisonConfiguration();
+    // THEN
+    assertThat(configuration.getIgnoredAnnotations()).containsExactly(annotation1, annotation2);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
@@ -26,10 +26,7 @@ import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
-import org.assertj.core.internal.objects.data.Address;
-import org.assertj.core.internal.objects.data.Giant;
-import org.assertj.core.internal.objects.data.Human;
-import org.assertj.core.internal.objects.data.Person;
+import org.assertj.core.internal.objects.data.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -486,6 +483,52 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
                                                                expected.neighbour.neighbour.dateOfBirth);
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               addressDifference, neighbourDateOfBirthDifference);
+  }
+
+  @ParameterizedTest(name = "{2}: actual={0} / expected={1}")
+  @MethodSource("recursivelyEqualObjectsIgnoringGivenAnnotations")
+  void should_pass_when_fields_with_given_annotation_are_ignored(Object actual,
+                                                                 Object expected,
+                                                                 @SuppressWarnings("unused") String testDescription,
+                                                                 List<Class<?>> ignoredAnnotations) {
+
+    assertThat(actual).usingRecursiveComparison()
+                      .ignoringFieldsWithAnnotations(ignoredAnnotations.toArray(new Class<?>[0]))
+                      .isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> recursivelyEqualObjectsIgnoringGivenAnnotations() {
+    PersonWithAnnotation p1 = new PersonWithAnnotation("John");
+    p1.home.address.number = 1;
+
+    PersonWithAnnotation p2 = new PersonWithAnnotation("Jack");
+    p2.home.address.number = 1;
+
+    PersonWithAnnotation p3 = new PersonWithAnnotation("John");
+    p3.dateOfBirth = new Date(123);
+
+    PersonWithAnnotation p4 = new PersonWithAnnotation("Jack");
+    p4.dateOfBirth = new Date(456);
+
+    PersonWithAnnotation p5 = new PersonWithAnnotation();
+    p5.home.address.number = 1;
+
+    PersonWithAnnotation p6 = new PersonWithAnnotation();
+    p6.home.address.number = 2;
+
+    PersonWithAnnotation p7 = new PersonWithAnnotation("John");
+    p7.neighbour = new PersonWithAnnotation("Jack");
+    p7.neighbour.home.address.number = 123;
+
+    PersonWithAnnotation p8 = new PersonWithAnnotation("John");
+    p8.neighbour = new PersonWithAnnotation("Jim");
+    p8.neighbour.home.address.number = 456;
+
+    return Stream.of(arguments(p1, p2, "same data and type, except for one ignored annotation", list(NameAnnotation.class)),
+                     arguments(p3, p4, "same data, different type, except for several ignored annotations", list(NameAnnotation.class, DateAnnotation.class)),
+                     arguments(p5, p6, "same data except for one subfield of an ignored annotation", list(AddressAnnotation.class)),
+                     arguments(p7, p8,
+                               "same data except for several subfields of ignored annotations", list(NameAnnotation.class, AddressAnnotation.class)));
   }
 
   @ParameterizedTest(name = "{2}: actual={0} / expected={1}")

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_multiLineDescription_Test.java
@@ -104,6 +104,16 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
   }
 
   @Test
+  void should_show_the_annotations_used_to_ignore_fields() {
+    // GIVEN
+    recursiveComparisonConfiguration.ignoreFieldsWithAnnotations(Test.class, BeforeEach.class);
+    // WHEN
+    String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
+    // THEN
+    then(multiLineDescription).contains(format("- the fields annotated with the following annotations were ignored in the comparison: org.junit.jupiter.api.Test, org.junit.jupiter.api.BeforeEach%n"));
+  }
+
+  @Test
   void should_show_the_ignored_all_overridden_equals_methods_flag() {
     // GIVEN
     recursiveComparisonConfiguration.ignoreAllOverriddenEquals();
@@ -299,6 +309,7 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
     recursiveComparisonConfiguration.ignoreFields("foo", "bar", "foo.bar");
     recursiveComparisonConfiguration.ignoreFieldsMatchingRegexes("f.*", ".ba.", "..b%sr..");
     recursiveComparisonConfiguration.ignoreFieldsOfTypes(UUID.class, ZonedDateTime.class);
+    recursiveComparisonConfiguration.ignoreFieldsWithAnnotations(Test.class, BeforeEach.class);
     recursiveComparisonConfiguration.useOverriddenEquals();
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForFieldsMatchingRegexes(".*oo", ".ar", "oo.ba");
     recursiveComparisonConfiguration.ignoreOverriddenEqualsForTypes(String.class, Multimap.class);
@@ -322,6 +333,7 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
                "- the following fields were ignored in the comparison: foo, bar, foo.bar%n" +
                "- the fields matching the following regexes were ignored in the comparison: f.*, .ba., ..b%%sr..%n"+
                "- the following types were ignored in the comparison: java.util.UUID, java.time.ZonedDateTime%n" +
+               "- the fields annotated with the following annotations were ignored in the comparison: org.junit.jupiter.api.Test, org.junit.jupiter.api.BeforeEach%n" +
                "- overridden equals methods were used in the comparison except for:%n" +
                "  - the following fields: foo, baz, foo.baz%n" +
                "  - the following types: java.lang.String, com.google.common.collect.Multimap%n" +

--- a/src/test/java/org/assertj/core/internal/objects/data/AddressAnnotation.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/AddressAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.objects.data;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AddressAnnotation {
+}

--- a/src/test/java/org/assertj/core/internal/objects/data/DateAnnotation.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/DateAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.objects.data;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DateAnnotation {
+}

--- a/src/test/java/org/assertj/core/internal/objects/data/HomeWithAnnotation.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/HomeWithAnnotation.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.objects.data;
+
+public class HomeWithAnnotation {
+  @AddressAnnotation
+  public Address address = new Address();
+
+  @Override
+  public String toString() {
+    return "Home [address=" + address + "]";
+  }
+}

--- a/src/test/java/org/assertj/core/internal/objects/data/NameAnnotation.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/NameAnnotation.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.objects.data;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NameAnnotation {
+}

--- a/src/test/java/org/assertj/core/internal/objects/data/PersonWithAnnotation.java
+++ b/src/test/java/org/assertj/core/internal/objects/data/PersonWithAnnotation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.objects.data;
+
+import java.util.*;
+
+public class PersonWithAnnotation {
+  @DateAnnotation
+  public Date dateOfBirth;
+  @NameAnnotation
+  public String name;
+  public Optional<String> phone;
+  public OptionalInt age;
+  public OptionalLong id;
+  public OptionalDouble weight;
+  @AddressAnnotation
+  public HomeWithAnnotation home = new HomeWithAnnotation();
+  public PersonWithAnnotation neighbour;
+
+  public PersonWithAnnotation() {}
+
+  public PersonWithAnnotation(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Person [dateOfBirth=%s, name=%s, phone=%s, home=%s]", dateOfBirth, name, phone, home);
+  }
+
+}
+


### PR DESCRIPTION
#### Check List:
* Fixes #2272
* Unit tests : YES
* Javadoc with a code example (on API only) : Yes (without an example)
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Failed to contribute because the annotation information is lost when getting field values from field names