### PR TITLE
Map additional assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -51,12 +51,11 @@ import org.assertj.core.util.VisibleForTesting;
  * Base class for all implementations of assertions for {@link Map}s.
  *
  * @param <SELF> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
- *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
- *          for more details.
+ * target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
+ * for more details.
  * @param <ACTUAL> the type of the "actual" value.
  * @param <K> the type of keys in the map.
  * @param <V> the type of values in the map.
- *
  * @author David DIDIER
  * @author Yvonne Wang
  * @author Alex Ruiz
@@ -638,8 +637,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map is {@code null}.
    * @throws IllegalArgumentException if the given map is empty.
    * @throws AssertionError if the actual map does not contain the entries of the given map with same order, i.e
-   *           the actual map contains some or none of the entries of the given map, or the actual map contains more
-   *           entries than the entries of the given map or entries are the same but the order is not.
+   * the actual map contains some or none of the entries of the given map, or the actual map contains more
+   * entries than the entries of the given map or entries are the same but the order is not.
    * @since 3.12.0
    */
   public SELF containsExactlyEntriesOf(Map<? extends K, ? extends V> map) {
@@ -682,8 +681,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map is {@code null}.
    * @throws IllegalArgumentException if the given map is empty.
    * @throws AssertionError if the actual map does not contain the entries of the given map, i.e the actual map contains
-   *           some or none of the entries of the given map, or the actual map contains more entries than the entries of
-   *           the given map.
+   * some or none of the entries of the given map, or the actual map contains more entries than the entries of
+   * the given map.
    * @since 3.13.0
    */
   public SELF containsExactlyInAnyOrderEntriesOf(Map<? extends K, ? extends V> map) {
@@ -1044,7 +1043,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map does not contain the given key.
    */
   public SELF containsKey(K key) {
-    return containsKeys(key);
+    maps.assertContainsKey(info, actual, key);
+    return myself;
   }
 
   /**
@@ -1083,6 +1083,33 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   /**
+   * Verifies that the actual map contains the given keys.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(nenya, galadriel);
+   * ringBearers.put(narya, gandalf);
+   * ringBearers.put(oneRing, frodo);
+   *
+   * // assertions will pass
+   * assertThat(ringBearers).containsKeys(Arrays.asList(nenya, oneRing));
+   *
+   * // assertions will fail
+   * assertThat(ringBearers).containsKeys(Collections.singleton(vilya));
+   * assertThat(ringBearers).containsKeys(Arrays.asList(vilya, oneRing));</code></pre>
+   *
+   * @param keys the given keys
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map does not contain the given key.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   */
+  public SELF containsKeys(Iterable<? extends K> keys) {
+    maps.assertContainsKeys(info, actual, omitPath(keys));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual map does not contain the given key.
    * <p>
    * Examples:
@@ -1103,7 +1130,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map contains the given key.
    */
   public SELF doesNotContainKey(K key) {
-    return doesNotContainKeys(key);
+    maps.assertDoesNotContainKey(info, actual, key);
+    return myself;
   }
 
   /**
@@ -1141,6 +1169,32 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   /**
+   * Verifies that the actual map does not contain any of the given keys.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; elvesRingBearers = new HashMap&lt;&gt;();
+   * elvesRingBearers.put(nenya, galadriel);
+   * elvesRingBearers.put(narya, gandalf);
+   * elvesRingBearers.put(vilya, elrond);
+   *
+   * // assertion will pass
+   * assertThat(elvesRingBearers).doesNotContainKeys(oneRing, someManRing);
+   *
+   * // assertions will fail
+   * assertThat(elvesRingBearers).doesNotContainKeys(Arrays.asList(vilya, nenya));
+   * assertThat(elvesRingBearers).doesNotContainKeys(Arrays.asList(vilya, oneRing));</code></pre>
+   *
+   * @param keys the given keys
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map contains the given key.
+   */
+  public SELF doesNotContainKeys(Iterable<? extends K> keys) {
+    maps.assertDoesNotContainKeys(info, actual, omitPath(keys));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
    * <p>
    * The verification tries to honor the key comparison semantic of the underlying map implementation.
@@ -1165,7 +1219,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @return {@code this} assertions object
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map does not contain the given keys, i.e. the actual map contains some or none
-   *           of the given keys, or the actual map contains more entries than the given ones.
+   * of the given keys, or the actual map contains more entries than the given ones.
    * @throws IllegalArgumentException if the given argument is an empty array.
    */
   @SafeVarargs
@@ -1207,19 +1261,12 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @return {@code this} assertions object
    * @throws AssertionError if the actual map is {@code null} or empty.
    * @throws AssertionError if the actual map does not contain the given keys, i.e. the actual map contains some or none
-   *           of the given keys, or the actual map's keys contains keys not in the given ones.
+   * of the given keys, or the actual map's keys contains keys not in the given ones.
    * @throws IllegalArgumentException if the given argument is an empty array.
    * @since 3.12.0
    */
-  @SuppressWarnings("unchecked")
   public SELF containsOnlyKeys(Iterable<? extends K> keys) {
-    if (keys instanceof Path) {
-      // do not treat Path as an Iterable
-      K path = (K) keys;
-      maps.assertContainsOnlyKeys(info, actual, singleton(path));
-    } else {
-      maps.assertContainsOnlyKeys(info, actual, keys);
-    }
+    maps.assertContainsOnlyKeys(info, actual, omitPath(keys));
     return myself;
   }
 
@@ -1285,6 +1332,33 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   }
 
   /**
+   * Verifies that the actual map contains the given values.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(nenya, galadriel);
+   * ringBearers.put(narya, gandalf);
+   * ringBearers.put(vilya, elrond);
+   * ringBearers.put(oneRing, frodo);
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).containsValues(Arrays.asList(frodo, galadriel));
+   *
+   * // assertions will fail
+   * assertThat(ringBearers).containsValues(Arrays.asList(sauron, aragorn));
+   * assertThat(ringBearers).containsValues(Arrays.asList(sauron, frodo));</code></pre>
+   *
+   * @param values the values to look for in the actual map.
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map does not contain the given values.
+   */
+  public SELF containsValues(Iterable<? extends V> values) {
+    maps.assertContainsValues(info, actual, omitPath(values));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual map does not contain the given value.
    * <p>
    * Examples:
@@ -1308,6 +1382,137 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   public SELF doesNotContainValue(V value) {
     maps.assertDoesNotContainValue(info, actual, value);
     return myself;
+  }
+
+  /**
+   * Verifies that the actual map does not contain any of the given values.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; elvesRingBearers = new HashMap&lt;&gt;();
+   * elvesRingBearers.put(nenya, galadriel);
+   * elvesRingBearers.put(narya, gandalf);
+   * elvesRingBearers.put(vilya, elrond);
+   *
+   * // assertion will pass
+   * assertThat(elvesRingBearers).doesNotContainValues(oneRing, someManRing);
+   *
+   * // assertions will fail
+   * assertThat(elvesRingBearers).doesNotContainValues(galadriel, elrond);
+   * assertThat(elvesRingBearers).doesNotContainValues(gandalf, oneRing);</code></pre>
+   *
+   * @param values the given values
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map contains at least one of the given values.
+   */
+  @SafeVarargs
+  public final SELF doesNotContainValues(V... values) {
+    return doesNotContainValuesForProxy(values);
+  }
+
+  // This method is protected in order to be proxied for SoftAssertions / Assumptions.
+  // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
+  // in order to avoid compiler warning in user code
+  protected SELF doesNotContainValuesForProxy(V[] values) {
+    maps.assertDoesNotContainValues(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual map does not contain any of the given values.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; elvesRingBearers = new HashMap&lt;&gt;();
+   * elvesRingBearers.put(nenya, galadriel);
+   * elvesRingBearers.put(narya, gandalf);
+   * elvesRingBearers.put(vilya, elrond);
+   *
+   * // assertion will pass
+   * assertThat(elvesRingBearers).doesNotContainValues(oneRing, someManRing);
+   *
+   * // assertions will fail
+   * assertThat(elvesRingBearers).doesNotContainValues(Arrays.asList(galadriel, elrond));
+   * assertThat(elvesRingBearers).doesNotContainValues(Arrays.asList(gandalf, oneRing));</code></pre>
+   *
+   * @param values the given values
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map contains at least one of the given values.
+   */
+  public SELF doesNotContainValues(Iterable<? extends V> values) {
+    maps.assertDoesNotContainValues(info, actual, omitPath(values));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual map contains only the given values and nothing else, in any order and ignoring duplicates (i.e.
+   * once a value is found, its duplicates are also considered found).
+   * <p>
+   * Examples :
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(nenya, galadriel);
+   * ringBearers.put(narya, gandalf);
+   * ringBearers.put(vilya, frodo);
+   * ringBearers.put(oneRing, frodo);
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).containsOnlyValues(galadriel, gandalf, frodo);
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).containsOnlyValues(galadriel, frodo);</code></pre>
+   *
+   * @param values the given values that should be in the actual map.
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map does not contain the given values, i.e. the actual map contains some or none
+   * of the given values, or the actual map contains more entries than the given ones.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   */
+  @SafeVarargs
+  public final SELF containsOnlyValues(V... values) {
+    return containsOnlyValuesForProxy(values);
+  }
+
+  // This method is protected in order to be proxied for SoftAssertions / Assumptions.
+  // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
+  // in order to avoid compiler warning in user code
+  protected SELF containsOnlyValuesForProxy(V[] values) {
+    maps.assertContainsOnlyValues(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual map contains only the given values and nothing else, in any order and ignoring duplicates (i.e.
+   * once a value is found, its duplicates are also considered found).
+   * <p>
+   * Examples :
+   * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
+   * ringBearers.put(nenya, galadriel);
+   * ringBearers.put(narya, gandalf);
+   * ringBearers.put(vilya, frodo);
+   * ringBearers.put(oneRing, frodo);
+   *
+   * // assertion will pass
+   * assertThat(ringBearers).containsOnlyValues(Arrays.asList(galadriel, gandalf, frodo));
+   *
+   * // assertion will fail
+   * assertThat(ringBearers).containsOnlyValues(Arrays.asList(galadriel, frodo));</code></pre>
+   *
+   * @param values the given values that should be in the actual map.
+   * @return {@code this} assertions object
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map does not contain the given values, i.e. the actual map contains some or none
+   * of the given values, or the actual map contains more entries than the given ones.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   */
+  public SELF containsOnlyValues(Iterable<? extends V> values) {
+    maps.assertContainsOnlyValues(info, actual, omitPath(values));
+    return myself;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Iterable<T> omitPath(Iterable<T> iterable) {
+    return (iterable instanceof Path) ? singleton((T) iterable) : iterable;
   }
 
   /**
@@ -1342,7 +1547,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws NullPointerException if the given argument is {@code null}.
    * @throws IllegalArgumentException if the given argument is an empty array.
    * @throws AssertionError if the actual map does not contain the given entries, i.e. the actual map contains some or
-   *           none of the given entries, or the actual map contains more entries than the given ones.
+   * none of the given entries, or the actual map contains more entries than the given ones.
    */
   @SafeVarargs
   public final SELF containsOnly(Map.Entry<? extends K, ? extends V>... entries) {
@@ -1385,8 +1590,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @throws AssertionError if the actual map is {@code null}.
    * @throws IllegalArgumentException if the given entries array is empty.
    * @throws AssertionError if the actual map does not contain the given entries with same order, i.e. the actual map
-   *           contains some or none of the given entries, or the actual map contains more entries than the given ones
-   *           or entries are the same but the order is not.
+   * contains some or none of the given entries, or the actual map contains more entries than the given ones
+   * or entries are the same but the order is not.
    */
   @SafeVarargs
   public final SELF containsExactly(Map.Entry<? extends K, ? extends V>... entries) {
@@ -1471,8 +1676,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   /**
    * Do not use this method.
    *
-   * @deprecated Custom element Comparator is not supported for MapEntry comparison.
    * @throws UnsupportedOperationException if this method is called.
+   * @deprecated Custom element Comparator is not supported for MapEntry comparison.
    */
   @Override
   @Deprecated
@@ -1483,8 +1688,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   /**
    * Do not use this method.
    *
-   * @deprecated Custom element Comparator is not supported for MapEntry comparison.
    * @throws UnsupportedOperationException if this method is called.
+   * @deprecated Custom element Comparator is not supported for MapEntry comparison.
    */
   @Override
   @Deprecated
@@ -1730,7 +1935,6 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *
    * @param keys the keys used to get values from the map under test
    * @return a new assertion object whose object under test is the array containing the extracted map values
-   *
    * @deprecated use {@link #extractingByKeys(Object[])} instead
    */
   @Deprecated
@@ -1806,7 +2010,6 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *
    * @param key the key used to get value from the map under test
    * @return a new {@link ObjectAssert} instance whose object under test is the extracted map value
-   *
    * @since 3.13.0
    * @deprecated use {@link #extractingByKey(Object)} instead
    */
@@ -1836,9 +2039,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *
    * @param key the key used to get value from the map under test
    * @return a new {@link ObjectAssert} instance whose object under test is the extracted map value
-   *
-   * @since 3.14.0
    * @see #extractingByKey(Object, InstanceOfAssertFactory)
+   * @since 3.14.0
    */
   @CheckReturnValue
   public AbstractObjectAssert<?, V> extractingByKey(K key) {
@@ -1868,12 +2070,11 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * Nested keys are not yet supported, passing "name.first" won't get a value for "name" and then try to extract
    * "first" from the previously extracted value, instead it will simply look for a value under "name.first" key.
    *
-   * @param <ASSERT>      the type of the resulting {@code Assert}
-   * @param key           the key used to get value from the map under test
+   * @param <ASSERT> the type of the resulting {@code Assert}
+   * @param key the key used to get value from the map under test
    * @param assertFactory the factory which verifies the type and creates the new {@code Assert}
    * @return a new narrowed {@link Assert} instance whose object under test is the extracted map value
    * @throws NullPointerException if the given factory is {@code null}
-   *
    * @since 3.14.0
    */
   @CheckReturnValue
@@ -1894,7 +2095,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * The extracted values are stored in a new list becoming the object under test.
    * <p>
    * Let's take a look at an example to make things clearer :
-   *  <pre><code class='java'> // Build a Map that associates family roles and name of the Simpson family
+   * <pre><code class='java'> // Build a Map that associates family roles and name of the Simpson family
    * Map&lt;String, CartoonCharacter&gt; characters = new HashMap&lt;&gt;();
    * characters.put(&quot;dad&quot;, new CartoonCharacter(&quot;Homer&quot;));
    * characters.put(&quot;mom&quot;, new CartoonCharacter(&quot;Marge&quot;));
@@ -1909,7 +2110,8 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @since 3.12.0
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extractingFromEntries(Function<? super Map.Entry<K, V>, Object> extractor) {
+  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extractingFromEntries(
+      Function<? super Map.Entry<K, V>, Object> extractor) {
     isNotNull();
     List<Object> extractedObjects = actual.entrySet().stream()
                                           .map(extractor)
@@ -1943,7 +2145,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *                                     tuple(&quot;mom&quot;, &quot;Marge&quot;),
    *                                     tuple(&quot;girl&quot;, &quot;Lisa&quot;),
    *                                     tuple(&quot;boy&quot;, &quot;Bart&quot;));</code></pre>
-   *
+   * <p>
    * Note that the order of extracted property/field values is consistent with the iteration order of the Iterable under
    * test, for example if it's a {@link HashSet}, you won't be able to make any assumptions on the extracted values
    * order.
@@ -1954,18 +2156,22 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    */
   @CheckReturnValue
   @SafeVarargs
-  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extractingFromEntries(Function<? super Map.Entry<K, V>, Object>... extractors) {
+  public final AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extractingFromEntries(
+      Function<? super Map.Entry<K, V>, Object>... extractors) {
     return extractingFromEntriesForProxy(extractors);
   }
 
   // This method is protected in order to be proxied for SoftAssertions / Assumptions.
   // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
   // in order to avoid compiler warning in user code
-  protected AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extractingFromEntriesForProxy(Function<? super Map.Entry<K, V>, Object>[] extractors) {
+  protected AbstractListAssert<?, List<? extends Tuple>, Tuple, ObjectAssert<Tuple>> extractingFromEntriesForProxy(
+      Function<? super Map.Entry<K, V>, Object>[] extractors) {
     isNotNull();
     // combine all extractors into one function
     Function<Map.Entry<K, V>, Tuple> tupleExtractor = objectToExtractValueFrom -> new Tuple(Stream.of(extractors)
-                                                                                                  .map(extractor -> extractor.apply(objectToExtractValueFrom))
+                                                                                                  .map(
+                                                                                                      extractor -> extractor.apply(
+                                                                                                          objectToExtractValueFrom))
                                                                                                   .toArray());
     List<Tuple> extractedTuples = actual.entrySet().stream()
                                         .map(tupleExtractor)
@@ -2064,7 +2270,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * leonard.setName("Leonard Ofstater");
    * assertThat(doctors).usingRecursiveComparison()
    *                    .isEqualTo(people);</code></pre>
-   *
+   * <p>
    * A detailed documentation for the recursive comparison is available here: <a href="https://assertj.github.io/doc/#assertj-core-recursive-comparison">https://assertj.github.io/doc/#assertj-core-recursive-comparison</a>.
    * <p>
    * The default recursive comparison behavior is {@link RecursiveComparisonConfiguration configured} as follows:
@@ -2095,12 +2301,13 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
 
   /**
    * Same as {@link #usingRecursiveComparison()} but allows to specify your own {@link RecursiveComparisonConfiguration}.
-   * @param recursiveComparisonConfiguration the {@link RecursiveComparisonConfiguration} used in the chained {@link RecursiveComparisonAssert#isEqualTo(Object) isEqualTo} assertion.
    *
+   * @param recursiveComparisonConfiguration the {@link RecursiveComparisonConfiguration} used in the chained {@link RecursiveComparisonAssert#isEqualTo(Object) isEqualTo} assertion.
    * @return a new {@link RecursiveComparisonAssert} instance built with the given {@link RecursiveComparisonConfiguration}.
    */
   @Override
-  public RecursiveComparisonAssert<?> usingRecursiveComparison(RecursiveComparisonConfiguration recursiveComparisonConfiguration) {
+  public RecursiveComparisonAssert<?> usingRecursiveComparison(
+      RecursiveComparisonConfiguration recursiveComparisonConfiguration) {
     // overridden for javadoc and to make this method public
     return super.usingRecursiveComparison(recursiveComparisonConfiguration);
   }
@@ -2112,7 +2319,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *
    * <p>The recursive algorithm employs cycle detection, so object graphs with cyclic references can safely be asserted over without causing looping.</p>
    *
-   * <p>This method enables recursive asserting using default configuration, which means all fields of all objects have the   
+   * <p>This method enables recursive asserting using default configuration, which means all fields of all objects have the
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainKey.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainKey.java
@@ -21,6 +21,16 @@ public class ShouldContainKey extends BasicErrorMessageFactory {
 
   /**
    * Creates a new <code>{@link ShouldContainKey}</code>.
+   * @param actual the actual key in the failed assertion.
+   * @param value the key not found
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainKey(Object actual, Object value) {
+    return new ShouldContainKey(actual, value);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldContainKey}</code>.
    *
    * @param actual the actual map in the failed assertion.
    * @param keyCondition key condition.
@@ -28,6 +38,15 @@ public class ShouldContainKey extends BasicErrorMessageFactory {
    */
   public static ErrorMessageFactory shouldContainKey(Object actual, Condition<?> keyCondition) {
     return new ShouldContainKey(actual, keyCondition);
+  }
+
+  private ShouldContainKey(Object actual, Object value) {
+    super("%n" +
+          "Expecting actual:%n" +
+          "  %s%n" +
+          "to contain key:%n" +
+          "  %s",
+          actual, value);
   }
 
   private ShouldContainKey(Object actual, Condition<?> keyCondition) {

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainOnlyValues.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainOnlyValues.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
+
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies map contains only a given set of values and
+ * nothing else failed.
+ *
+ * @author Ilya Koshaleu
+ */
+public class ShouldContainOnlyValues extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldContainOnlyValues}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param notFound values in {@code expected} not found in {@code actual}.
+   * @param notExpected values in {@code actual} that were not in {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainOnlyValues(Object actual, Object expected, Object notFound,
+                                                          Iterable<?> notExpected) {
+    if (isNullOrEmpty(notExpected)) {
+      return new ShouldContainOnlyValues(actual, expected, notFound, StandardComparisonStrategy.instance());
+    }
+    return new ShouldContainOnlyValues(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+  }
+
+  public ShouldContainOnlyValues(Object actual, Object expected, Object notFound, Object notExpected,
+                                 ComparisonStrategy comparisonStrategy) {
+    super("%n" +
+          "Expecting actual:%n" +
+          "  %s%n" +
+          "to contain only following values:%n" +
+          "  %s%n" +
+          "values not found:%n" +
+          "  %s%n" +
+          "and values not expected:%n" +
+          "  %s%n%s", actual,
+          expected, notFound, notExpected, comparisonStrategy);
+  }
+
+  private ShouldContainOnlyValues(Object actual, Object expected, Object notFound, ComparisonStrategy comparisonStrategy) {
+    super("%n" +
+          "Expecting actual:%n" +
+          "  %s%n" +
+          "to contain only following values:%n" +
+          "  %s%n" +
+          "but could not find the following values:%n" +
+          "  %s%n%s",
+          actual, expected, notFound, comparisonStrategy);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainValues.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainValues.java
@@ -12,32 +12,31 @@
  */
 package org.assertj.core.error;
 
-import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
+import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
 
 import java.util.Set;
 
 /**
- * Creates an error message indicating that an assertion that verifies a map contains a key..
+ * Creates an error message indicating that an assertion that verifies a map does not contain a values.
  *
- * @author Nicolas François
- * @author Joel Costigliola
+ * @author Ilya Koshaleu
  */
-public class ShouldContainKeys extends BasicErrorMessageFactory {
+public class ShouldNotContainValues extends BasicErrorMessageFactory {
 
   /**
-   * Creates a new <code>{@link ShouldContainKeys}</code>.
+   * Creates a new <code>{@link ShouldNotContainValues}</code>.
    *
-   * @param <K> key type
+   * @param <V> value type
    * @param actual the actual value in the failed assertion.
-   * @param keys the expected keys
+   * @param values the unexpected values
    * @return the created {@code ErrorMessageFactory}.
    */
-  public static <K> ErrorMessageFactory shouldContainKeys(Object actual, Set<K> keys) {
-    if (keys.size() == 1) return shouldContainKey(actual, keys.iterator().next());
-    return new ShouldContainKeys(actual, keys);
+  public static <V> ErrorMessageFactory shouldNotContainValues(Object actual, Set<V> values) {
+    if (values.size() == 1) return shouldNotContainValue(actual, values.iterator().next());
+    return new ShouldNotContainValues(actual, values);
   }
 
-  private <K> ShouldContainKeys(Object actual, Set<K> key) {
-    super("%nExpecting actual:%n  %s%nto contain keys:%n  %s", actual, key);
+  public <V> ShouldNotContainValues(Object actual, Set<V> values) {
+    super("%nExpecting actual:%n  %s%nnot to contain values:%n  %s", actual, values);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/internal/ErrorMessages.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/ErrorMessages.java
@@ -47,6 +47,14 @@ public final class ErrorMessages {
     return String.format("The %s to look for should not be null", placeholder);
   }
 
+  public static String valuesToLookForIsEmpty(String placeholder) {
+    return String.format("The %s to look for should not be empty", placeholder);
+  }
+
+  public static String valuesToLookForIsNull(String placeholder) {
+    return String.format("The %s to look for should not be null", placeholder);
+  }
+
   public static String entriesToLookForIsEmpty() {
     return "The array of entries to look for should not be empty";
   }

--- a/assertj-core/src/main/java/org/assertj/core/internal/Maps.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Maps.java
@@ -31,6 +31,7 @@ import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.error.ShouldContainOnlyKeys.shouldContainOnlyKeys;
+import static org.assertj.core.error.ShouldContainOnlyValues.shouldContainOnlyValues;
 import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.error.ShouldContainValues.shouldContainValues;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
@@ -38,6 +39,7 @@ import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.error.ShouldNotContainKey.shouldNotContainKey;
 import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
 import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
+import static org.assertj.core.error.ShouldNotContainValues.shouldNotContainValues;
 import static org.assertj.core.internal.Arrays.assertIsArray;
 import static org.assertj.core.internal.CommonValidations.checkSizeBetween;
 import static org.assertj.core.internal.CommonValidations.checkSizeGreaterThan;
@@ -49,6 +51,7 @@ import static org.assertj.core.internal.CommonValidations.hasSameSizeAsCheck;
 import static org.assertj.core.internal.ErrorMessages.keysToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.IterableUtil.toArray;
@@ -80,6 +83,12 @@ import org.assertj.core.util.VisibleForTesting;
  * @author dorzey
  */
 public class Maps {
+
+  private static final String KEYS_ARRAY = "array of keys";
+  private static final String KEYS_ITERABLE = "keys iterable";
+
+  private static final String VALUES_ARRAY = "array of values";
+  private static final String VALUES_ITERABLE = "values iterable";
 
   private static final Maps INSTANCE = new Maps();
 
@@ -323,18 +332,26 @@ public class Maps {
     if (!found.isEmpty()) throw failures.failure(info, shouldNotContain(actual, entries, found));
   }
 
+  public <K, V> void assertContainsKey(AssertionInfo info, Map<K, V> actual, K key) {
+    assertContainsKeys(info, actual, array(key));
+  }
+
   public <K, V> void assertContainsKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
+    assertContainsKeys(info, actual, KEYS_ARRAY, keys);
+  }
+
+  public <K, V> void assertContainsKeys(AssertionInfo info, Map<K, V> actual, Iterable<? extends K> keys) {
+    assertContainsKeys(info, actual, KEYS_ITERABLE, toArray(keys));
+  }
+
+  private <K, V> void assertContainsKeys(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages, K[] keys) {
     assertNotNull(info, actual);
-    requireNonNull(keys, keysToLookForIsNull("array of keys"));
+    requireNonNull(keys, keysToLookForIsNull(placeholderForErrorMessages));
     if (actual.isEmpty() && keys.length == 0) return;
-    failIfEmpty(keys, keysToLookForIsEmpty("array of keys"));
+    failIfEmpty(keys, keysToLookForIsEmpty(placeholderForErrorMessages));
 
     Set<K> notFound = getNotFoundKeys(actual, keys);
     if (!notFound.isEmpty()) throw failures.failure(info, shouldContainKeys(actual, notFound));
-  }
-
-  public <K, V> void assertContainsKey(AssertionInfo info, Map<K, V> actual, K key) {
-    assertContainsKeys(info, actual, array(key));
   }
 
   public <K, V> void assertDoesNotContainKey(AssertionInfo info, Map<K, V> actual, K key) {
@@ -343,18 +360,27 @@ public class Maps {
   }
 
   public <K, V> void assertDoesNotContainKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
+    assertDoesNotContainKeys(info, actual, KEYS_ARRAY, keys);
+  }
+
+  public <K, V> void assertDoesNotContainKeys(AssertionInfo info, Map<K, V> actual, Iterable<? extends K> keys) {
+    assertDoesNotContainKeys(info, actual, KEYS_ITERABLE, toArray(keys));
+  }
+
+  private <K, V> void assertDoesNotContainKeys(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages,
+                                               K[] keys) {
     assertNotNull(info, actual);
-    requireNonNull(keys, keysToLookForIsNull("array of keys"));
+    requireNonNull(keys, keysToLookForIsNull(placeholderForErrorMessages));
     Set<K> found = getFoundKeys(actual, keys);
     if (!found.isEmpty()) throw failures.failure(info, shouldNotContainKeys(actual, found));
   }
 
   public <K, V> void assertContainsOnlyKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
-    assertContainsOnlyKeys(info, actual, "array of keys", keys);
+    assertContainsOnlyKeys(info, actual, KEYS_ARRAY, keys);
   }
 
   public <K, V> void assertContainsOnlyKeys(AssertionInfo info, Map<K, V> actual, Iterable<? extends K> keys) {
-    assertContainsOnlyKeys(info, actual, "keys iterable", toArray(keys));
+    assertContainsOnlyKeys(info, actual, KEYS_ITERABLE, toArray(keys));
   }
 
   private <K, V> void assertContainsOnlyKeys(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages, K[] keys) {
@@ -370,6 +396,31 @@ public class Maps {
 
     if (!notFound.isEmpty() || !notExpected.isEmpty())
       throw failures.failure(info, shouldContainOnlyKeys(actual, keys, notFound, notExpected));
+  }
+
+  public <K, V> void assertContainsOnlyValues(AssertionInfo info, Map<K, V> actual, V[] values) {
+    assertContainsOnlyValues(info, actual, VALUES_ARRAY, values);
+  }
+
+  public <K, V> void assertContainsOnlyValues(AssertionInfo info, Map<K, V> actual, Iterable<? extends V> values) {
+    assertContainsOnlyValues(info, actual, VALUES_ITERABLE, toArray(values));
+  }
+
+  private <K, V> void assertContainsOnlyValues(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages,
+                                               V[] values) {
+    assertNotNull(info, actual);
+    requireNonNull(values, valuesToLookForIsNull(placeholderForErrorMessages));
+    if (actual.isEmpty() && values.length == 0) {
+      return;
+    }
+    failIfEmpty(values, valuesToLookForIsEmpty(placeholderForErrorMessages));
+
+    Set<V> notFound = getNotFoundValues(actual, values);
+    Set<V> notExpected = getNotExpectedValues(actual, values);
+
+    if (!notExpected.isEmpty() || !notFound.isEmpty()) {
+      throw failures.failure(info, shouldContainOnlyValues(actual, values, notFound, notExpected));
+    }
   }
 
   private static <K> Set<K> getFoundKeys(Map<K, ?> actual, K[] expectedKeys) {
@@ -459,10 +510,18 @@ public class Maps {
   }
 
   public <K, V> void assertContainsValues(AssertionInfo info, Map<K, V> actual, V[] values) {
+    assertContainsValues(info, actual, VALUES_ARRAY, values);
+  }
+
+  public <K, V> void assertContainsValues(AssertionInfo info, Map<K, V> actual, Iterable<? extends V> values) {
+    assertContainsValues(info, actual, VALUES_ITERABLE, toArray(values));
+  }
+
+  private <K, V> void assertContainsValues(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages, V[] values) {
     assertNotNull(info, actual);
-    requireNonNull(values, "The array of values to look for should not be null");
+    requireNonNull(values, valuesToLookForIsNull(placeholderForErrorMessages));
     if (actual.isEmpty() && values.length == 0) return;
-    failIfEmpty(values, valuesToLookForIsEmpty());
+    failIfEmpty(values, valuesToLookForIsEmpty(placeholderForErrorMessages));
 
     Set<V> notFound = getNotFoundValues(actual, values);
     if (!notFound.isEmpty()) throw failures.failure(info, shouldContainValues(actual, notFound));
@@ -473,6 +532,30 @@ public class Maps {
     if (containsValue(actual, value)) throw failures.failure(info, shouldNotContainValue(actual, value));
   }
 
+  public <K, V> void assertDoesNotContainValues(AssertionInfo info, Map<K, V> actual, V[] values) {
+    assertDoesNotContainValues(info, actual, VALUES_ARRAY, values);
+  }
+
+  public <K, V> void assertDoesNotContainValues(AssertionInfo info, Map<K, V> actual, Iterable<? extends V> values) {
+    assertDoesNotContainValues(info, actual, VALUES_ITERABLE, toArray(values));
+  }
+
+  private <K, V> void assertDoesNotContainValues(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages,
+                                                 V[] values) {
+    assertNotNull(info, actual);
+    requireNonNull(values, valuesToLookForIsNull(placeholderForErrorMessages));
+    Set<V> found = getFoundValues(actual, values);
+    if (!found.isEmpty()) throw failures.failure(info, shouldNotContainValues(actual, found));
+  }
+
+  private static <V> Set<V> getFoundValues(Map<?, V> actual, V[] expectedValues) {
+    Set<V> found = new LinkedHashSet<>();
+    for (V expectedValue : expectedValues) {
+      if (containsValue(actual, expectedValue)) found.add(expectedValue);
+    }
+    return found;
+  }
+
   private static <V> Set<V> getNotFoundValues(Map<?, V> actual, V[] expectedValues) {
     // Stream API avoided for performance reasons
     Set<V> notFound = new LinkedHashSet<>();
@@ -480,6 +563,15 @@ public class Maps {
       if (!containsValue(actual, expectedValue)) notFound.add(expectedValue);
     }
     return notFound;
+  }
+
+  private static <V> Set<V> getNotExpectedValues(Map<?, V> actual, V[] expectedValues) {
+    // Stream API avoided for performance reasons
+    Set<V> valuesSet = new LinkedHashSet<>(actual.values());
+    for (V expectedValue : expectedValues) {
+      valuesSet.remove(expectedValue);
+    }
+    return valuesSet;
   }
 
   private static <V> boolean containsValue(Map<?, V> actual, V value) {
@@ -620,8 +712,8 @@ public class Maps {
     return expectedEntries;
   }
 
-  private static <K> void failIfEmpty(K[] keys, String errorMessage) {
-    checkArgument(keys.length > 0, errorMessage);
+  private static <T> void failIfEmpty(T[] array, String errorMessage) {
+    checkArgument(array.length > 0, errorMessage);
   }
 
   private static <K, V> void failIfEmpty(Entry<? extends K, ? extends V>[] entries) {

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1664,9 +1664,11 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
     softly.then(map).containsKeys("K1", "K2");
     softly.then(map).containsOnly(entry("op", "OP"), entry("qr", "QR"));
     softly.then(map).containsOnlyKeys("K3", "K4");
+    softly.then(map).containsOnlyValues("V1", "V2");
     softly.then(map).containsValues("V1", "V2");
     softly.then(map).doesNotContain(entry("a", "1"), entry("abc", "ABC"));
     softly.then(map).doesNotContainKeys("a", "b");
+    softly.then(map).doesNotContainValues("1", "2");
     softly.then(map).extracting("a", "b").contains("456");
     softly.then(iterableMap)
           .flatExtracting("name", "job", "city", "rank")
@@ -1685,7 +1687,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .isEqualTo("456");
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(16);
+    assertThat(errors).hasSize(18);
     assertThat(errors.get(0)).hasMessageContaining("\"abc\"=\"ABC\"");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -1694,15 +1696,17 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(4)).hasMessageContaining("K2");
     assertThat(errors.get(5)).hasMessageContaining("OP");
     assertThat(errors.get(6)).hasMessageContaining("K4");
-    assertThat(errors.get(7)).hasMessageContaining("V2");
-    assertThat(errors.get(8)).hasMessageContaining("ABC");
-    assertThat(errors.get(9)).hasMessageContaining("b");
-    assertThat(errors.get(10)).hasMessageContaining("456");
-    assertThat(errors.get(11)).hasMessageContaining("Unexpected");
-    assertThat(errors.get(12)).hasMessage("[size()] error message");
-    assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
-    assertThat(errors.get(14)).hasMessageContaining("to contain only");
-    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
+    assertThat(errors.get(7)).hasMessageContaining("V1");
+    assertThat(errors.get(8)).hasMessageContaining("V2");
+    assertThat(errors.get(9)).hasMessageContaining("ABC");
+    assertThat(errors.get(10)).hasMessageContaining("b");
+    assertThat(errors.get(11)).hasMessageContaining("1");
+    assertThat(errors.get(12)).hasMessageContaining("456");
+    assertThat(errors.get(13)).hasMessageContaining("Unexpected");
+    assertThat(errors.get(14)).hasMessage("[size()] error message");
+    assertThat(errors.get(15)).hasMessageContaining("\"a\"=\"1\"");
+    assertThat(errors.get(16)).hasMessageContaining("to contain only");
+    assertThat(errors.get(17)).hasMessage("[extracting(\"a\")] error message");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -2018,9 +2018,11 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     softly.assertThat(map).containsKeys("K1", "K2");
     softly.assertThat(map).containsOnly(entry("op", "OP"), entry("qr", "QR"));
     softly.assertThat(map).containsOnlyKeys("K3", "K4");
+    softly.assertThat(map).containsOnlyValues("V1", "V2");
     softly.assertThat(map).containsValues("V1", "V2");
     softly.assertThat(map).doesNotContain(entry("a", "1"), entry("abc", "ABC"));
     softly.assertThat(map).doesNotContainKeys("a", "b");
+    softly.assertThat(map).doesNotContainValues("1", "2");
     softly.assertThat(map)
           .as("extracting(\"a\", \"b\")")
           .overridingErrorMessage("error message")
@@ -2050,7 +2052,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
           .startsWith("456");
     // THEN
     List<Throwable> errors = softly.errorsCollected();
-    assertThat(errors).hasSize(17);
+    assertThat(errors).hasSize(19);
     assertThat(errors.get(0)).hasMessageContaining("\"abc\"=\"ABC\"");
     assertThat(errors.get(1)).hasMessageContaining("empty");
     assertThat(errors.get(2)).hasMessageContaining("gh")
@@ -2059,16 +2061,18 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(4)).hasMessageContaining("K2");
     assertThat(errors.get(5)).hasMessageContaining("OP");
     assertThat(errors.get(6)).hasMessageContaining("K4");
-    assertThat(errors.get(7)).hasMessageContaining("V2");
-    assertThat(errors.get(8)).hasMessageContaining("ABC");
-    assertThat(errors.get(9)).hasMessageContaining("b");
-    assertThat(errors.get(10)).hasMessage("[extracting(\"a\", \"b\")] error message");
-    assertThat(errors.get(11)).hasMessage("[flatExtracting(\"name\", \"job\", \"city\", \"rank\")] error message");
-    assertThat(errors.get(12)).hasMessage("[size()] error message");
-    assertThat(errors.get(13)).hasMessageContaining("\"a\"=\"1\"");
-    assertThat(errors.get(14)).hasMessageContaining("to contain only");
-    assertThat(errors.get(15)).hasMessage("[extracting(\"a\")] error message");
-    assertThat(errors.get(16)).hasMessage("[extracting(\"a\") as string] error message");
+    assertThat(errors.get(7)).hasMessageContaining("V1");
+    assertThat(errors.get(8)).hasMessageContaining("V2");
+    assertThat(errors.get(9)).hasMessageContaining("ABC");
+    assertThat(errors.get(10)).hasMessageContaining("b");
+    assertThat(errors.get(11)).hasMessageContaining("1");
+    assertThat(errors.get(12)).hasMessage("[extracting(\"a\", \"b\")] error message");
+    assertThat(errors.get(13)).hasMessage("[flatExtracting(\"name\", \"job\", \"city\", \"rank\")] error message");
+    assertThat(errors.get(14)).hasMessage("[size()] error message");
+    assertThat(errors.get(15)).hasMessageContaining("\"a\"=\"1\"");
+    assertThat(errors.get(16)).hasMessageContaining("to contain only");
+    assertThat(errors.get(17)).hasMessage("[extracting(\"a\")] error message");
+    assertThat(errors.get(18)).hasMessage("[extracting(\"a\") as string] error message");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsKeys_with_Iterables_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsKeys_with_Iterables_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MapAssert_containsKeys_with_Iterables_Test extends MapAssertBaseTest {
+
+  final List<String> keys = list("key1", "key2");
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsKeys(keys);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertContainsKeys(getInfo(assertions), getActual(assertions), keys);
+  }
+
+  @Test
+  void should_work_with_iterable_of_subclass_of_value_type() {
+    // GIVEN
+    Map<Number, String> map = mapOf(entry(1, "one"), entry(2, "two"));
+    // THEN
+    List<Integer> ints = list(1, 2); // not a List<Number>
+    assertThat(map).containsKeys(ints);
+  }
+
+  @Nested
+  @DisplayName("given Path parameter")
+  class MapAssert_containsKeys_with_Path_Test extends MapAssertBaseTest {
+
+    private final Path path = Paths.get("file");
+
+    @Override
+    protected MapAssert<Object, Object> invoke_api_method() {
+      return assertions.containsKeys(path);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+      verify(maps).assertContainsKeys(getInfo(assertions), getActual(assertions), singleton(path));
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyValues_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyValues_Test.java
@@ -19,19 +19,21 @@ import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 
 /**
- * Tests for <code>{@link MapAssert#containsKey(Object)}</code>.
+ * Tests for <code>{@link org.assertj.core.api.MapAssert#containsOnlyValues(Object[])}</code>.
  *
- * @author Nicolas François
+ * @author Ilya Koshaleu
  */
-class MapAssert_containsKey_Test extends MapAssertBaseTest {
+class MapAssert_containsOnlyValues_Test extends MapAssertBaseTest {
+
+  final Object[] values = array("value1", "value2");
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.containsKey("key1");
+    return assertions.containsOnlyValues(values);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(maps).assertContainsKey(getInfo(assertions), getActual(assertions), "key1");
+    verify(maps).assertContainsOnlyValues(getInfo(assertions), getActual(assertions), values);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyValues_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsOnlyValues_with_Iterable_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.MapAssert#containsOnlyValues(Iterable)}</code>.
+ *
+ * @author Ilya Koshaleu
+ */
+class MapAssert_containsOnlyValues_with_Iterable_Test extends MapAssertBaseTest {
+
+  final List<String> values = list("value1", "value2");
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsOnlyValues(values);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertContainsOnlyValues(getInfo(assertions), getActual(assertions), values);
+  }
+
+  @Test
+  void should_work_with_iterable_of_subclass_of_value_type() {
+    // GIVEN
+    Map<String, Number> map = mapOf(entry("one", 1), entry("two", 2));
+    // THEN
+    List<Integer> ints = list(1, 2); // not a List<Number>
+    assertThat(map).containsOnlyValues(ints);
+  }
+
+  @Nested
+  @DisplayName("given Path parameter")
+  class MapAssert_containsOnlyValues_with_Path_Test extends MapAssertBaseTest {
+
+    private final Path path = Paths.get("file");
+
+    @Override
+    protected MapAssert<Object, Object> invoke_api_method() {
+      return assertions.containsOnlyValues(path);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+      verify(maps).assertContainsOnlyValues(getInfo(assertions), getActual(assertions), singleton(path));
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsValues_with_Iterables_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_containsValues_with_Iterables_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MapAssert_containsValues_with_Iterables_Test extends MapAssertBaseTest {
+
+  final List<String> values = list("value1", "value2");
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsValues(values);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertContainsValues(getInfo(assertions), getActual(assertions), values);
+  }
+
+  @Test
+  void should_work_with_iterable_of_subclass_of_value_type() {
+    // GIVEN
+    Map<String, Number> map = mapOf(entry("one", 1), entry("two", 2));
+    // THEN
+    List<Integer> ints = list(1, 2); // not a List<Number>
+    assertThat(map).containsValues(ints);
+  }
+
+  @Nested
+  @DisplayName("given Path parameter")
+  class MapAssert_containsValues_with_Path_Test extends MapAssertBaseTest {
+
+    private final Path path = Paths.get("file");
+
+    @Override
+    protected MapAssert<Object, Object> invoke_api_method() {
+      return assertions.containsValues(path);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+      verify(maps).assertContainsValues(getInfo(assertions), getActual(assertions), singleton(path));
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainKey_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainKey_Test.java
@@ -33,6 +33,6 @@ class MapAssert_doesNotContainKey_Test extends MapAssertBaseTest {
 
   @Override
   protected void verify_internal_effects() {
-    verify(maps).assertDoesNotContainKeys(getInfo(assertions), getActual(assertions), array("key1"));
+    verify(maps).assertDoesNotContainKey(getInfo(assertions), getActual(assertions), "key1");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainKeys_with_Iterables_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainKeys_with_Iterables_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.MapAssert#doesNotContainKeys(Iterable)}</code>.
+ *
+ * @author Ilya Koshaleu
+ */
+class MapAssert_doesNotContainKeys_with_Iterables_Test extends MapAssertBaseTest {
+
+  final List<String> keys = list("key1");
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.doesNotContainKeys(keys);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertDoesNotContainKeys(getInfo(assertions), getActual(assertions), keys);
+  }
+
+  @Test
+  void should_work_with_iterable_of_subclass_of_value_type() {
+    // GIVEN
+    Map<Number, String> map = mapOf(entry(1, "one"), entry(2, "two"));
+    // THEN
+    List<Integer> ints = list(3, 4); // not a List<Number>
+    assertThat(map).doesNotContainKeys(ints);
+  }
+
+  @Nested
+  @DisplayName("given Path parameter")
+  class MapAssert_doesNotContainKeys_with_Path_Test extends MapAssertBaseTest {
+
+    private final Path path = Paths.get("file");
+
+    @Override
+    protected MapAssert<Object, Object> invoke_api_method() {
+      return assertions.doesNotContainKeys(path);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+      verify(maps).assertDoesNotContainKeys(getInfo(assertions), getActual(assertions), singleton(path));
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValue_Test.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 
-
 /**
  * Tests for <code>{@link MapAssert#doesNotContainValue(Object)}</code>.
  * 

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValues_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValues_Test.java
@@ -19,19 +19,21 @@ import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.MapAssertBaseTest;
 
 /**
- * Tests for <code>{@link MapAssert#containsKey(Object)}</code>.
+ * Tests for <code>{@link MapAssert#doesNotContainValues(Object[])}</code>.
  *
- * @author Nicolas François
+ * @author Ilya Koshaleu
  */
-class MapAssert_containsKey_Test extends MapAssertBaseTest {
+class MapAssert_doesNotContainValues_Test extends MapAssertBaseTest {
+
+  final Object[] values = array("value1", "value2");
 
   @Override
   protected MapAssert<Object, Object> invoke_api_method() {
-    return assertions.containsKey("key1");
+    return assertions.doesNotContainValues(values);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(maps).assertContainsKey(getInfo(assertions), getActual(assertions), "key1");
+    verify(maps).assertDoesNotContainValues(getInfo(assertions), getActual(assertions), values);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValues_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/map/MapAssert_doesNotContainValues_with_Iterable_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.map;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.MapAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.MapAssert#doesNotContainValues(Iterable)}</code>.
+ *
+ * @author Ilya Koshaleu
+ */
+class MapAssert_doesNotContainValues_with_Iterable_Test extends MapAssertBaseTest {
+
+  final List<String> values = list("value1");
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.doesNotContainValues(values);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertDoesNotContainValues(getInfo(assertions), getActual(assertions), values);
+  }
+
+  @Test
+  void should_work_with_iterable_of_subclass_of_value_type() {
+    // GIVEN
+    Map<String, Number> map = mapOf(entry("one", 1), entry("two", 2));
+    // THEN
+    List<Integer> ints = list(3, 4); // not a List<Number>
+    assertThat(map).doesNotContainValues(ints);
+  }
+
+  @Nested
+  @DisplayName("given Path parameter")
+  class MapAssert_doesNotContainValues_with_Path_Test extends MapAssertBaseTest {
+
+    private final Path path = Paths.get("file");
+
+    @Override
+    protected MapAssert<Object, Object> invoke_api_method() {
+      return assertions.doesNotContainValues(path);
+    }
+
+    @Override
+    protected void verify_internal_effects() {
+      verify(maps).assertDoesNotContainValues(getInfo(assertions), getActual(assertions), singleton(path));
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainOnlyValues_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainOnlyValues_create_Test.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainOnlyValues.shouldContainOnlyValues;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Lists.list;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for
+ * <code>{@link ShouldContainOnlyValues#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
+ *
+ * @author Ilya Koshaleu
+ */
+class ShouldContainOnlyValues_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnlyValues(mapOf(entry("name", "Yoda"), entry("color", "green")),
+                                                          list("jedi", "green"),
+                                                          singleton("jedi"),
+                                                          singleton("Yoda"));
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), StandardRepresentation.STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(String.format("[Test] %n"
+                                          + "Expecting actual:%n"
+                                          + "  {\"color\"=\"green\", \"name\"=\"Yoda\"}%n"
+                                          + "to contain only following values:%n"
+                                          + "  [\"jedi\", \"green\"]%n"
+                                          + "values not found:%n"
+                                          + "  [\"jedi\"]%n"
+                                          + "and values not expected:%n"
+                                          + "  [\"Yoda\"]%n"));
+  }
+
+  @Test
+  void should_create_error_message_without_unexpected_elements() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainOnlyValues(singletonMap("color", "green"),
+                                                          list("jedi", "green"),
+                                                          singleton("jedi"),
+                                                          emptySet());
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), StandardRepresentation.STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(String.format("[Test] %n"
+                                          + "Expecting actual:%n"
+                                          + "  {\"color\"=\"green\"}%n"
+                                          + "to contain only following values:%n"
+                                          + "  [\"jedi\", \"green\"]%n"
+                                          + "but could not find the following values:%n"
+                                          + "  [\"jedi\"]%n"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainValues_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainValues_create_Test.java
@@ -13,51 +13,46 @@
 package org.assertj.core.error;
 
 import static java.lang.String.format;
+import static java.util.Collections.singleton;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
-import static org.assertj.core.error.ShouldContainKey.shouldContainKey;
+import static org.assertj.core.error.ShouldNotContainValues.shouldNotContainValues;
 import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.util.Sets.set;
 
-import java.util.Map;
-
-import org.assertj.core.api.TestCondition;
-import org.assertj.core.description.Description;
-import org.assertj.core.description.TextDescription;
+import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShouldContainKey#create(Description)}</code>.
- */
-class ShouldContainKey_create_Test {
+class ShouldNotContainValues_create_Test {
 
   @Test
   void should_create_error_message() {
     // GIVEN
-    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
-    ErrorMessageFactory factory = shouldContainKey(map, "VeryOld");
+    ErrorMessageFactory factory = shouldNotContainValues(mapOf(entry("name", "Yoda"), entry("color", "green")),
+                                                         singleton("C3PO"));
     // WHEN
-    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    String message = factory.create(new TestDescription("Test"), StandardRepresentation.STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
                                    "  {\"color\"=\"green\", \"name\"=\"Yoda\"}%n" +
-                                   "to contain key:%n" +
-                                   "  \"VeryOld\""));
+                                   "not to contain value:%n" +
+                                   "  \"C3PO\""));
   }
 
   @Test
-  void should_create_error_message_with_key_condition() {
+  void should_create_error_message_multiple_values() {
     // GIVEN
-    Map<?, ?> map = mapOf(entry("name", "Yoda"), entry("color", "green"));
-    ErrorMessageFactory factory = shouldContainKey(map, new TestCondition<>("test condition"));
+    ErrorMessageFactory factory = shouldNotContainValues(mapOf(entry("name", "Yoda"), entry("color", "green")),
+                                                         set("C3PO", "gold"));
     // WHEN
-    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    String message = factory.create(new TestDescription("Test"), StandardRepresentation.STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
                                    "  {\"color\"=\"green\", \"name\"=\"Yoda\"}%n" +
-                                   "to contain a key satisfying:%n" +
-                                   "  test condition"));
+                                   "not to contain values:%n" +
+                                   "  [\"C3PO\", \"gold\"]"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/MapsBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/MapsBaseTest.java
@@ -46,7 +46,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
  * Base class for {@link Maps} unit tests
  * <p>
  * Is in <code>org.assertj.core.internal</code> package to be able to set {@link Maps} attributes appropriately.
- * 
+ *
  * @author Joel Costigliola
  */
 public class MapsBaseTest extends WithPlayerData {
@@ -113,4 +113,7 @@ public class MapsBaseTest extends WithPlayerData {
     return new String[0];
   }
 
+  protected static String[] emptyValues() {
+    return new String[0];
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_with_Array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_with_Array_Test.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
+import static org.assertj.core.internal.ErrorMessages.keysToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.collections4.map.SingletonMap;
+import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author William Delanoue
+ */
+class Maps_assertContainsKeys_with_Array_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    String[] keys = { "name" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsKeys(someInfo(), null, keys));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_keys_array_is_null() {
+    // GIVEN
+    String[] keys = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsKeys(someInfo(), actual, keys));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull("array of keys"));
+  }
+
+  @Test
+  void should_fail_if_given_keys_array_is_empty() {
+    // GIVEN
+    String[] keys = emptyKeys();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsKeys(someInfo(), actual, keys));
+    // THEN
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(keysToLookForIsEmpty("array of keys"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+      "caseInsensitiveMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, String[] expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsKeys(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), emptyKeys()),
+                     arguments(singletonMap("name", "Yoda"), array("name")),
+                     arguments(new SingletonMap<>("name", "Yoda"), array("name")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("name", "job")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("job", "name")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "job")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("job", "name")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("name", "job")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("job", "name")));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("name")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("name", "job")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("job", "name"))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
+    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("name", "job")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("job", "name")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("Name", "Job")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("Job", "Name"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+      "caseInsensitiveMapsFailureTestCases",
+      "commonsCollectionsCaseInsensitiveMapFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, String[] expected, Set<String> notFound) {
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertContainsKeys(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldContainKeys(actual, notFound).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(emptyMap(),
+                               array("name"),
+                               set("name")),
+                     arguments(singletonMap("name", "Yoda"),
+                               array("color"),
+                               set("color")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array("color"),
+                               set("color")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array("name", "color"),
+                               set("color")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array("name", "color"),
+                               set("color")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               array("name", "color"),
+                               set("color")),
+                     arguments(Jdk11.Map.of("name", "Yoda"),
+                               array((String) null), // implementation not permitting null keys
+                               set((String) null)));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          array("name", "color"),
+                                                          set("color")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("name", "color"),
+                                                          set("color"))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
+    return Stream.of(CASE_INSENSITIVE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("name", "color"),
+                                                          set("color")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("Name", "Color"),
+                                                          set("Color"))));
+  }
+
+  private static Stream<Arguments> commonsCollectionsCaseInsensitiveMapFailureTestCases() {
+    return Stream.of(arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array("name", "color"),
+                               set("color")), // internal keys are always lowercase
+                     arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array("Name", "Color"),
+                               set("Color"))); // internal keys are always lowercase
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKeys_with_Iterable_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal.maps;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Collections.unmodifiableMap;
@@ -25,9 +26,9 @@ import static org.assertj.core.internal.ErrorMessages.keysToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Sets.set;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -48,14 +49,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * @author William Delanoue
+ * @author Ilya Koshaleu
  */
-class Maps_assertContainsKeys_Test extends MapsBaseTest {
+class Maps_assertContainsKeys_with_Iterable_Test extends MapsBaseTest {
 
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    String[] keys = { "name" };
+    Iterable<String> keys = list("name");
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> maps.assertContainsKeys(someInfo(), null, keys));
     // THEN
@@ -63,23 +64,23 @@ class Maps_assertContainsKeys_Test extends MapsBaseTest {
   }
 
   @Test
-  void should_fail_if_given_keys_array_is_null() {
+  void should_fail_if_given_keys_iterable_is_null() {
     // GIVEN
-    String[] keys = null;
+    Iterable<String> keys = null;
     // WHEN
     Throwable thrown = catchThrowable(() -> maps.assertContainsKeys(someInfo(), actual, keys));
     // THEN
-    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull("array of keys"));
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull("keys iterable"));
   }
 
   @Test
-  void should_fail_if_given_keys_array_is_empty() {
+  void should_fail_if_given_keys_iterable_is_empty() {
     // GIVEN
-    String[] keys = emptyKeys();
+    Iterable<String> keys = emptyList();
     // WHEN
     Throwable thrown = catchThrowable(() -> maps.assertContainsKeys(someInfo(), actual, keys));
     // THEN
-    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(keysToLookForIsEmpty("array of keys"));
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(keysToLookForIsEmpty("keys iterable"));
   }
 
   @ParameterizedTest
@@ -88,44 +89,44 @@ class Maps_assertContainsKeys_Test extends MapsBaseTest {
       "modifiableMapsSuccessfulTestCases",
       "caseInsensitiveMapsSuccessfulTestCases",
   })
-  void should_pass(Map<String, String> actual, String[] expected) {
+  void should_pass(Map<String, String> actual, Iterable<String> expected) {
     // WHEN/THEN
     assertThatNoException().as(actual.getClass().getName())
                            .isThrownBy(() -> maps.assertContainsKeys(info, actual, expected));
   }
 
   private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
-    return Stream.of(arguments(emptyMap(), emptyKeys()),
-                     arguments(singletonMap("name", "Yoda"), array("name")),
-                     arguments(new SingletonMap<>("name", "Yoda"), array("name")),
-                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("name", "job")),
-                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("job", "name")),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "job")),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("job", "name")),
-                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("name", "job")),
-                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("job", "name")));
+    return Stream.of(arguments(emptyMap(), emptyList()),
+                     arguments(singletonMap("name", "Yoda"), list("name")),
+                     arguments(new SingletonMap<>("name", "Yoda"), list("name")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("name", "job")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("job", "name")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("name", "job")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("job", "name")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("name", "job")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("job", "name")));
   }
 
   private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
     return Stream.of(MODIFIABLE_MAPS)
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("name")),
+                                                          list("name")),
                                                 arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("name", "job")),
+                                                          list("name", "job")),
                                                 arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("job", "name"))));
+                                                          list("job", "name"))));
   }
 
   private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
     return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("name", "job")),
+                                                          list("name", "job")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("job", "name")),
+                                                          list("job", "name")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("Name", "Job")),
+                                                          list("Name", "Job")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("Job", "Name"))));
+                                                          list("Job", "Name"))));
   }
 
   @ParameterizedTest
@@ -135,7 +136,7 @@ class Maps_assertContainsKeys_Test extends MapsBaseTest {
       "caseInsensitiveMapsFailureTestCases",
       "commonsCollectionsCaseInsensitiveMapFailureTestCases",
   })
-  void should_fail(Map<String, String> actual, String[] expected, Set<String> notFound) {
+  void should_fail(Map<String, String> actual, Iterable<String> expected, Set<String> notFound) {
     // WHEN
     assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
                                                    .isThrownBy(() -> maps.assertContainsKeys(info, actual, expected))
@@ -145,55 +146,54 @@ class Maps_assertContainsKeys_Test extends MapsBaseTest {
 
   private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
     return Stream.of(arguments(emptyMap(),
-                               array("name"),
+                               list("name"),
                                set("name")),
                      arguments(singletonMap("name", "Yoda"),
-                               array("color"),
+                               list("color"),
                                set("color")),
                      arguments(new SingletonMap<>("name", "Yoda"),
-                               array("color"),
+                               list("color"),
                                set("color")),
                      arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
-                               array("name", "color"),
+                               list("name", "color"),
                                set("color")),
                      arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
-                               array("name", "color"),
+                               list("name", "color"),
                                set("color")),
                      arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
-                               array("name", "color"),
+                               list("name", "color"),
                                set("color")),
                      arguments(Jdk11.Map.of("name", "Yoda"),
-                               array((String) null), // implementation not permitting null keys
+                               list((String) null), // implementation not permitting null keys
                                set((String) null)));
   }
 
   private static Stream<Arguments> modifiableMapsFailureTestCases() {
     return Stream.of(MODIFIABLE_MAPS)
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
-                                                          array("name", "color"),
+                                                          list("name", "color"),
                                                           set("color")),
                                                 arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("name", "color"),
+                                                          list("name", "color"),
                                                           set("color"))));
   }
 
   private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
     return Stream.of(CASE_INSENSITIVE_MAPS)
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("name", "color"),
+                                                          list("name", "color"),
                                                           set("color")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("Name", "Color"),
+                                                          list("Name", "Color"),
                                                           set("Color"))));
   }
 
   private static Stream<Arguments> commonsCollectionsCaseInsensitiveMapFailureTestCases() {
     return Stream.of(arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                               array("name", "color"),
+                               list("name", "color"),
                                set("color")), // internal keys are always lowercase
                      arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                               array("Name", "Color"),
+                               list("Name", "Color"),
                                set("Color"))); // internal keys are always lowercase
   }
-
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyValues_with_Array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyValues_with_Array_Test.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainOnlyValues.shouldContainOnlyValues;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.SingletonMap;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Ilya Koshaleu
+ */
+class Maps_assertContainsOnlyValues_with_Array_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    String[] values = { "value" };
+    // WHEN
+    AssertionError error = expectAssertionError(() -> maps.assertContainsOnlyValues(someInfo(), null, values));
+    // THEN
+    then(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_values_array_is_null() {
+    // GIVEN
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(valuesToLookForIsNull("array of values"));
+  }
+
+  @Test
+  void should_fail_if_given_values_array_is_empty() {
+    // GIVEN
+    String[] values = emptyValues();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(valuesToLookForIsEmpty("array of values"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases"
+  })
+  void should_pass(Map<String, String> actual, String[] expected) {
+    // GIVEN
+    int initialSize = actual.size();
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsOnlyValues(info, actual, expected));
+
+    then(actual).hasSize(initialSize);
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), emptyKeys()),
+                     arguments(singletonMap("name", "Yoda"), array("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"), array("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("Yoda", "Jedi")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("Jedi", "Yoda")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("Yoda", "Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("Jedi", "Yoda")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("Yoda", "Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("Jedi", "Yoda")));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda", "Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Jedi", "Yoda"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases"
+  })
+  void should_fail(Map<String, String> actual, String[] expected, Set<String> notFound, Set<String> notExpected) {
+    // GIVEN
+    int initialSize = actual.size();
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertContainsOnlyValues(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldContainOnlyValues(actual, expected,
+                                                                                        notFound, notExpected).create());
+
+    then(actual).hasSize(initialSize);
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(emptyMap(),
+                               array("name"),
+                               set("name"),
+                               emptySet()),
+                     arguments(singletonMap("name", "Yoda"),
+                               array("green"),
+                               set("green"),
+                               set("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array("green"),
+                               set("green"),
+                               set("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               array("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          array("Yoda", "green"),
+                                                          set("green"),
+                                                          emptySet()),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda"),
+                                                          emptySet(),
+                                                          set("Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda", "green"),
+                                                          set("green"),
+                                                          set("Jedi"))));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyValues_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyValues_with_Iterable_Test.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainOnlyValues.shouldContainOnlyValues;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.SingletonMap;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Ilya Koshaleu
+ */
+class Maps_assertContainsOnlyValues_with_Iterable_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Iterable<String> values = list("value");
+    // WHEN
+    AssertionError error = expectAssertionError(() -> maps.assertContainsOnlyValues(someInfo(), null, values));
+    // THEN
+    then(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_values_iterable_is_null() {
+    // GIVEN
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(valuesToLookForIsNull("values iterable"));
+  }
+
+  @Test
+  void should_fail_if_given_values_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> values = emptyList();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(valuesToLookForIsEmpty("values iterable"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases"
+  })
+  void should_pass(Map<String, String> actual, Iterable<String> expected) {
+    // GIVEN
+    int initialSize = actual.size();
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsOnlyValues(info, actual, expected));
+
+    then(actual).hasSize(initialSize);
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), emptyList()),
+                     arguments(singletonMap("name", "Yoda"), list("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"), list("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("Yoda", "Jedi")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("Jedi", "Yoda")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("Yoda", "Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("Jedi", "Yoda")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("Yoda", "Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("Jedi", "Yoda")));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda", "Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Jedi", "Yoda"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases"
+  })
+  void should_fail(Map<String, String> actual, Iterable<String> expected, Set<String> notFound, Set<String> notExpected) {
+    // GIVEN
+    int initialSize = actual.size();
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertContainsOnlyValues(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldContainOnlyValues(actual, expected,
+                                                                                        notFound, notExpected).create());
+
+    then(actual).hasSize(initialSize);
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(emptyMap(),
+                               list("name"),
+                               set("name"),
+                               emptySet()),
+                     arguments(singletonMap("name", "Yoda"),
+                               list("green"),
+                               set("green"),
+                               set("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               list("green"),
+                               set("green"),
+                               set("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "green"),
+                               set("green"),
+                               set("Jedi")));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          list("Yoda", "green"),
+                                                          set("green"),
+                                                          emptySet()),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda"),
+                                                          emptySet(),
+                                                          set("Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda", "green"),
+                                                          set("green"),
+                                                          set("Jedi"))));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_with_Array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_with_Array_Test.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainValues.shouldContainValues;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.SingletonMap;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Nicolas François
+ * @author Joel Costigliola
+ * @author Alexander Bischof
+ */
+class Maps_assertContainsValues_with_Array_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    String[] values = { "Yoda" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsValues(someInfo(), null, values));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_values_array_is_null() {
+    // GIVEN
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage("The array of values to look for should not be null");
+  }
+
+  @Test
+  void should_fail_if_given_values_array_is_empty() {
+    // GIVEN
+    String[] values = array();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("The array of values to look for should not be empty");
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, String[] expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsValues(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), emptyKeys()),
+                     arguments(singletonMap("name", "Yoda"), array("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"), array("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("Yoda", "Jedi")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("Jedi", "Yoda")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("Yoda", "Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("Jedi", "Yoda")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("Yoda", "Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), array("Jedi", "Yoda")));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda", "Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Jedi", "Yoda"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, String[] expected, Set<String> notFound) {
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertContainsValues(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldContainValues(actual, notFound).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(emptyMap(),
+                               array("Yoda"),
+                               set("Yoda")),
+                     arguments(singletonMap("name", "Yoda"),
+                               array("green"),
+                               set("green")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array("green"),
+                               set("green")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array("Yoda", "green"),
+                               set("green")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array("Yoda", "green"),
+                               set("green")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               array("Yoda", "green"),
+                               set("green")),
+                     arguments(Jdk11.Map.of("name", "Yoda"),
+                               array((String) null), // implementation not permitting null keys
+                               set((String) null)));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          array("Yoda", "green"),
+                                                          set("green")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array("Yoda", "green"),
+                                                          set("green"))));
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsValues_with_Iterable_Test.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldContainValues.shouldContainValues;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.SingletonMap;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Ilya Koshaleu
+ */
+class Maps_assertContainsValues_with_Iterable_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Iterable<String> values = list("Yoda");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsValues(someInfo(), null, values));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_values_iterable_is_null() {
+    // GIVEN
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(valuesToLookForIsNull("values iterable"));
+  }
+
+  @Test
+  void should_fail_if_given_values_iterable_is_empty() {
+    // GIVEN
+    Iterable<String> values = emptyList();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(valuesToLookForIsEmpty("values iterable"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, Iterable<String> expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsValues(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), emptyList()),
+                     arguments(singletonMap("name", "Yoda"), list("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"), list("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("Yoda", "Jedi")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("Jedi", "Yoda")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("Yoda", "Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("Jedi", "Yoda")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("Yoda", "Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("Jedi", "Yoda")));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda", "Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Jedi", "Yoda"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, Iterable<String> expected, Set<String> notFound) {
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertContainsValues(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldContainValues(actual, notFound).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(emptyMap(),
+                               list("Yoda"),
+                               set("Yoda")),
+                     arguments(singletonMap("name", "Yoda"),
+                               list("green"),
+                               set("green")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               list("green"),
+                               set("green")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("Yoda", "green"),
+                               set("green")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "green"),
+                               set("green")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "green"),
+                               set("green")),
+                     arguments(Jdk11.Map.of("name", "Yoda"),
+                               list((String) null), // implementation not permitting null keys
+                               set((String) null)));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          list("Yoda", "green"),
+                                                          set("green")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda", "green"),
+                                                          set("green"))));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_with_Array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_with_Array_Test.java
@@ -49,7 +49,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * @author dorzey
  */
