### PR TITLE
Draft: Testing Module Testing with Maven for #2760

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -3019,7 +3019,7 @@ public final class BDDAssumptions extends Assumptions {
    * Executed test:
    * <pre><code class='java'> {@literal @Test}
    * public void given_the_assumption_is_met_the_test_is_executed() {
-   *   given(new File("file.ext").toPath()).isRelative();
+   *   given(ResourceUtil.getResource("file.ext")).isRelative();
    *   // the remaining code is executed
    *   // ...
    * }</code></pre>
@@ -3027,7 +3027,7 @@ public final class BDDAssumptions extends Assumptions {
    * Skipped test:
    * <pre><code class='java'> {@literal @Test}
    * public void given_the_assumption_is_not_met_the_test_is_skipped() {
-   *   given(new File("file.ext").toPath()).isAbsolute();
+   *   given(ResourceUtil.getResource("file.ext")).isAbsolute();
    *   // the remaining code is NOT executed.
    *   // ...
    *}</code></pre>

--- a/assertj-core/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class Assertions_linesOf_Test {
@@ -30,14 +31,14 @@ class Assertions_linesOf_Test {
 
   @Test
   void should_read_lines_of_file_with_UTF8_charset() {
-    File file = new File("src/test/resources/utf8.txt");
+    File file = ResourceUtil.getResource("utf8.txt").toFile();
     assertThat(linesOf(file, "UTF-8")).isEqualTo(EXPECTED_CONTENT);
     assertThat(linesOf(file, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
   }
 
   @Test
   void should_read_lines_of_path_with_UTF8_charset() {
-    Path path = Paths.get("src", "test", "resources", "utf8.txt");
+    Path path = ResourceUtil.getResource("utf8.txt");
     assertThat(linesOf(path, "UTF-8")).isEqualTo(EXPECTED_CONTENT);
     assertThat(linesOf(path, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -99,6 +99,7 @@ import org.assertj.core.test.Animal;
 import org.assertj.core.test.CartoonCharacter;
 import org.assertj.core.test.Name;
 import org.assertj.core.test.Person;
+import org.assertj.core.util.ResourceUtil;
 import org.assertj.core.util.VisibleForTesting;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -1877,7 +1878,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void path_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
     // GIVEN
-    Path path = new File("src/test/resources/actual_file.txt").toPath();
+    Path path = ResourceUtil.getResource("actual_file.txt");
     // WHEN
     softly.then(path)
           .overridingErrorMessage("error message")
@@ -1900,7 +1901,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void file_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     softly.then(file)
           .overridingErrorMessage("error message")
@@ -1923,7 +1924,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void file_soft_assertions_should_work_with_navigation_methods() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     softly.then(file)
           .overridingErrorMessage("error message")

--- a/assertj-core/src/test/java/org/assertj/core/api/EntryPointAssertions_contentOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/EntryPointAssertions_contentOf_Test.java
@@ -22,6 +22,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,7 +34,7 @@ class EntryPointAssertions_contentOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileContentOfWithCharsetFunctions")
   void should_read_file_content_with_charset(BiFunction<File, Charset, String> contentOfWithCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/utf8.txt");
+    File sampleFile = ResourceUtil.getResource("utf8.txt").toFile();
     // WHEN
     String content = contentOfWithCharsetFunction.apply(sampleFile, UTF_8);
     // THEN
@@ -48,7 +49,7 @@ class EntryPointAssertions_contentOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileContentOfWithCharsetAsStringFunctions")
   void should_read_file_content_with_charset_as_string(BiFunction<File, String, String> contentOfWithCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/utf8.txt");
+    File sampleFile = ResourceUtil.getResource("utf8.txt").toFile();
     // WHEN
     String content = contentOfWithCharsetFunction.apply(sampleFile, "UTF8");
     // THEN
@@ -63,7 +64,7 @@ class EntryPointAssertions_contentOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileContentOfWithDefaultCharsetFunctions")
   void should_read_file_content_with_default_charset(Function<File, String> contentOfWithDefaultCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/ascii.txt");
+    File sampleFile = ResourceUtil.getResource("ascii.txt").toFile();
     // WHEN
     String content = contentOfWithDefaultCharsetFunction.apply(sampleFile);
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/EntryPointAssertions_linesOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/EntryPointAssertions_linesOf_Test.java
@@ -25,6 +25,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,7 +37,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileLinesOfWithCharsetFunctions")
   void should_read_file_lines_with_charset(BiFunction<File, Charset, List<String>> linesOfWithCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/utf8.txt");
+    File sampleFile = ResourceUtil.getResource("utf8.txt").toFile();
     // WHEN
     List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, UTF_8);
     // THEN
@@ -51,7 +52,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileLinesOfWithCharsetAsStringFunctions")
   void should_read_file_lines_with_charset_as_string(BiFunction<File, String, List<String>> linesOfWithCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/utf8.txt");
+    File sampleFile = ResourceUtil.getResource("utf8.txt").toFile();
     // WHEN
     List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, "UTF8");
     // THEN
@@ -66,7 +67,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("fileLinesOfWithDefaultCharsetFunctions")
   void should_read_file_lines_with_default_charset(Function<File, List<String>> linesOfWithDefaultCharsetFunction) {
     // GIVEN
-    File sampleFile = new File("src/test/resources/ascii.txt");
+    File sampleFile = ResourceUtil.getResource("ascii.txt").toFile();
     // WHEN
     List<String> lines = linesOfWithDefaultCharsetFunction.apply(sampleFile);
     // THEN
@@ -81,7 +82,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("pathLinesOfWithCharsetFunctions")
   void should_read_path_lines_with_charset(BiFunction<Path, Charset, List<String>> linesOfWithCharsetFunction) {
     // GIVEN
-    Path sampleFile = Paths.get("src", "test", "resources", "utf8.txt");
+    Path sampleFile = ResourceUtil.getResource("utf8.txt");
     // WHEN
     List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, UTF_8);
     // THEN
@@ -96,7 +97,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("pathLinesOfWithCharsetAsStringFunctions")
   void should_read_path_lines_with_charset_as_string(BiFunction<Path, String, List<String>> linesOfWithCharsetFunction) {
     // GIVEN
-    Path sampleFile = Paths.get("src", "test", "resources", "utf8.txt");
+    Path sampleFile = ResourceUtil.getResource("utf8.txt");
     // WHEN
     List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, "UTF8");
     // THEN
@@ -111,7 +112,7 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   @MethodSource("pathLinesOfWithDefaultCharsetFunctions")
   void should_read_path_lines_with_default_charset(Function<Path, List<String>> linesOfWithDefaultCharsetFunction) {
     // GIVEN
-    Path sampleFile = Paths.get("src", "test", "resources", "ascii.txt");
+    Path sampleFile = ResourceUtil.getResource("ascii.txt");
     // WHEN
     List<String> lines = linesOfWithDefaultCharsetFunction.apply(sampleFile);
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -100,6 +100,7 @@ import org.assertj.core.test.CaseInsensitiveStringComparator;
 import org.assertj.core.test.Name;
 import org.assertj.core.test.Person;
 import org.assertj.core.util.Lists;
+import org.assertj.core.util.ResourceUtil;
 import org.assertj.core.util.VisibleForTesting;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -2544,7 +2545,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void path_soft_assertions_should_work_with_content() {
     // GIVEN
-    Path path = new File("src/test/resources/actual_file.txt").toPath();
+    Path path = ResourceUtil.getResource("actual_file.txt");
     // WHEN
     softly.assertThat(path)
           .overridingErrorMessage("error message")
@@ -2567,7 +2568,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void file_soft_assertions_should_report_errors_on_methods_that_switch_the_object_under_test() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     softly.assertThat(file)
           .overridingErrorMessage("error message")
@@ -2590,7 +2591,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void file_soft_assertions_should_work_with_navigation_methods() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     softly.assertThat(file)
           .overridingErrorMessage("error message")
@@ -2611,7 +2612,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void file_soft_assertions_should_work_with_binaryContent() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     softly.assertThat(file)
           .overridingErrorMessage("error message")
@@ -2632,7 +2633,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   @Test
   void path_soft_assertions_should_work_with_binaryContent() {
     // GIVEN
-    Path path = new File("src/test/resources/actual_file.txt").toPath();
+    Path path = ResourceUtil.getResource("actual_file.txt");
     // WHEN
     softly.assertThat(path)
           .overridingErrorMessage("error message")

--- a/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_Test.java
@@ -36,6 +36,7 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.ThrowingConsumer;
 import org.assertj.core.data.TolkienCharacter;
 import org.assertj.core.description.TextDescription;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -105,7 +106,7 @@ class AbstractAssert_satisfiesAnyOf_Test extends AbstractAssertBaseTest {
     ThrowingConsumer<Reader> hasNotReachedEOF = reader -> assertThat(reader.read()).isPositive();
     Consumer<Object> notNullObject = object -> assertThat(object).isNotNull();
     // THEN
-    then(new FileReader("src/test/resources/ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, notNullObject);
+    then(ResourceUtil.getResourceAsReader("ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, notNullObject);
   }
   
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test.java
@@ -29,6 +29,7 @@ import org.assertj.core.api.ConcreteAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.ThrowingConsumer;
 import org.assertj.core.description.TextDescription;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -64,7 +65,7 @@ class AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test extends AbstractAsser
     ThrowingConsumer<FileReader> hasReachedEOF = reader -> assertThat(reader.read()).isEqualTo(-1);
     ThrowingConsumer<FileReader> startsWithZ = reader -> assertThat(reader.read()).isEqualTo('Z');
     // THEN
-    then(new FileReader("src/test/resources/empty.txt")).satisfiesAnyOf(hasReachedEOF, startsWithZ);
+    then(ResourceUtil.getResourceAsReader("empty.txt")).satisfiesAnyOf(hasReachedEOF, startsWithZ);
   }
 
   @Test
@@ -73,7 +74,7 @@ class AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test extends AbstractAsser
     ThrowingConsumer<FileReader> hasNotReachedEOF = reader -> assertThat(reader.read()).isPositive();
     ThrowingConsumer<FileReader> startsWitha = reader -> assertThat(reader.read()).isEqualTo('a');
     // THEN
-    then(new FileReader("src/test/resources/ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, startsWitha);
+    then(ResourceUtil.getResourceAsReader("ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, startsWitha);
   }
 
   @Test
@@ -82,16 +83,16 @@ class AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test extends AbstractAsser
     ThrowingConsumer<Reader> hasNotReachedEOF = reader -> assertThat(reader.read()).isPositive();
     ThrowingConsumer<Object> notNullObject = object -> assertThat(object).isNotNull();
     // THEN
-    then(new FileReader("src/test/resources/ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, notNullObject);
+    then(ResourceUtil.getResourceAsReader("ascii.txt")).satisfiesAnyOf(hasNotReachedEOF, notNullObject);
   }
-  
+
   @Test
   void should_fail_if_all_of_the_given_assertions_groups_fail() {
     // GIVEN
     ThrowingConsumer<FileReader> hasReachedEOF = reader -> assertThat(reader.read()).isEqualTo(-1);
     ThrowingConsumer<FileReader> startsWithZ = reader -> assertThat(reader.read()).isEqualTo('Z');
     // WHEN/THEN
-    expectAssertionError(() -> assertThat(new FileReader("src/test/resources/ascii.txt")).satisfiesAnyOf(hasReachedEOF,
+    expectAssertionError(() -> assertThat(ResourceUtil.getResourceAsReader("ascii.txt")).satisfiesAnyOf(hasReachedEOF,
                                                                                                          startsWithZ));
   }
 
@@ -100,7 +101,7 @@ class AbstractAssert_satisfiesAnyOf_ThrowingConsumers_Test extends AbstractAsser
     // GIVEN
     ThrowingConsumer<FileReader> hasReachedEOF = reader -> assertThat(reader.read()).isEqualTo(-1);
     // WHEN/THEN
-    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(new FileReader("src/test/resources/empty.txt")).satisfiesAnyOf(hasReachedEOF,
+    assertThatIllegalArgumentException().isThrownBy(() -> assertThat(ResourceUtil.getResourceAsReader("empty.txt")).satisfiesAnyOf(hasReachedEOF,
                                                                                                                                     null))
                                         .withMessage("No assertions group should be null");
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfies_with_ThrowingConsumers_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_satisfies_with_ThrowingConsumers_Test.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
@@ -32,7 +33,7 @@ class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
   @Test
   void should_pass_satisfying_single_requirement() {
     // GIVEN
-    Path emptyFile = Paths.get("src/test/resources/empty.txt");
+    Path emptyFile = ResourceUtil.getResource("empty.txt");
     ThrowingConsumer<Path> isEmpty = path -> assertThat(readAllLines(path)).isEmpty();
     // WHEN/THEN
     then(emptyFile).satisfies(isEmpty);
@@ -41,7 +42,7 @@ class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
   @Test
   void should_pass_satisfying_multiple_requirements() {
     // GIVEN
-    Path emptyFile = Paths.get("src/test/resources/empty.txt");
+    Path emptyFile = ResourceUtil.getResource("empty.txt");
     ThrowingConsumer<Path> readableConsumer = path -> assertThat(isReadable(path)).isTrue();
     ThrowingConsumer<Path> emptyConsumer = path -> assertThat(readAllLines(path)).isEmpty();
     // WHEN/THEN
@@ -59,7 +60,7 @@ class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
   @Test
   void should_fail_not_satisfying_single_requirement() {
     // GIVEN
-    Path asciiFile = Paths.get("src/test/resources/ascii.txt");
+    Path asciiFile = ResourceUtil.getResource("ascii.txt");
     ThrowingConsumer<Path> emptyConsumer = path -> assertThat(readAllLines(path)).isEmpty();
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(asciiFile).satisfies(emptyConsumer));
@@ -70,7 +71,7 @@ class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
   @Test
   void should_fail_not_satisfying_any_requirements() {
     // GIVEN
-    Path asciiFile = Paths.get("src/test/resources/ascii.txt");
+    Path asciiFile = ResourceUtil.getResource("ascii.txt");
     ThrowingConsumer<Path> emptyConsumer = path -> assertThat(readAllLines(path)).as("empty check").isEmpty();
     ThrowingConsumer<Path> directoryConsumer = path -> assertThat(path).as("directory check").isDirectory();
     // WHEN
@@ -82,7 +83,7 @@ class AbstractAssert_satisfies_with_ThrowingConsumers_Test {
   @Test
   void should_fail_not_satisfying_some_requirements() {
     // GIVEN
-    Path asciiFile = Paths.get("src/test/resources/ascii.txt");
+    Path asciiFile = ResourceUtil.getResource("ascii.txt");
     ThrowingConsumer<Path> notEmptyConsumer = path -> assertThat(readAllLines(path)).as("not empty check").isNotEmpty();
     ThrowingConsumer<Path> directoryConsumer = path -> assertThat(path).as("directory check").isDirectory();
     // WHEN

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_binaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_binaryContent_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetExcepti
 import java.io.File;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
  */
 class Assumptions_assumeThat_with_File_binaryContent_Test {
 
-  private static final File FILE = new File("src/test/resources/actual_file.txt");
+  private static final File FILE = ResourceUtil.getResource("actual_file.txt").toFile();
 
   @Test
   void should_run_test_when_assumption_using_file_binaryContent_succeeds() {

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_content_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_content_Test.java
@@ -20,11 +20,12 @@ import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetExcepti
 import java.io.File;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class Assumptions_assumeThat_with_File_content_Test {
 
-  private static final File FILE = new File("src/test/resources/actual_file.txt");
+  private static final File FILE = ResourceUtil.getResource("actual_file.txt").toFile();
 
   @Test
   void should_run_test_when_assumption_using_file_content_succeeds() {

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_File_size_Test.java
@@ -19,11 +19,12 @@ import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetExcepti
 import java.io.File;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class Assumptions_assumeThat_with_File_size_Test {
 
-  private static final File FILE = new File("src/test/resources/actual_file.txt");
+  private static final File FILE = ResourceUtil.getResource("actual_file.txt").toFile();
 
   @Test
   void should_run_test_when_assumption_using_file_size_succeeds() {

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_Path_binaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_Path_binaryContent_Test.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.nio.file.Path;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
  */
 class Assumptions_assumeThat_with_Path_binaryContent_Test {
 
-  private static final Path PATH = new File("src/test/resources/actual_file.txt").toPath();
+  private static final Path PATH = ResourceUtil.getResource("actual_file.txt");
 
   @Test
   void should_run_test_when_assumption_using_path_binaryContent_succeeds() {

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_Path_content_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_Path_content_Test.java
@@ -18,20 +18,55 @@ import static org.assertj.core.api.BDDAssertions.thenCode;
 import static org.assertj.core.util.AssertionsUtil.expectAssumptionNotMetException;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 
+import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
+import org.springframework.util.ResourceUtils;
 
 class Assumptions_assumeThat_with_Path_content_Test {
 
-  private static final Path PATH = new File("src/test/resources/actual_file.txt").toPath();
+  private static final Path PATH = ResourceUtil.getResource("actual_file.txt");
 
   @Test
   void should_run_test_when_assumption_using_path_content_succeeds() {
     // WHEN
     ThrowingCallable assumptionCode = () -> assumeThat(PATH).content().contains("actual");
     // THEN
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
+    System.out.println(PATH.toString());
     thenCode(assumptionCode).doesNotThrowAnyException();
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_various_types_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_with_various_types_Test.java
@@ -47,6 +47,7 @@ import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.test.ComparableExample;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -189,7 +190,7 @@ class Assumptions_assumeThat_with_various_types_Test {
             assumeThat(actual).hasName("test");
           }
         },
-        new AssumptionRunner<Path>(new File("test").toPath()) {
+        new AssumptionRunner<Path>(ResourceUtil.getResource("test")) {
           @Override
           public void runFailingAssumption() {
             assumeThat(actual).isNull();

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/BDDAssumptionsTest.java
@@ -71,6 +71,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1362,7 +1363,7 @@ class BDDAssumptionsTest {
 
   @Nested
   class BDDAssumptions_given_Path_Test {
-    private final Path actual = new File("file.ext").toPath();
+    private final Path actual = ResourceUtil.getResource("file.ext");
 
     @Test
     void should_run_test_when_assumption_passes() {

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isXmlEqualToContentOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isXmlEqualToContentOf_Test.java
@@ -19,6 +19,7 @@ import java.io.File;
 
 import org.assertj.core.api.CharSequenceAssert;
 import org.assertj.core.api.CharSequenceAssertBaseTest;
+import org.assertj.core.util.ResourceUtil;
 
 /**
  * Tests for <code>{@link org.assertj.core.api.CharSequenceAssert#isXmlEqualToContentOf(java.io.File)}</code>.
@@ -27,7 +28,7 @@ import org.assertj.core.api.CharSequenceAssertBaseTest;
  */
 class CharSequenceAssert_isXmlEqualToContentOf_Test extends CharSequenceAssertBaseTest {
 
-  private File xmlFile = new File("src/test/resources/expected.xml");
+  private File xmlFile = ResourceUtil.getResource("expected.xml").toFile();
 
   @Override
   protected CharSequenceAssert invoke_api_method() {

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_binaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_binaryContent_Test.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.AbstractByteArrayAssert;
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class FileAssert_binaryContent_Test extends FileAssertBaseTest implements NavigationMethodBaseTest<FileAssert> {
@@ -41,13 +42,13 @@ class FileAssert_binaryContent_Test extends FileAssertBaseTest implements Naviga
 
   @Override
   protected FileAssert create_assertions() {
-    return new FileAssert(new File("src/test/resources/actual_file.txt"));
+    return new FileAssert(ResourceUtil.getResource("actual_file.txt").toFile());
   }
 
   @Test
   void should_return_ByteArrayAssert_on_path_content() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     AbstractByteArrayAssert<?> byteArrayAssert = assertThat(file).binaryContent();
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_content_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_content_Test.java
@@ -23,6 +23,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class FileAssert_content_Test extends FileAssertBaseTest implements NavigationMethodBaseTest<FileAssert> {
@@ -40,13 +41,13 @@ class FileAssert_content_Test extends FileAssertBaseTest implements NavigationMe
   
   @Override
   protected FileAssert create_assertions() {
-    return new FileAssert(new File("src/test/resources/actual_file.txt"));
+    return new FileAssert(ResourceUtil.getResource("actual_file.txt").toFile());
   }
 
   @Test
   public void should_return_StringAssert_on_path_content() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     AbstractStringAssert<?> stringAssert = assertThat(file).content();
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_content_with_charset_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_content_with_charset_Test.java
@@ -23,6 +23,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class FileAssert_content_with_charset_Test extends FileAssertBaseTest implements NavigationMethodBaseTest<FileAssert> {
@@ -40,13 +41,13 @@ class FileAssert_content_with_charset_Test extends FileAssertBaseTest implements
 
   @Override
   protected FileAssert create_assertions() {
-    return new FileAssert(new File("src/test/resources/utf8.txt"));
+    return new FileAssert(ResourceUtil.getResource("utf8.txt").toFile());
   }
 
   @Test
   public void should_return_StringAssert_on_path_content() {
     // GIVEN
-    File file = new File("src/test/resources/utf8.txt");
+    File file = ResourceUtil.getResource("utf8.txt").toFile();
     // WHEN
     AbstractStringAssert<?> stringAssert = assertThat(file).content(UTF_8);
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.io.File;
 
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class FileAssert_size_Test {
@@ -25,7 +26,7 @@ class FileAssert_size_Test {
   @Test
   void should_be_able_to_use_file_assertions_on_file_size() {
     // GIVEN
-    File file = new File("src/test/resources/actual_file.txt");
+    File file = ResourceUtil.getResource("actual_file.txt").toFile();
     // THEN
     then(file).size()
               .isGreaterThan(4L)

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_binaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_binaryContent_Test.java
@@ -25,6 +25,7 @@ import org.assertj.core.api.AbstractByteArrayAssert;
 import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.PathAssert;
 import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,13 +46,13 @@ class PathAssert_binaryContent_Test extends PathAssertBaseTest implements Naviga
 
   @Override
   protected PathAssert create_assertions() {
-    return new PathAssert(new File("src/test/resources/actual_file.txt").toPath());
+    return new PathAssert(ResourceUtil.getResource("actual_file.txt"));
   }
 
   @Test
   void should_return_ByteArrayAssert_on_path_content() {
     // GIVEN
-    Path path = new File("src/test/resources/actual_file.txt").toPath();
+    Path path = ResourceUtil.getResource("actual_file.txt");
     // WHEN
     AbstractByteArrayAssert<?> byteAssert = assertThat(path).binaryContent();
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_content_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_content_Test.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.PathAssert;
 import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class PathAssert_content_Test extends PathAssertBaseTest implements NavigationMethodBaseTest<PathAssert> {
@@ -41,13 +42,13 @@ class PathAssert_content_Test extends PathAssertBaseTest implements NavigationMe
 
   @Override
   protected PathAssert create_assertions() {
-    return new PathAssert(new File("src/test/resources/actual_file.txt").toPath());
+    return new PathAssert(ResourceUtil.getResource("actual_file.txt"));
   }
 
   @Test
   public void should_return_StringAssert_on_path_content() {
     // GIVEN
-    Path path = new File("src/test/resources/actual_file.txt").toPath();
+    Path path = ResourceUtil.getResource("actual_file.txt");
     // WHEN
     AbstractStringAssert<?> stringAssert = assertThat(path).content();
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_content_with_charset_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_content_with_charset_Test.java
@@ -24,6 +24,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.NavigationMethodBaseTest;
 import org.assertj.core.api.PathAssert;
 import org.assertj.core.api.PathAssertBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class PathAssert_content_with_charset_Test extends PathAssertBaseTest implements NavigationMethodBaseTest<PathAssert> {
@@ -41,13 +42,13 @@ class PathAssert_content_with_charset_Test extends PathAssertBaseTest implements
 
   @Override
   protected PathAssert create_assertions() {
-    return new PathAssert(new File("src/test/resources/utf8.txt").toPath());
+    return new PathAssert(ResourceUtil.getResource("utf8.txt"));
   }
 
   @Test
   public void should_return_StringAssert_on_path_content_with_given_charset() {
     // GIVEN
-    Path path = new File("src/test/resources/utf8.txt").toPath();
+    Path path = ResourceUtil.getResource("utf8.txt");
     // WHEN
     AbstractStringAssert<?> stringAssert = assertThat(path).content(UTF_8);
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/File_assertHasSize_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/File_assertHasSize_Test.java
@@ -24,6 +24,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +39,7 @@ class File_assertHasSize_Test extends FilesBaseTest {
 
   @BeforeAll
   static void setUpOnce() {
-    actual = new File("src/test/resources/actual_file.txt");
+    actual = ResourceUtil.getResource("actual_file.txt").toFile();
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,7 +56,7 @@ class Files_assertCanRead_Test extends FilesBaseTest {
 
   @Test
   void should_pass_if_actual_can_read() {
-    File actual = new File("src/test/resources/actual_file.txt");
+    File actual = ResourceUtil.getResource("actual_file.txt").toFile();
     files.assertCanRead(INFO, actual);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,7 +47,7 @@ class Files_assertDoesNotExist_Test extends FilesBaseTest {
   @Test
   void should_fail_if_actual_exists() {
     // GIVEN
-    File actual = new File("src/test/resources/actual_file.txt");
+    File actual = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     expectAssertionError(() -> files.assertDoesNotExist(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -55,7 +56,7 @@ class Files_assertExists_Test extends FilesBaseTest {
 
   @Test
   void should_pass_if_actual_exists() {
-    File actual = new File("src/test/resources/actual_file.txt");
+    File actual = ResourceUtil.getResource("actual_file.txt").toFile();
     files.assertExists(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
@@ -31,6 +31,7 @@ import org.assertj.core.internal.BinaryDiff;
 import org.assertj.core.internal.BinaryDiffResult;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
   @BeforeAll
   static void setUpOnce() {
     // Does not matter if the values differ, the actual comparison is mocked in this test
-    actual = new File("src/test/resources/actual_file.txt");
+    actual = ResourceUtil.getResource("actual_file.txt").toFile();
     expected = new byte[] {};
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -31,6 +31,7 @@ import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Diff;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
   @BeforeAll
   static void setUpOnce() {
     // Does not matter if the values differ, the actual comparison is mocked in this test
-    actual = new File("src/test/resources/actual_file.txt");
+    actual = ResourceUtil.getResource("actual_file.txt").toFile();
     expected = "xyz";
     charset = Charset.defaultCharset();
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
@@ -31,6 +31,7 @@ import java.io.UncheckedIOException;
 import org.assertj.core.internal.BinaryDiff;
 import org.assertj.core.internal.BinaryDiffResult;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
@@ -42,8 +43,8 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
   @BeforeAll
   static void setUpOnce() throws IOException {
     // Does not matter if the values differ, the actual comparison is mocked in this test
-    actual = new File("src/test/resources/actual_file.txt");
-    expected = new File("src/test/resources/expected_file.txt");
+    actual = ResourceUtil.getResource("actual_file.txt").toFile();
+    expected = ResourceUtil.getResource("expected_file.txt").toFile();
     expectedBytes = readAllBytes(expected.toPath());
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyFile_Test.java
@@ -27,6 +27,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,7 +48,7 @@ class Files_assertIsEmptyFile_Test extends FilesBaseTest {
   @Test
   void should_fail_if_actual_is_not_empty() {
     // GIVEN
-    File actual = new File("src/test/resources/actual_file.txt");
+    File actual = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     expectAssertionError(() -> files.assertIsEmptyFile(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyFile_Test.java
@@ -27,6 +27,7 @@ import java.io.File;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,7 +38,7 @@ class Files_assertIsNotEmptyFile_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_is_not_empty() {
     // GIVEN
-    File actual = new File("src/test/resources/actual_file.txt");
+    File actual = ResourceUtil.getResource("actual_file.txt").toFile();
     // WHEN
     files.assertIsNotEmptyFile(INFO, actual);
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
@@ -20,10 +20,12 @@ import static org.assertj.core.util.Files.newFile;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -57,7 +59,8 @@ class Files_assertIsRelative_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_is_relative_path() {
     // GIVEN
-    File actual = new File("src/test/resources/actual_file.txt");
+    Path actualPath = ResourceUtil.getResource("actual_file.txt");
+    File actual = actualPath.relativize(actualPath.getParent()).toFile();
     // THEN
     files.assertIsRelative(INFO, actual);
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.assertj.core.internal.Diff;
 import org.assertj.core.internal.FilesBaseTest;
 import org.assertj.core.util.Files;
+import org.assertj.core.util.ResourceUtil;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -53,8 +54,8 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @BeforeAll
   static void setUpOnce() {
-    actual = new File("src/test/resources/actual_file.txt");
-    expected = new File("src/test/resources/expected_file.txt");
+    actual = ResourceUtil.getResource("actual_file.txt").toFile();
+    expected = ResourceUtil.getResource("expected_file.txt").toFile();
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/Files_contentOf_Test.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
  * @author Olivier Michallat
  */
 class Files_contentOf_Test {
-  private final File sampleFile = new File("src/test/resources/utf8.txt");
+  private final File sampleFile = ResourceUtil.getResource("utf8.txt").toFile();
   private final String expectedContent = "A text file encoded in UTF-8, with diacritics:\né à";
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/Files_linesOf_Test.java
@@ -34,9 +34,9 @@ import org.junit.jupiter.api.Test;
  */
 class Files_linesOf_Test {
 
-  private static final File SAMPLE_UNIX_FILE = new File("src/test/resources/utf8.txt");
-  private static final File SAMPLE_WIN_FILE = new File("src/test/resources/utf8_win.txt");
-  private static final File SAMPLE_MAC_FILE = new File("src/test/resources/utf8_mac.txt");
+  private static final File SAMPLE_UNIX_FILE = ResourceUtil.getResource("utf8.txt").toFile();
+  private static final File SAMPLE_WIN_FILE = ResourceUtil.getResource("utf8_win.txt").toFile();
+  private static final File SAMPLE_MAC_FILE = ResourceUtil.getResource("utf8_mac.txt").toFile();
 
   private static final List<String> EXPECTED_CONTENT = newArrayList("A text file encoded in UTF-8, with diacritics:", "é à");
   public static final String UTF_8 = "UTF-8";

--- a/assertj-core/src/test/java/org/assertj/core/util/Paths_linesOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/Paths_linesOf_Test.java
@@ -35,11 +35,9 @@ import org.junit.jupiter.api.Test;
  */
 class Paths_linesOf_Test {
 
-  private static final Path RESOURCES_DIRECTORY = java.nio.file.Paths.get("src", "test", "resources");
-
-  private static final Path SAMPLE_UNIX_FILE = RESOURCES_DIRECTORY.resolve("utf8.txt");
-  private static final Path SAMPLE_WIN_FILE = RESOURCES_DIRECTORY.resolve("utf8_win.txt");
-  private static final Path SAMPLE_MAC_FILE = RESOURCES_DIRECTORY.resolve("utf8_mac.txt");
+  private static final Path SAMPLE_UNIX_FILE = ResourceUtil.getResource("utf8.txt");
+  private static final Path SAMPLE_WIN_FILE = ResourceUtil.getResource("utf8_win.txt");
+  private static final Path SAMPLE_MAC_FILE = ResourceUtil.getResource("utf8_mac.txt");
 
   private static final List<String> EXPECTED_CONTENT = newArrayList("A text file encoded in UTF-8, with diacritics:", "é à");
   public static final String UTF_8 = "UTF-8";

--- a/assertj-core/src/test/java/org/assertj/core/util/ResourceUtil.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/ResourceUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+
+/**
+ * Utility methods for loading test resources.
+ * @author Simon Schrottner
+ */
+public final class ResourceUtil {
+
+    private ResourceUtil() {}
+
+    public static Path getResource(String path) {
+        URL resource = ResourceUtil.class.getClassLoader().getResource(path);
+        if(Objects.nonNull(resource)) {
+            return Paths.get(resource.getPath());
+        } else {
+            return new File(path).toPath();
+        }
+    }
+    public static FileReader getResourceAsReader(String path) throws FileNotFoundException {
+        return new FileReader(getResource(path).toAbsolutePath().toString());
+    }
+}

--- a/assertj-core/src/test/java/org/assertj/core/util/diff/GenerateUnifiedDiffTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/diff/GenerateUnifiedDiffTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.util.Files;
+import org.assertj.core.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 class GenerateUnifiedDiffTest {
@@ -28,14 +29,11 @@ class GenerateUnifiedDiffTest {
   /** File separator. */
   private static final String FS = File.separator;
 
-  /** The base resource path. */
-  private static String BASE_FOLDER_RESOURCES = "src" + FS + "test" + FS + "resources";
-
   /** The base folder containing the test files. Ends with {@link #FS}. */
-  private static final String MOCK_FOLDER = BASE_FOLDER_RESOURCES + FS + "diffs" + FS;
+  private static final String MOCK_FOLDER =  "diffs" + FS;
 
   private List<String> fileToLines(String filename) {
-    return Files.linesOf(new File(MOCK_FOLDER, filename), Charset.defaultCharset());
+    return Files.linesOf(ResourceUtil.getResource(MOCK_FOLDER+filename).toFile(), Charset.defaultCharset());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit5_Assertions_To_Assertj_Test.java
+++ b/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit5_Assertions_To_Assertj_Test.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -27,6 +28,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author XiaoMingZHM, Eveneko
  */
 @DisplayName("Convert JUnit5 assertions to AssertJ")
+@DisabledIfEnvironmentVariable(named = "MODULAR_TEST", matches = "true")
 public class Convert_Junit5_Assertions_To_Assertj_Test {
   private ShellScriptInvoker tester;
 

--- a/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit_Assertions_To_Assertj_Test.java
+++ b/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit_Assertions_To_Assertj_Test.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 
 @DisplayName("Convert JUnit assertions to AssertJ")
+@DisabledIfEnvironmentVariable(named = "MODULAR_TEST", matches = "true")
 public class Convert_Junit_Assertions_To_Assertj_Test {
   private ShellScriptInvoker conversionScriptInvoker;
 

--- a/assertj-tests/assertj-module-tests/pom.xml
+++ b/assertj-tests/assertj-module-tests/pom.xml
@@ -9,35 +9,35 @@
         <version>3.24.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>assertj-core-moduletest</artifactId>
+    <artifactId>assertj-module-tests</artifactId>
 
     <name>AssertJ Core Module Tests</name>
     <properties>
         <java.version>11</java.version>
-        <hamcrest.version>2.2</hamcrest.version>
     </properties>
     <build>
-        <testSourceDirectory>../../assertj-core/src/test/java</testSourceDirectory>
-        <testResources>
-            <testResource>
-                <directory>../../assertj-core/src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>module-info</id>
+                        <id>copy-resource-one</id>
+                        <phase>generate-test-resources</phase>
                         <goals>
-                            <goal>testCompile</goal>
+                            <goal>copy-resources</goal>
                         </goals>
+
                         <configuration>
-                            <compileSourceRoots>
-                                <!--                                <compileSourceRoot>${project.build.testSourceDirectory}</compileSourceRoot>-->
-                                <compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
-                            </compileSourceRoots>
+                            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../../assertj-core/target/test-classes</directory>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>
@@ -51,6 +51,46 @@
                     </environmentVariables>
                 </configuration>
             </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>default-testCompile</id>-->
+<!--                        <goals>-->
+<!--                            <goal>testCompile</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <compileSourceRoots>-->
+<!--                                <compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>-->
+<!--                                <compileSourceRoot>../../assertj-core/src/test/java</compileSourceRoot>-->
+<!--                            </compileSourceRoots>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-resources-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>default-testResources</id>-->
+<!--                        <goals>-->
+<!--                            <goal>testResources</goal>-->
+<!--                        </goals>-->
+<!--                        <configuration>-->
+<!--                            <resources>-->
+<!--                                <resource>-->
+<!--                                    <directory>../../assertj-core/src/test/resources</directory>-->
+<!--                                </resource>-->
+<!--                                <resource>-->
+<!--                                    <directory>${project.basedir}/src/test/resources</directory>-->
+<!--                                </resource>-->
+<!--                            </resources>-->
+<!--                        </configuration>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/assertj-tests/assertj-module-tests/pom.xml
+++ b/assertj-tests/assertj-module-tests/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-tests</artifactId>
+        <version>3.24.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>assertj-core-moduletest</artifactId>
+
+    <name>AssertJ Core Module Tests</name>
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <hamcrest.version>2.2</hamcrest.version>
+        <project.moduleName>org.assertj.core</project.moduleName>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+<!--                    <configuration>-->
+<!--                        <dependenciesToScan>-->
+<!--                            <dependency>org.assertj:assertj-core:test-jar</dependency>-->
+<!--                        </dependenciesToScan>-->
+<!--                    </configuration>-->
+
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+      <!--  <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>-->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/assertj-tests/assertj-module-tests/pom.xml
+++ b/assertj-tests/assertj-module-tests/pom.xml
@@ -42,6 +42,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <MODULAR_TEST>true</MODULAR_TEST>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/assertj-tests/assertj-module-tests/pom.xml
+++ b/assertj-tests/assertj-module-tests/pom.xml
@@ -14,55 +14,114 @@
     <name>AssertJ Core Module Tests</name>
     <properties>
         <java.version>11</java.version>
-        <maven.compiler.release>${java.version}</maven.compiler.release>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
         <hamcrest.version>2.2</hamcrest.version>
-        <project.moduleName>org.assertj.core</project.moduleName>
     </properties>
     <build>
+        <testSourceDirectory>../../assertj-core/src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>../../assertj-core/src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
-<!--                    <configuration>-->
-<!--                        <dependenciesToScan>-->
-<!--                            <dependency>org.assertj:assertj-core:test-jar</dependency>-->
-<!--                        </dependenciesToScan>-->
-<!--                    </configuration>-->
-
+                <executions>
+                    <execution>
+                        <id>module-info</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <!--                                <compileSourceRoot>${project.build.testSourceDirectory}</compileSourceRoot>-->
+                                <compileSourceRoot>${project.basedir}/src/test/java</compileSourceRoot>
+                            </compileSourceRoots>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <dependencies>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>3.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-      <!--  <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${project.version}</version>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>3.18.0</version>
             <scope>test</scope>
-            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.1.2.Final</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
+                    <groupId>jakarta.inject</groupId>
+                    <artifactId>jakarta.inject-api</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>-->
+        </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,16 +140,39 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- required to run JUnit4 tests in eclipse without to explicitly select JUnit 4 runner ... -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.3.22</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- This has to be excluded because it's subjecting the code to the incorrect version of certain hamcrest packages. -->
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/assertj-tests/assertj-module-tests/src/test/java/module-info.java
+++ b/assertj-tests/assertj-module-tests/src/test/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+module org.assertj.moduletest {
+    // AssertJ Core's package API
+    requires org.assertj.core;
+    requires org.junit.jupiter.api;
+    requires org.junit.platform.launcher;
+
+    opens org.assertj.moduletest.api to org.junit.platform.commons;
+    //provides org.assertj.core.configuration.Configuration with org.assertj.core.test.ConfigurationForTests;
+}
+  

--- a/assertj-tests/assertj-module-tests/src/test/java/module-info.java
+++ b/assertj-tests/assertj-module-tests/src/test/java/module-info.java
@@ -16,6 +16,8 @@ module org.assertj.moduletest {
     requires org.junit.jupiter.api;
     requires org.junit.platform.launcher;
 
+    requires static org.hamcrest;
+
     opens org.assertj.moduletest.api to org.junit.platform.commons;
     //provides org.assertj.core.configuration.Configuration with org.assertj.core.test.ConfigurationForTests;
 }

--- a/assertj-tests/assertj-module-tests/src/test/java/org/assertj/moduletest/api/IterableAssert_extracting_Test.java
+++ b/assertj-tests/assertj-module-tests/src/test/java/org/assertj/moduletest/api/IterableAssert_extracting_Test.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.moduletest.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IterableAssert_extracting_Test {
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @Test
+    void should_allow_assertions_on_property_values_extracted_from_given_iterable() {
+        List<String> names = List.of("sith", "jedi", "yoda");
+
+        List<TestObject> testObjects = names.stream().map(TestObject::new).collect(Collectors.toList());
+
+        assertThat(testObjects).extractingResultOf("name").containsAll(names);
+
+
+    }
+
+    static final class TestObject {
+        private final String name;
+
+        TestObject(String name) {
+            this.name = name;
+        }
+
+        public String name() {
+            return name;
+        }
+    }
+
+}
+

--- a/assertj-tests/pom.xml
+++ b/assertj-tests/pom.xml
@@ -38,7 +38,6 @@
             </goals>
             <configuration>
               <rules>
-              <!--
                 <bannedDependencies>
                   <includes>
                     <include>*:*:*:jar:test</include>
@@ -46,7 +45,7 @@
                   <excludes>
                     <exclude>*</exclude>
                   </excludes>
-                </bannedDependencies>-->
+                </bannedDependencies>
                 <dependencyConvergence/>
               </rules>
             </configuration>

--- a/assertj-tests/pom.xml
+++ b/assertj-tests/pom.xml
@@ -15,6 +15,7 @@
   <name>AssertJ Tests</name>
 
   <modules>
+    <module>assertj-module-tests</module>
     <module>assertj-integration-tests</module>
     <module>assertj-performance-tests</module>
   </modules>
@@ -37,6 +38,7 @@
             </goals>
             <configuration>
               <rules>
+              <!--
                 <bannedDependencies>
                   <includes>
                     <include>*:*:*:jar:test</include>
@@ -44,7 +46,7 @@
                   <excludes>
                     <exclude>*</exclude>
                   </excludes>
-                </bannedDependencies>
+                </bannedDependencies>-->
                 <dependencyConvergence/>
               </rules>
             </configuration>


### PR DESCRIPTION
Sorry i simply started experimenting out of curiosity regarding #2760 , and I want to share what I tried and what worked and did not work for such modular tests. Please just close this pr, if you do not think it is fitting. Although if you think, this needs just polishing, let me know, i can adapt and help to make it better.

This pr works, but only has one test - so theoretically it is usable :) 

BUT... i wanted to experiment a little bit more, and maybe make the original unit tests work within this modular module. 

## test-jar approach

I tried adding following to the assertj-core to generate a test jar 
```
<plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-jar-plugin</artifactId>
        <executions>
          <execution>
            <goals>
              <goal>test-jar</goal>
            </goals>
          </execution>
        </executions>
      </plugin>
``` 
and tried to apply it as a dependency within my modular test. Sadly this ended up with a lot of package errors
<details>
  <summary>errors</summary>

```
[ERROR] the unnamed module reads package org.assertj.core.api from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.api.filter from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.api.iterable from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.api.junit.jupiter from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.api.recursive.comparison from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.condition from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.configuration from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.data from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.description from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.error from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.error.future from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.error.uri from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.extractor from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.groups from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.matcher from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.presentation from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.util from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.util.diff from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.util.diff.myers from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.util.introspection from both assertj.core and org.assertj.core
[ERROR] the unnamed module reads package org.assertj.core.util.xml from both assertj.core and org.assertj.core
[ERROR] module assertj.core reads package org.assertj.core.util from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.util.introspection from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.util.diff from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.util.diff.myers from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.util.xml from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.groups from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.configuration from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.condition from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.description from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.extractor from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.api from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.api.filter from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.api.junit.jupiter from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.api.iterable from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.api.recursive.comparison from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.matcher from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.data from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.error from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.error.future from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.error.uri from both org.assertj.core and assertj.core
[ERROR] module assertj.core reads package org.assertj.core.presentation from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.util from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.util.introspection from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.util.diff from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.util.diff.myers from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.util.xml from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.groups from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.configuration from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.condition from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.description from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.extractor from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.api from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.api.filter from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.api.junit.jupiter from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.api.iterable from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.api.recursive.comparison from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.matcher from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.data from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.error from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.error.future from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.error.uri from both org.assertj.core and assertj.core
[ERROR] module org.hamcrest reads package org.assertj.core.presentation from both org.assertj.core and assertj.core
[INFO] 63 errors 
[INFO] -------------------------------------------------------------
```
</details>

## additional source directory

Then i thought maybe extracting them into `target/test-classes` could also do the trick - sadly not
Then i thought maybe i could simply add the test source directory to the modularTest module, but this somehow needed more than 5 minutes and did not finish, so i also stepped away from this approach.

