### PR TITLE
Add missing description to nested condition

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
+++ b/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
@@ -174,6 +174,11 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
       public Description conditionDescriptionWithStatus(ACTUAL actual) {
         return condition.conditionDescriptionWithStatus(extractor.apply(actual));
       }
+
+      @Override
+      public Description description() {
+        return condition.description();
+      }
     };
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
+++ b/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
@@ -164,7 +164,7 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
   }
 
   private static <ACTUAL, NESTED> Condition<ACTUAL> compose(Condition<NESTED> condition, Function<ACTUAL, NESTED> extractor) {
-    return new Condition<ACTUAL>() {
+    return new Condition<ACTUAL>(condition.description()) {
       @Override
       public boolean matches(ACTUAL value) {
         return condition.matches(extractor.apply(value));
@@ -173,11 +173,6 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
       @Override
       public Description conditionDescriptionWithStatus(ACTUAL actual) {
         return condition.conditionDescriptionWithStatus(extractor.apply(actual));
-      }
-
-      @Override
-      public Description description() {
-        return condition.description();
       }
     };
   }

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
@@ -47,6 +47,6 @@ class NestableCondition_description_Test {
                                             "      first line: 11, Downing Street,\n" +
                                             "      postcode: SW1A 2AA\n" +
                                             "   ]\n" +
-                                            "  ]");
+                                            "]");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.condition;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.condition.NestableConditionFixtures.address;
 import static org.assertj.core.condition.NestableConditionFixtures.customer;
@@ -39,14 +40,14 @@ class NestableCondition_description_Test {
                                                      firstLine("11, Downing Street"),
                                                      postcode("SW1A 2AA")));
     // THEN
-    then(condition.description().value()).isEqualTo("customer:[\n" +
-                                            "   name:[\n" +
-                                            "      first: John\n" +
-                                            "   ],\n" +
-                                            "   address:[\n" +
-                                            "      first line: 11, Downing Street,\n" +
-                                            "      postcode: SW1A 2AA\n" +
-                                            "   ]\n" +
-                                            "]");
+    then(condition.description().value()).isEqualTo(format("customer:[%n" +
+                                            "   name:[%n" +
+                                            "      first: John%n" +
+                                            "   ],%n" +
+                                            "   address:[%n" +
+                                            "      first line: 11, Downing Street,%n" +
+                                            "      postcode: SW1A 2AA%n" +
+                                            "   ]%n" +
+                                            "]"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_description_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.condition;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.condition.NestableConditionFixtures.address;
+import static org.assertj.core.condition.NestableConditionFixtures.customer;
+import static org.assertj.core.condition.NestableConditionFixtures.first;
+import static org.assertj.core.condition.NestableConditionFixtures.firstLine;
+import static org.assertj.core.condition.NestableConditionFixtures.name;
+import static org.assertj.core.condition.NestableConditionFixtures.postcode;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link NestableCondition#description()}}</code>.
+ * 
+ * @author Alessandro Ciccimarra
+ */
+class NestableCondition_description_Test {
+  @Test
+  void should_return_description_for_nested_conditions() {
+    // GIVEN
+    Condition<Customer> condition = customer(
+                                             name(
+                                                  first("John")),
+                                             address(
+                                                     firstLine("11, Downing Street"),
+                                                     postcode("SW1A 2AA")));
+    // THEN
+    then(condition.description().value()).isEqualTo("customer:[\n" +
+                                            "   name:[\n" +
+                                            "      first: John\n" +
+                                            "   ],\n" +
+                                            "   address:[\n" +
+                                            "      first line: 11, Downing Street,\n" +
+                                            "      postcode: SW1A 2AA\n" +
+                                            "   ]\n" +
+                                            "  ]");
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-osgi/verify.bndrun
+++ b/assertj-tests/assertj-integration-tests/assertj-core-osgi/verify.bndrun
@@ -37,5 +37,5 @@
 	junit-platform-commons;version='[1.9.0,1.9.1)',\
 	junit-platform-engine;version='[1.9.0,1.9.1)',\
 	junit-platform-launcher;version='[1.9.0,1.9.1)',\
-	net.bytebuddy.byte-buddy;version='[1.12.13,1.12.14)',\
+	net.bytebuddy.byte-buddy;version='[1.12.14,1.12.15)',\
 	org.opentest4j;version='[1.2.0,1.2.1)'


### PR DESCRIPTION
#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Calling the `description()` method of a nested condition is currently returning empty strings, e.g.:
```java
customer(
   name(
      first("John")),
      address(
         firstLine("11, Downing Street"),
         postcode("SW1A 2AA"))).description()
```
is
```
customer:[
     name:[
        
     ],
     address:[
        ,
        
     ]
  ]
```
but we should have:
```
customer:[
     name:[
        first: John
     ],
     address:[
        first line: 11, Downing Street,
        postcode: SW1A 2AA
     ]
  ]
```
This PR fixes the issue.