### PR TITLE
Add SQLException versions for assertThat and assumeThat

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -1185,6 +1186,20 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    */
   public static <T extends Throwable> AbstractThrowableAssert<?, T> assertThat(T actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created {@link ThrowableAssert}.
+   * @since 3.23.1
+   */
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> assertThat(T actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assumptions.java
@@ -30,6 +30,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1026,6 +1027,21 @@ public class Assumptions {
   @SuppressWarnings("unchecked")
   public static <T extends Throwable> AbstractThrowableAssert<?, T> assumeThat(T actual) {
     return asAssumption(ThrowableAssert.class, Throwable.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code> assumption.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.23.1
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> assumeThat(T actual) {
+    return asAssumption(ThrowableAssert.class, SQLException.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -1291,6 +1292,20 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion Throwable.
    */
   public static <T extends Throwable> AbstractThrowableAssert<?, T> then(T actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created assertion Throwable.
+   * @since 3.23.1
+   */
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1441,6 +1442,36 @@ public final class BDDAssumptions extends Assumptions {
    * @since 3.14.0
    */
   public static <T extends Throwable> AbstractThrowableAssert<?, T> given(T actual) {
+    return assumeThat(actual);
+  }
+
+  /**
+   * Creates a new assumption's instance for a {@link java.sql.SQLException} value.
+   * <p>
+   * Examples:
+   * <p>
+   * Executed test:
+   * <pre><code class='java'> {@literal @Test}
+   * public void given_the_assumption_is_met_the_test_is_executed() {
+   *   given(new SQLException("Yoda time")).hasMessage("Yoda time");
+   *   // the remaining code is executed
+   *   // ...
+   * }</code></pre>
+   * <p>
+   * Skipped test:
+   * <pre><code class='java'> {@literal @Test}
+   * public void given_the_assumption_is_not_met_the_test_is_skipped() {
+   *   given(new SQLException("Yoda time")).hasMessage("");
+   *   // the remaining code is NOT executed.
+   *   // ...
+   *}</code></pre>
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual {@link java.sql.SQLException} value to be validated.
+   * @return the {@link AbstractThrowableAssert} assertion object to be used for assumptions.
+   * @since 3.23.1
+   */
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> given(T actual) {
     return assumeThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -782,6 +783,26 @@ public interface InstanceOfAssertFactories {
    * @since 3.21.0
    */
   static <T extends Throwable> InstanceOfAssertFactory<T, AbstractThrowableAssert<?, T>> throwable(Class<T> type) {
+    return new InstanceOfAssertFactory<>(type, Assertions::assertThat);
+  }
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link SQLException}.
+   */
+  InstanceOfAssertFactory<SQLException, AbstractThrowableAssert<?, SQLException>> SQL_EXCEPTION = new InstanceOfAssertFactory<>(SQLException.class,
+    Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link SQLException}.
+   *
+   * @param <T>  the {@code SQLException} type.
+   * @param type the element type instance.
+   * @return the factory instance.
+   *
+   * @see #SQL_EXCEPTION
+   * @since 3.23.1
+   */
+  static <T extends SQLException> InstanceOfAssertFactory<T, AbstractThrowableAssert<?, T>> sqlException(Class<T> type) {
     return new InstanceOfAssertFactory<>(type, Assertions::assertThat);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.sql.SQLException;
 import java.text.DateFormat;
 import java.util.Collection;
 import java.util.Date;
@@ -1062,6 +1063,20 @@ public class Java6Assertions {
    * @return the created {@link ThrowableAssert}.
    */
   public static <T extends Throwable> AbstractThrowableAssert<?, T> assertThat(T actual) {
+    return new ThrowableAssert<>(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created {@link ThrowableAssert}.
+   * @since 3.23.1
+   */
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> assertThat(T actual) {
     return new ThrowableAssert<>(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -934,6 +935,20 @@ public class Java6BDDAssertions {
    * @return the created assertion Throwable.
    */
   public static <T extends Throwable> AbstractThrowableAssert<?, T> then(T actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created assertion Throwable.
+   * @since 3.23.1
+   */
+  public static <T extends SQLException> AbstractThrowableAssert<?, T> then(T actual) {
     return assertThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/Java6BDDSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Java6BDDSoftAssertionsProvider.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -860,6 +861,21 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
   @SuppressWarnings("unchecked")
   default <T extends Throwable> ThrowableAssert<T> then(T actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created assertion Throwable.
+   * @since 3.23.1
+   */
+  @SuppressWarnings("unchecked")
+  default <T extends SQLException> ThrowableAssert<T> then(T actual) {
+    return proxy(ThrowableAssert.class, SQLException.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/Java6StandardSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Java6StandardSoftAssertionsProvider.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -852,6 +853,21 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
   @SuppressWarnings("unchecked")
   default <T extends Throwable> ThrowableAssert<T> assertThat(T actual) {
     return proxy(ThrowableAssert.class, Throwable.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created assertion Throwable.
+   * @since 3.23.1
+   */
+  @SuppressWarnings("unchecked")
+  default <T extends SQLException> ThrowableAssert<T> assertThat(T actual) {
+    return proxy(ThrowableAssert.class, SQLException.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -421,6 +422,20 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    */
   default <T extends Throwable> AbstractThrowableAssert<?, T> assertThat(final T actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ThrowableAssert}</code>.
+   * This overload's purpose is to disambiguate the call for <code>{@link SQLException}</code>.
+   * Indeed, this class implements <code>{@link Iterable}</code> and is considered ambiguous.
+   *
+   * @param <T> the type of the actual SQL exception.
+   * @param actual the actual value.
+   * @return the created {@link ThrowableAssert}.
+   * @since 3.23.1
+   */
+  default <T extends SQLException> AbstractThrowableAssert<?, T> assertThat(final T actual) {
     return Assertions.assertThat(actual);
   }
 

--- a/assertj-core/src/main/java9/module-info.java
+++ b/assertj-core/src/main/java9/module-info.java
@@ -38,6 +38,7 @@ module org.assertj.core {
 
   requires static java.logging; // required when printThreadDump is true
   requires static java.management;
+  requires static java.sql;
   requires static java.xml; // used for XML pretty print
   requires static junit;
   requires static net.bytebuddy;

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Date;
@@ -204,6 +205,11 @@ class BDDAssertions_then_Test {
   @Test
   void then_Throwable() {
     then(new IllegalArgumentException("Foo")).hasMessage("Foo");
+  }
+
+  @Test
+  void then_SQLException() {
+    then(new SQLException("Foo")).hasMessage("Foo");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_various_types_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_various_types_Test.java
@@ -34,6 +34,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -233,6 +234,17 @@ class Assumptions_assumeThat_with_various_types_Test {
             assumeThat(actual).isInstanceOf(IllegalArgumentException.class);
           }
         },
+      new AssumptionRunner<SQLException>(new SQLException()) {
+        @Override
+        public void runFailingAssumption() {
+          assumeThat(actual).isInstanceOf(NullPointerException.class);
+        }
+
+        @Override
+        public void runPassingAssumption() {
+          assumeThat(actual).isInstanceOf(SQLException.class);
+        }
+      },
         new AssumptionRunner<ThrowingCallable>(new ThrowingCallable() {
           @Override
           public void call() {

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -645,6 +646,21 @@ class BDDAssumptionsTest {
   @Nested
   class BDDAssumptions_given_Throwable_Test {
     private final Throwable actual = new Exception("Yoda time");
+
+    @Test
+    void should_run_test_when_assumption_passes() {
+      thenCode(() -> given(actual).hasMessage("Yoda time")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_ignore_test_when_assumption_fails() {
+      expectAssumptionNotMetException(() -> given(actual).hasMessage(""));
+    }
+  }
+
+  @Nested
+  class BDDAssumptions_given_SQLException_Test {
+    private final SQLException actual = new SQLException("Yoda time");
 
     @Test
     void should_run_test_when_assumption_passes() {

--- a/assertj-core/src/test/java/org/assertj/core/api/test/Assertions_assertThat_ambiguous_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/test/Assertions_assertThat_ambiguous_Test.java
@@ -16,9 +16,11 @@ import static org.assertj.core.api.Assertions.assertThatIterator;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.PredicateAssert.assertThatPredicate;
 
+import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 // not in org.assertj.core.api package to avoid resolving classes from it
@@ -34,6 +36,15 @@ class Assertions_solving_assertThat_ambiguous_Test {
     // assertions from AssertionsForClassTypes.assertThat
     assertThat("").isEmpty();
     assertThat(2L).isPositive();
+  }
+
+  @Test
+  void should_resolve_ambiguous_assertThat_for_SqlException() {
+    // GIVEN
+    SQLException sqlException = new SQLException("test");
+
+    // WHEN/THEN
+    Assertions.assertThat(sqlException).hasMessage("test");
   }
 
   static class IteratorPredicate<T> implements Iterator<T>, Predicate<T> {


### PR DESCRIPTION
The goal is to disambiguate these calls. Indeed, SQLException implements Iterable, which creates ambiguity between assertThat(Iterable) and assertThat(Throwable).

#### Check List:
* Fixes #2721 
* Unit tests: YES
* Javadoc with a code example (on API only): YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
