### PR TITLE
GH-2647 stack trace assertions skeleton base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -4193,7 +4193,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
     return text.endsWith(ASSERT) ? text.substring(0, text.length() - ASSERT.length()) : text;
   }
 
-  private ObjectAssert<ELEMENT> toAssert(ELEMENT value, String description) {
+  protected ObjectAssert<ELEMENT> toAssert(ELEMENT value, String description) {
     return new ObjectAssert<>(value).as(description);
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -43,8 +43,11 @@ public abstract class AbstractSoftAssertions extends DefaultAssertionErrorCollec
   }
 
   @Override
-  public <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(Class<SELF> assertClass,
-                                                                                    Class<ACTUAL> actualClass, ACTUAL actual) {
+  public <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(
+    Class<SELF> assertClass,
+    Class<? extends ACTUAL> actualClass,
+    ACTUAL actual
+  ) {
     return proxies.createSoftAssertionProxy(assertClass, actualClass, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractStackTraceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractStackTraceAssert.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * Base class for all implementations of assertions for
+ * {@link StackTraceElement[] stack trace arrays} of
+ * {@link StackTraceElement stack trace elements}.
+ *
+ * @param <SELF> the "self" type of this assertion class. Please read &quot;<a
+ *               href="http://bit.ly/1IZIRcY" target="_blank">Emulating 'self types' using Java
+ *               Generics to simplify fluent API implementation</a>&quot; for more details.
+ * @author Ashley Scopes
+ */
+public abstract class AbstractStackTraceAssert<SELF extends AbstractStackTraceAssert<SELF, ELEMENT_ASSERT>,
+                                               ELEMENT_ASSERT extends AbstractStackTraceElementAssert<ELEMENT_ASSERT>>
+  extends AbstractAssert<SELF, StackTraceElement[]> {
+
+  /**
+   * Initialize this assertion.
+   *
+   * @param actual   the stack trace array to perform assertions upon.
+   * @param selfType the type of the implementation of this class.
+   */
+  protected AbstractStackTraceAssert(StackTraceElement[] actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Create an assertion for a {@link StackTraceElement} and return it.
+   *
+   * @param stackTraceElement the stack trace element to create an assertion for.
+   * @return the created assertion.
+   */
+  protected abstract ELEMENT_ASSERT newStackTraceElementAssert(StackTraceElement stackTraceElement);
+}

--- a/src/main/java/org/assertj/core/api/AbstractStackTraceElementAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractStackTraceElementAssert.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * Base class for all implementations of assertions for
+ * {@link StackTraceElement stack trace elements}.
+ *
+ * @param <SELF> the "self" type of this assertion class. Please read &quot;<a
+ *               href="http://bit.ly/1IZIRcY" target="_blank">Emulating 'self types' using Java
+ *               Generics to simplify fluent API implementation</a>&quot; for more details.
+ * @author Ashley Scopes
+ */
+public abstract class AbstractStackTraceElementAssert<SELF extends AbstractStackTraceElementAssert<SELF>>
+  extends AbstractAssert<SELF, StackTraceElement> {
+
+  /**
+   * Initialize this assertion.
+   *
+   * @param actual the stack trace element to perform assertions upon.
+   * @param selfType the type of the implementation of this class.
+   */
+  protected AbstractStackTraceElementAssert(StackTraceElement actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -143,6 +143,7 @@ import org.assertj.core.util.introspection.Introspection;
  * @author Julien Meddah
  * @author William Bakker
  * @author William Delanoue
+ * @author Ashley Scopes
  */
 @CheckReturnValue
 public class Assertions implements InstanceOfAssertFactories {
@@ -3538,6 +3539,30 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static <K, V> MapAssert<K, V> assertThat(Map<K, V> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement[])
+   */
+  public static AbstractStackTraceElementAssert<?> assertThat(StackTraceElement actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement)
+   */
+  public static AbstractStackTraceAssert<?, ?> assertThat(StackTraceElement[] actual) {
+    return AssertionsForClassTypes.assertThat(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -725,6 +725,29 @@ public class AssertionsForClassTypes {
   }
 
   /**
+   * Create a new instance of {@link AbstractStackTraceElementAssert}.
+   *
+   * @param actual the actual {@link StackTraceElement}.
+   * @return the created {@link AbstractStackTraceElementAssert}.
+   * @see #assertThat(StackTraceElement[])
+   */
+  public static AbstractStackTraceElementAssert<?> assertThat(StackTraceElement actual) {
+    return new StackTraceElementAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement)
+   */
+  public static AbstractStackTraceAssert<?, ?> assertThat(StackTraceElement[] actual) {
+    return new StackTraceAssert(actual);
+  }
+
+  /**
    * Allows to capture and then assert on a {@link Throwable} (easier done with lambdas).
    * <p>
    * Java 8 example :

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -1503,6 +1503,30 @@ public class Assumptions {
   }
 
   /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} assumption for the given
+   * {@link StackTraceElement stack trace element} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assumeThat(StackTraceElement[])
+   */
+  public static AbstractStackTraceElementAssert<?> assumeThat(StackTraceElement actual) {
+    return asAssumption(StackTraceElementAssert.class, StackTraceElement.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} assumption for the given
+   * {@link StackTraceElement[] stack trace element array}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assumeThat(StackTraceElement)
+   */
+  public static AbstractStackTraceAssert<?, ?> assumeThat(StackTraceElement[] actual) {
+    return asAssumption(StackTraceAssert.class, StackTraceElement[].class, actual);
+  }
+
+  /**
    * Sets which exception is thrown if an assumption is not met. 
    * <p>
    * This method is useful if you are using a testing framework that supports assumptions and expect a specific exception to be thrown when an assumption is not met. 

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -1539,9 +1539,9 @@ public class Assumptions {
   // private methods
 
   private static <ASSERTION, ACTUAL> ASSERTION asAssumption(Class<ASSERTION> assertionType,
-                                                            Class<ACTUAL> actualType,
-                                                            Object actual) {
-    return asAssumption(assertionType, array(actualType), array(actual));
+                                                            Class<? extends ACTUAL> actualType,
+                                                            ACTUAL actual) {
+    return asAssumption(assertionType, array(actualType), array((Object) actual));
   }
 
   private static <ASSERTION> ASSERTION asAssumption(Class<ASSERTION> assertionType,

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -132,6 +132,7 @@ import org.assertj.core.util.CheckReturnValue;
  * @author Julien Meddah
  * @author William Delanoue
  * @author Mariusz Smykula
+ * @author Ashley Scopes
  */
 @CheckReturnValue
 public class BDDAssertions extends Assertions {
@@ -1835,6 +1836,30 @@ public class BDDAssertions extends Assertions {
    * @since 3.14.0
    */
   public static <ELEMENT> SpliteratorAssert<ELEMENT> then(Spliterator<ELEMENT> actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #then(StackTraceElement[])
+   */
+  public static AbstractStackTraceElementAssert<?> then(StackTraceElement actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #then(StackTraceElement)
+   */
+  public static AbstractStackTraceAssert<?, ?> then(StackTraceElement[] actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -3113,6 +3113,30 @@ public final class BDDAssumptions extends Assumptions {
   }
 
   /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} assumption for the given
+   * {@link StackTraceElement stack trace element} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #given(StackTraceElement[])
+   */
+  public static AbstractStackTraceElementAssert<?> given(StackTraceElement actual) {
+    return assumeThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} assumption for the given
+   * {@link StackTraceElement[] stack trace element array}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #given(StackTraceElement)
+   */
+  public static AbstractStackTraceAssert<?, ?> given(StackTraceElement[] actual) {
+    return assumeThat(actual);
+  }
+
+  /**
    * Sets which exception is thrown if an assumption is not met.
    * <p>
    * This method is useful if you are using a testing framework that supports assumptions and expect a specific exception to be thrown when an assumption is not met.

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -418,4 +418,27 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
     return proxy(LongAdderAssert.class, LongAdder.class, actual);
   }
 
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #then(StackTraceElement[])
+   */
+  default AbstractStackTraceElementAssert<?> then(StackTraceElement actual) {
+    return proxy(StackTraceElementAssert.class, StackTraceElement.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #then(StackTraceElement)
+   */
+  default AbstractStackTraceAssert<?, ?> then(StackTraceElement[] actual) {
+    return proxy(StackTraceAssert.class, StackTraceElement[].class, actual);
+  }
 }

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -584,6 +584,20 @@ public interface InstanceOfAssertFactories {
   InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<Object>> ATOMIC_INTEGER_FIELD_UPDATER = atomicIntegerFieldUpdater(Object.class);
 
   /**
+   * {@link InstanceOfAssertFactory} for a {@link StackTraceElement}.
+   */
+  InstanceOfAssertFactory<StackTraceElement, AbstractStackTraceElementAssert<?>> STACK_TRACE_ELEMENT = new InstanceOfAssertFactory<>(
+    StackTraceElement.class,
+    Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link StackTraceElement stack trace element array}.
+   */
+  InstanceOfAssertFactory<StackTraceElement[], AbstractStackTraceAssert<?, ?>> STACK_TRACE_ARRAY = new InstanceOfAssertFactory<>(
+    StackTraceElement[].class,
+    Assertions::assertThat);
+
+  /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}.
    *
    * @param <OBJECT>   the {@code AtomicIntegerFieldUpdater} object type.

--- a/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/SoftAssertionsProvider.java
@@ -41,8 +41,11 @@ public interface SoftAssertionsProvider extends AssertionErrorCollector {
    * @param actual The actual object-under-test.
    * @return A proxied assertion class for the given object-under-test.
    */
-  <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(Class<SELF> assertClass, Class<ACTUAL> actualClass,
-                                                                             ACTUAL actual);
+  <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF proxy(
+    Class<SELF> assertClass,
+    Class<? extends ACTUAL> actualClass,
+    ACTUAL actual
+  );
 
   /**
    * Verifies that no soft assertions have failed.

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -114,7 +114,7 @@ class SoftProxies {
   }
 
   <SELF extends Assert<? extends SELF, ? extends ACTUAL>, ACTUAL> SELF createSoftAssertionProxy(Class<SELF> assertClass,
-                                                                                                Class<ACTUAL> actualClass,
+                                                                                                Class<? extends ACTUAL> actualClass,
                                                                                                 ACTUAL actual) {
     try {
       Class<? extends SELF> proxyClass = createSoftAssertionProxyClass(assertClass);

--- a/src/main/java/org/assertj/core/api/StackTraceAssert.java
+++ b/src/main/java/org/assertj/core/api/StackTraceAssert.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * Implementation of a set of assertions that can be performed on
+ * {@link StackTraceElement[] stack trace element arrays} types.
+ *
+ * @author Ashley Scopes
+ */
+public class StackTraceAssert extends AbstractStackTraceAssert<StackTraceAssert, StackTraceElementAssert> {
+
+  /**
+   * Initialize these assertions.
+   *
+   * @param actual the stack trace element array to perform assertions on.
+   */
+  protected StackTraceAssert(StackTraceElement[] actual) {
+    super(actual, StackTraceAssert.class);
+  }
+
+  @Override
+  protected StackTraceElementAssert newStackTraceElementAssert(StackTraceElement actual) {
+    return new StackTraceElementAssert(actual);
+  }
+}

--- a/src/main/java/org/assertj/core/api/StackTraceElementAssert.java
+++ b/src/main/java/org/assertj/core/api/StackTraceElementAssert.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * Assertion methods for {@link StackTraceElement stack trace elements}.
+ *
+ * @author Ashley Scopes
+ */
+public class StackTraceElementAssert extends AbstractStackTraceElementAssert<StackTraceElementAssert> {
+
+  /**
+   * Initialize this assertion.
+   *
+   * @param stackTraceElement the stack trace element to perform assertions upon.
+   */
+  protected StackTraceElementAssert(StackTraceElement stackTraceElement) {
+    super(stackTraceElement, StackTraceElementAssert.class);
+  }
+}

--- a/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -414,4 +414,27 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
     return proxy(LongAdderAssert.class, LongAdder.class, actual);
   }
 
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement[])
+   */
+  default AbstractStackTraceElementAssert<?> assertThat(StackTraceElement actual) {
+    return proxy(StackTraceElementAssert.class, StackTraceElement.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement)
+   */
+  default AbstractStackTraceAssert<?, ?> assertThat(StackTraceElement[] actual) {
+    return proxy(StackTraceAssert.class, StackTraceElement[].class, actual);
+  }
 }

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -3317,6 +3317,30 @@ public interface WithAssertions extends InstanceOfAssertFactories {
     return Assertions.assertThat(component);
   }
 
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement[])
+   */
+  default AbstractStackTraceElementAssert<?> assertThat(StackTraceElement actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assertThat(StackTraceElement)
+   */
+  default AbstractStackTraceAssert<?, ?> assertThat(StackTraceElement[] actual) {
+    return Assertions.assertThat(actual);
+  }
+
   // --------------------------------------------------------------------------------------------------
   // Filter methods : not assertions but here to have a complete entry point to all AssertJ features.
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -1206,6 +1206,31 @@ public interface WithAssumptions {
     return Assumptions.assumeThat(spliterator);
   }
 
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceElementAssert} assumption for the given
+   * {@link StackTraceElement} value.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assumeThat(StackTraceElement[])
+   */
+  default AbstractStackTraceElementAssert<?> assumeThat(StackTraceElement actual) {
+    return Assumptions.assumeThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link AbstractStackTraceAssert} assumption for the given
+   * {@link StackTraceElement} array.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @see #assumeThat(StackTraceElement)
+   */
+  default AbstractStackTraceAssert<?, ?> assumeThat(StackTraceElement[] actual) {
+    return Assumptions.assumeThat(actual);
+  }
+
   /**
    * Sets which exception is thrown if an assumption is not met. 
    * <p>

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StackTraceElementArray_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StackTraceElementArray_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(StackTraceElement[])}</code>.
+ *
+ * @author Ashley Scopes
+ */
+class Assertions_assertThat_with_StackTraceElementArray_Test {
+
+  private StackTraceElement[] actual;
+
+  @BeforeEach
+  void before() {
+    actual = new StackTraceElement[]{
+      mock(StackTraceElement.class, withSettings().stubOnly().name("foo")),
+      mock(StackTraceElement.class, withSettings().stubOnly().name("bar")),
+      mock(StackTraceElement.class, withSettings().stubOnly().name("baz"))
+    };
+  }
+
+  @Test
+  void should_create_Assert() {
+    AbstractStackTraceAssert<?, ?> assertions = assertThat(actual);
+    assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  void should_pass_actual() {
+    AbstractStackTraceAssert<?, ?> assertions = assertThat(actual);
+    assertThat(actual).isEqualTo(assertions.actual);
+  }
+
+  @SuppressWarnings("ThrowableNotThrown")
+  @Test
+  void should_propagate_failure() {
+    AbstractStackTraceAssert<?, ?> assertions = assertThat(actual);
+    expectAssertionError(() -> assertThat(actual).isNotEqualTo(assertions.actual));
+  }
+}

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StackTraceElement_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_StackTraceElement_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(StackTraceElement)}</code>.
+ *
+ * @author Ashley Scopes
+ */
+class Assertions_assertThat_with_StackTraceElement_Test {
+
+  private StackTraceElement actual;
+
+  @BeforeEach
+  void before() {
+    actual = mock(StackTraceElement.class, withSettings().stubOnly());
+  }
+
+  @Test
+  void should_create_Assert() {
+    AbstractStackTraceElementAssert<?> assertions = assertThat(actual);
+    assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  void should_pass_actual() {
+    AbstractStackTraceElementAssert<?> assertions = assertThat(actual);
+    assertThat(actual).isSameAs(assertions.actual);
+  }
+
+  @SuppressWarnings("ThrowableNotThrown")
+  @Test
+  void should_propagate_failure() {
+    AbstractStackTraceElementAssert<?> assertions = assertThat(actual);
+    expectAssertionError(() -> assertThat(actual).isNotSameAs(assertions.actual));
+  }
+}

--- a/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.assertj.core.api.BDDAssertions.thenWith;
 import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.Lists.list;
 
 import java.io.IOException;
@@ -377,6 +378,40 @@ class BDDAssertions_then_Test {
   @Test
   void then_Duration() {
     then(Duration.ofHours(1)).isNotNull().isPositive();
+  }
+
+  @Test
+  void then_StackTraceElement_succeeds() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    StackTraceElement frame1 = stackTrace[1];
+
+    then(frame1).isEqualTo(frame1);
+  }
+
+  @SuppressWarnings("ThrowableNotThrown")
+  @Test
+  void then_StackTraceElement_fails() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    StackTraceElement frame1 = stackTrace[1];
+    StackTraceElement frame2 = stackTrace[2];
+
+    expectAssertionError(() -> then(frame1).isEqualTo(frame2));
+  }
+
+  @Test
+  void then_StackTrace_succeeds() {
+    StackTraceElement[] stackTrace = Arrays.copyOf(Thread.currentThread().getStackTrace(), 5);
+
+    then(stackTrace).isEqualTo(stackTrace);
+  }
+
+  @SuppressWarnings("ThrowableNotThrown")
+  @Test
+  void then_StackTrace_fails() {
+    StackTraceElement[] stackTrace1 = Arrays.copyOf(Thread.currentThread().getStackTrace(), 3);
+    StackTraceElement[] stackTrace2 = Arrays.copyOfRange(Thread.currentThread().getStackTrace(), 2, 5);
+
+    expectAssertionError(() -> then(stackTrace1).isEqualTo(stackTrace2));
   }
 
   @SuppressWarnings("static-access")

--- a/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -91,6 +91,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.SHORT;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT_2D_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.SHORT_ARRAY;
 import static org.assertj.core.api.InstanceOfAssertFactories.SPLITERATOR;
+import static org.assertj.core.api.InstanceOfAssertFactories.STACK_TRACE_ARRAY;
+import static org.assertj.core.api.InstanceOfAssertFactories.STACK_TRACE_ELEMENT;
 import static org.assertj.core.api.InstanceOfAssertFactories.STREAM;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUFFER;
@@ -1232,6 +1234,30 @@ class InstanceOfAssertFactoriesTest {
     MapAssert<String, String> result = assertThat(value).asInstanceOf(map(String.class, String.class));
     // THEN
     result.containsExactly(entry("key", "value"));
+  }
+
+  @Test
+  void stack_trace_element_factory_should_allow_stack_trace_element_assertions() {
+    // GIVEN
+    StackTraceElement stackTraceElement = new StackTraceElement("foo", "bar", "baz", 123);
+    // WHEN
+    AbstractStackTraceElementAssert<?> result = assertThat(stackTraceElement).asInstanceOf(STACK_TRACE_ELEMENT);
+    // THEN
+    result.isSameAs(stackTraceElement);
+  }
+
+  @Test
+  void stack_trace_factory_should_allow_stack_trace_assertions() {
+    // GIVEN
+    StackTraceElement[] stackTrace = new StackTraceElement[]{
+      new StackTraceElement("foo", "bar", "baz", 123),
+      new StackTraceElement("lorem", "ipsum", "dolor", 456),
+      new StackTraceElement("sit", "amet", "???", 789)
+    };
+    // WHEN
+    AbstractStackTraceAssert<?, ?> result = assertThat(stackTrace).asInstanceOf(STACK_TRACE_ARRAY);
+    // THEN
+    result.isSameAs(stackTrace);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
+++ b/src/test/java/org/assertj/core/api/WithAssertions_delegation_Test.java
@@ -957,7 +957,23 @@ class WithAssertions_delegation_Test implements WithAssertions {
   @Test
   void withAssertions_assertThat_class_loader_Test() {
     // FIXME replace with class loader specific assertion
-    assertThat(WithAssertions.class.getClassLoader()).isSameAs(WithAssertions.class.getClassLoader());
+    assertThat(WithAssertions.class.getClassLoader()).isSameAs(
+      WithAssertions.class.getClassLoader());
+  }
+
+  void withAssertions_assertThat_stackTraceElement_Test() {
+    assertThat(new StackTraceElement("foo", "bar", "baz", 123))
+      .isNotEqualTo(new StackTraceElement("baz", "bork", "quxx", 456));
+  }
+
+  @Test
+  void withAssertions_assertThat_stackTrace_Test() {
+    StackTraceElement[] stackTrace = {
+      new StackTraceElement("foo", "bar", "baz", 123),
+      new StackTraceElement("baz", "bork", "qux", 1234)
+    };
+
+    assertThat(stackTrace).isSameAs(stackTrace);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_StackTraceElementArray_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_StackTraceElementArray_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.assumptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.assertj.core.api.AbstractStackTraceAssert;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Assumptions#assumeThat(StackTraceElement[])}</code>.
+ *
+ * @author Ashley Scopes
+ */
+class Assumptions_assumeThat_with_StackTraceElementArray_Test {
+
+  private StackTraceElement[] actual;
+
+  @BeforeEach
+  void before() {
+    actual = new StackTraceElement[]{
+      mock(StackTraceElement.class, withSettings().stubOnly().name("foo")),
+      mock(StackTraceElement.class, withSettings().stubOnly().name("bar")),
+      mock(StackTraceElement.class, withSettings().stubOnly().name("baz"))
+    };
+  }
+
+  @Test
+  void should_create_assumption() {
+    AbstractStackTraceAssert<?, ?> assumptions = assumeThat(actual);
+    assertThat(assumptions).isNotNull();
+  }
+
+  @Test
+  void should_pass_actual() {
+    AbstractStackTraceAssert<?, ?> assumptions = assumeThat(actual);
+    assertThatCode(() -> assumptions.isSameAs(actual))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_propagate_failure() {
+    AbstractStackTraceAssert<?, ?> assumptions = assumeThat(actual);
+    expectAssumptionNotMetException(() -> assumptions.isNotSameAs(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_StackTraceElement_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_StackTraceElement_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.assumptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.assertj.core.api.AbstractStackTraceElementAssert;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Assumptions#assumeThat(StackTraceElement)}</code>.
+ *
+ * @author Ashley Scopes
+ */
+class Assumptions_assumeThat_with_StackTraceElement_Test {
+
+  private StackTraceElement actual;
+
+  @BeforeEach
+  void before() {
+    actual = mock(StackTraceElement.class, withSettings().stubOnly());
+  }
+
+  @Test
+  void should_create_assumption() {
+    AbstractStackTraceElementAssert<?> assumptions = assumeThat(actual);
+    assertThat(assumptions).isNotNull();
+  }
+
+  @Test
+  void should_pass_actual() {
+    AbstractStackTraceElementAssert<?> assumptions = assumeThat(actual);
+    assertThatCode(() -> assumptions.isSameAs(actual))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_propagate_failure() {
+    AbstractStackTraceElementAssert<?> assumptions = assumeThat(actual);
+    expectAssumptionNotMetException(() -> assumptions.isNotSameAs(actual));
+  }
+}

--- a/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
+++ b/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
@@ -1413,4 +1413,38 @@ class BDDAssumptionsTest {
       expectAssumptionNotMetException(() -> given(Duration.ofHours(1)).isNotNull().isNegative());
     }
   }
+
+  @Test
+  void then_StackTraceElement_succeeds() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    StackTraceElement frame1 = stackTrace[1];
+
+    thenCode(() -> given(frame1).isEqualTo(frame1))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void then_StackTraceElement_fails() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    StackTraceElement frame1 = stackTrace[1];
+    StackTraceElement frame2 = stackTrace[2];
+
+    expectAssumptionNotMetException(() -> given(frame1).isEqualTo(frame2));
+  }
+
+  @Test
+  void then_StackTrace_succeeds() {
+    StackTraceElement[] stackTrace = Arrays.copyOf(Thread.currentThread().getStackTrace(), 5);
+
+    thenCode(() -> given(stackTrace).isEqualTo(stackTrace))
+      .doesNotThrowAnyException();
+  }
+
+  @Test
+  void then_StackTrace_fails() {
+    StackTraceElement[] stackTrace1 = Arrays.copyOf(Thread.currentThread().getStackTrace(), 3);
+    StackTraceElement[] stackTrace2 = Arrays.copyOfRange(Thread.currentThread().getStackTrace(), 2, 5);
+
+    expectAssumptionNotMetException(() -> given(stackTrace1).isEqualTo(stackTrace2));
+  }
 }

--- a/src/test/java/org/example/custom/CustomAsserts_filter_stacktrace_Test.java
+++ b/src/test/java/org/example/custom/CustomAsserts_filter_stacktrace_Test.java
@@ -12,11 +12,10 @@
  */
 package org.example.custom;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
+import org.assertj.core.api.ObjectArrayAssert;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +28,7 @@ public class CustomAsserts_filter_stacktrace_Test {
     try {
       new CustomAssert("").fail();
     } catch (AssertionError e) {
-      assertThat(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
+      assertThatGh2647(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
     }
   }
 
@@ -38,7 +37,7 @@ public class CustomAsserts_filter_stacktrace_Test {
     try {
       new CustomAssert("").overridingErrorMessage("overridden message").fail();
     } catch (AssertionError e) {
-      assertThat(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
+      assertThatGh2647(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
     }
   }
 
@@ -47,7 +46,7 @@ public class CustomAsserts_filter_stacktrace_Test {
     try {
       new CustomAssert("").throwAnAssertionError();
     } catch (AssertionError e) {
-      assertThat(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
+      assertThatGh2647(e.getStackTrace()).areNot(elementOf(CustomAssert.class));
     }
   }
 
@@ -56,7 +55,7 @@ public class CustomAsserts_filter_stacktrace_Test {
     try {
       new CustomAssert("").failInAbstractAssert();
     } catch (AssertionError e) {
-      assertThat(e.getStackTrace()).areNot(elementOf(CustomAbstractAssert.class));
+      assertThatGh2647(e.getStackTrace()).areNot(elementOf(CustomAbstractAssert.class));
     }
   }
 
@@ -66,7 +65,7 @@ public class CustomAsserts_filter_stacktrace_Test {
     try {
       new CustomAssert("").fail();
     } catch (AssertionError e) {
-      assertThat(e.getStackTrace()).areAtLeastOne(elementOf(CustomAssert.class));
+      assertThatGh2647(e.getStackTrace()).areAtLeastOne(elementOf(CustomAssert.class));
     }
   }
 
@@ -77,6 +76,8 @@ public class CustomAsserts_filter_stacktrace_Test {
   }
 
   private static Condition<StackTraceElement> elementOf(final Class<?> clazz) {
+    // Diamond inference for anonymous types was not introduced until JDK 9.
+    //noinspection Convert2Diamond
     return new Condition<StackTraceElement>("StackTraceElement of " + clazz) {
       @Override
       public boolean matches(StackTraceElement value) {
@@ -112,5 +113,13 @@ public class CustomAsserts_filter_stacktrace_Test {
       failWithMessage("failing assert");
       return myself;
     }
+  }
+
+  // TODO(ascopes): refactor this test to use the StackTraceAssert API once it is implemented.
+  //   This is just done for now to prevent these tests failing due to the new signatures
+  //   that have been implemented as part of GH-2647. We cast to Object first to use the existing
+  //   assertion implementations instead of the incomplete API I am building.
+  private static ObjectArrayAssert<StackTraceElement> assertThatGh2647(StackTraceElement[] stackTrace) {
+    return new ObjectArrayAssert<>(stackTrace);
   }
 }


### PR DESCRIPTION
First PR for GH-2647 to implement assertions for `StackTraceElement` and `StackTraceElement[]` types.

    GH-2647: Implement skeleton for stack trace assertions.
    
    This introduces the skeleton for two new types of
    assertion/assumption:
    
    - assertThat(StackTraceElement) - to perform assertions
      upon StackTraceElement types.
    - assertThat(StackTraceElement[]) - to perform assertions
      upon StackTraceElement[] types.
    
    Due to the new signature conflicting with one of the existing
    test suites, I have implemented a temporary workaround to prevent
    having to totally reimplement that class, since the new
    API is not yet usable in this set of changes. I will remove
    this in the second PR that implements the actual functionality.
    
    I have also made one of the proxy methods in the API less restrictive
    to allow it to work with passing array types around.
