### PR TITLE
[#2664] add forbidden-api check

### DIFF
--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -30,6 +30,7 @@
     <opentest4j.version>1.2.0</opentest4j.version>
     <!-- Plugin versions -->
     <bnd.version>6.3.1</bnd.version>
+    <forbiddenapis.version>3.4</forbiddenapis.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
@@ -101,6 +102,20 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>${spotbugs-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>de.thetaphi</groupId>
+          <artifactId>forbiddenapis</artifactId>
+          <version>${forbiddenapis.version}</version>
+          <configuration>
+            <failOnUnsupportedJava>true</failOnUnsupportedJava>
+            <bundledSignatures>
+              <bundledSignature>jdk-unsafe</bundledSignature>
+              <bundledSignature>jdk-deprecated</bundledSignature>
+              <bundledSignature>jdk-non-portable</bundledSignature>
+              <bundledSignature>jdk-reflection</bundledSignature>
+            </bundledSignatures>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -232,25 +247,20 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>${versions-maven-plugin.version}</version>
         </plugin>
-        <plugin>
-          <groupId>de.thetaphi</groupId>
-          <artifactId>forbiddenapis</artifactId>
-          <version>3.3</version>
-          <configuration>
-            <failOnUnsupportedJava>true</failOnUnsupportedJava>
-            <bundledSignatures>
-              <bundledSignature>jdk-unsafe</bundledSignature>
-              <bundledSignature>jdk-deprecated</bundledSignature>
-              <!-- disallow undocumented classes like sun.misc.Unsafe: -->
-              <bundledSignature>jdk-non-portable</bundledSignature>
-              <!-- don't allow unsafe reflective access: -->
-              <bundledSignature>jdk-reflection</bundledSignature>
-            </bundledSignatures>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>de.thetaphi</groupId>
+        <artifactId>forbiddenapis</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
@@ -286,17 +296,6 @@
             <include>**/*Test.java</include>
           </includes>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>de.thetaphi</groupId>
-        <artifactId>forbiddenapis</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -232,6 +232,22 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>${versions-maven-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>de.thetaphi</groupId>
+          <artifactId>forbiddenapis</artifactId>
+          <version>3.3</version>
+          <configuration>
+            <failOnUnsupportedJava>true</failOnUnsupportedJava>
+            <bundledSignatures>
+              <bundledSignature>jdk-unsafe</bundledSignature>
+              <bundledSignature>jdk-deprecated</bundledSignature>
+              <!-- disallow undocumented classes like sun.misc.Unsafe: -->
+              <bundledSignature>jdk-non-portable</bundledSignature>
+              <!-- don't allow unsafe reflective access: -->
+              <bundledSignature>jdk-reflection</bundledSignature>
+            </bundledSignatures>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -270,6 +286,17 @@
             <include>**/*Test.java</include>
           </includes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>de.thetaphi</groupId>
+        <artifactId>forbiddenapis</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Adds https://github.com/policeman-tools/forbidden-apis to your maven parent's pom.xml. The pluginManagement section contains both version and configuration, while the plugin section contains the inherited forced execution.
TODO: check if I need to add `<inherited>true</inherited>`.

#### Check List:
* [x] Fixes #2664 (ignore if not applicable)
* [ ] Unit tests : NA (added maven plugin, not testable code)
* [ ] Javadoc with a code example (on API only) : NA
* [ ] PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