-class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
+class Maps_assertDoesNotContainKeys_with_Array_Test extends MapsBaseTest {
 
   @Test
   void should_fail_if_actual_is_null() {
@@ -179,5 +179,4 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
                                                           array("Job", "Name"),
                                                           set("Job", "Name"))));
   }
-
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_with_Iterable_Test.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
+import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.collections4.map.SingletonMap;
+import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Ilya Koshaleu
+ */
+class Maps_assertDoesNotContainKeys_with_Iterable_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Iterable<String> keys = list("name");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), null, keys));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_keys_iterable_is_null() {
+    // GIVEN
+    Iterable<String> keys = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertDoesNotContainKeys(someInfo(), actual, keys));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull("keys iterable"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+      "caseInsensitiveMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, Iterable<String> expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertDoesNotContainKeys(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), list("name")),
+                     arguments(singletonMap("name", "Yoda"), list("color")),
+                     arguments(new SingletonMap<>("name", "Yoda"), list("color")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("color", "age")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("color", "age")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("color", "age")),
+                     // implementation not permitting null keys
+                     arguments(Jdk11.Map.of("name", "Yoda"), list((String) null)));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")), list("color")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("color", "age"))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
+    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("color", "age")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("Color", "Age"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+      "caseInsensitiveMapsFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, Iterable<String> expected, Set<String> notFound) {
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertDoesNotContainKeys(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldNotContainKeys(actual, notFound).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(singletonMap("name", "Yoda"),
+                               list("name"),
+                               set("name")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               list("name"),
+                               set("name")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("name", "job"),
+                               set("name", "job")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("job", "name"),
+                               set("job", "name")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("name", "job"),
+                               set("name", "job")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("job", "name"),
+                               set("job", "name")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("name", "job"),
+                               set("name", "job")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("job", "name"),
+                               set("job", "name")));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("name"),
+                                                          set("name")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("name", "job"),
+                                                          set("name", "job")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("job", "name"),
+                                                          set("job", "name"))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
+    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("name", "job"),
+                                                          set("name", "job")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("job", "name"),
+                                                          set("job", "name")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("Name", "Job"),
+                                                          set("Name", "Job")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          list("Job", "Name"),
+                                                          set("Job", "Name"))));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainValues_with_Iterable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainValues_with_Iterable_Test.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.maps;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldNotContainValues.shouldNotContainValues;
+import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.map.SingletonMap;
+import org.assertj.core.internal.MapsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author Ilya Koshaleu
+ */
+class Maps_assertDoesNotContainValues_with_Iterable_Test extends MapsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Iterable<String> values = list("value");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertDoesNotContainValues(someInfo(), null, values));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_given_values_iterable_is_null() {
+    // GIVEN
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertDoesNotContainValues(someInfo(), actual, values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull("values iterable"));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, Iterable<String> expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertDoesNotContainValues(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(emptyMap(), list("Yoda")),
+                     arguments(singletonMap("name", "Yoda"), list("green")),
+                     arguments(new SingletonMap<>("name", "Yoda"), list("green")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), list("green", "many")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), list("green", "many")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"), list("green", "many")),
+                     // implementation not permitting null keys
+                     arguments(Jdk11.Map.of("name", "Yoda"), list((String) null)));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")), list("green")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("green", "many"))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, Iterable<String> expected, Set<String> notFound) {
+    // WHEN
+    assertThatExceptionOfType(AssertionError.class).as(actual.getClass().getName())
+                                                   .isThrownBy(() -> maps.assertDoesNotContainValues(info, actual, expected))
+                                                   // THEN
+                                                   .withMessage(shouldNotContainValues(actual, notFound).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(singletonMap("name", "Yoda"),
+                               list("Yoda"),
+                               set("Yoda")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               list("Yoda"),
+                               set("Yoda")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("Yoda", "Jedi"),
+                               set("Yoda", "Jedi")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               list("Jedi", "Yoda"),
+                               set("Jedi", "Yoda")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "Jedi"),
+                               set("Yoda", "Jedi")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               list("Jedi", "Yoda"),
+                               set("Jedi", "Yoda")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("Yoda", "Jedi"),
+                               set("Yoda", "Jedi")),
+                     arguments(Jdk11.Map.of("name", "Yoda", "job", "Jedi"),
+                               list("Jedi", "Yoda"),
+                               set("Jedi", "Yoda")));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda"),
+                                                          set("Yoda")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Yoda", "Jedi"),
+                                                          set("Yoda", "Jedi")),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          list("Jedi", "Yoda"),
+                                                          set("Jedi", "Yoda"))));
+  }
+}


### PR DESCRIPTION
1. Added the following methods for the MapAssert:

    - containsKeys(Iterable)
    - containsValues(Iterable)
    - containsOnlyValues(Object[])
    - containsOnlyValues(Iterable)
    - doesNotContainKeys(Iterable)
    - doesNotContainValues(Object[])
    - doesNotContainValues(Iterable)

2. Fixed the issue #2428