### PR TITLE
Add Error Prone static analysis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,23 @@ jobs:
       - name: Test
         run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc
 
+  errorprone:
+    name: Errorprone
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: add-opens for javac
+        # Error Prone with Java 16+ requires add-exports: https://errorprone.info/docs/installation
+        run: cp .mvn/jvm.errorprone.config .mvn/jvm.config
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+#          cache: 'maven'
+      - name: Test
+        run: ./mvnw -V --no-transfer-progress -e -Perrorprone -DskipTests package
+
   sonar:
     name: Sonar code analysis
     runs-on: ubuntu-latest

--- a/.mvn/jvm.errorprone.config
+++ b/.mvn/jvm.errorprone.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <cdg.pitest.version>0.2.0</cdg.pitest.version>
     <!-- Plugin versions overriding -->
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <error-prone.version>2.14.0</error-prone.version>
   </properties>
 
   <dependencyManagement>
@@ -657,6 +658,41 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration combine.children="append">
+              <showWarnings>true</showWarnings>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>
+                  -Xplugin:ErrorProne \
+                  -Xep:ClassCanBeStatic:ERROR \
+                  -Xep:FieldCanBeStatic:ERROR \
+                  -Xep:MethodCanBeStatic:ERROR
+                </arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+                <!-- Other annotation processors go here.
+
+                If 'annotationProcessorPaths' is set, processors will no longer be
+                discovered on the regular -classpath; see also 'Using Error Prone
+                together with other annotation processors' below. -->
+              </annotationProcessorPaths>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Error Prone has good patterns, and it prints good messages.

See https://errorprone.info/bugpatterns

Sample output:

```
[ERROR] /../assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java:[2083,29] [CheckReturnValue] Ignored return value of 'usingElementComparator', which is annotated with @CheckReturnValue
[ERROR]     (see https://errorprone.info/bugpattern/CheckReturnValue)
[ERROR] /../assertj-core/src/main/java/org/assertj/core/internal/Paths.java:[438,3] [MethodCanBeStatic] A private method that does not reference the enclosing instance can be static
[ERROR]     (see https://errorprone.info/bugpattern/MethodCanBeStatic)
[ERROR]   Did you mean 'private static List<Path> sortedRecursiveContent(Path path) {'?
```


#### Check List:
* Unit tests : CI
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
