### PR TITLE
Improving null-safety of isEqualToNormalizingNewlines

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -59,6 +59,7 @@ import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringCase.shouldNotBeEqualIgnoringCase;
 import static org.assertj.core.error.ShouldNotBeEqualIgnoringWhitespace.shouldNotBeEqualIgnoringWhitespace;
 import static org.assertj.core.error.ShouldNotBeEqualNormalizingWhitespace.shouldNotBeEqualNormalizingWhitespace;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.error.ShouldNotContainAnyWhitespaces.shouldNotContainAnyWhitespaces;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContainIgnoringCase;
@@ -671,6 +672,12 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are equal after normalizing newlines.
    */
   public void assertIsEqualToNormalizingNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
+    if (actual == null && expected == null)
+      return;
+    if (actual == null)
+      throw failures.failure(info, shouldNotBeNull("actual"));
+    if (expected == null)
+      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, "null"));
     String actualNormalized = normalizeNewlines(actual);
     String expectedNormalized = normalizeNewlines(expected);
     if (!actualNormalized.equals(expectedNormalized))

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.internal.strings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNewLineDifferences.shouldBeEqualIgnoringNewLineDifferences;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
@@ -56,4 +57,32 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
                              "Lord of the Rings\n\nis cool", expected);
   }
 
+  @Test
+  void compare_null_and_null() {
+    String actual = null;
+    String expected = null;
+    assertThat(actual).isEqualToNormalizingNewlines(expected);
+  }
+
+  @Test
+  void compare_null_and_empty() {
+    String actual = null;
+    String expected = "";
+
+    Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
+    assertThat(error).isInstanceOf(AssertionError.class);
+
+    verify(failures).failure(someInfo(), shouldNotBeNull("actual"));
+  }
+
+  @Test
+  void compare_empty_and_null() {
+    String actual = "";
+    String expected = null;
+
+    Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
+    assertThat(error).isInstanceOf(AssertionError.class);
+
+    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, "null"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -58,14 +58,14 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
   }
 
   @Test
-  void compare_null_and_null() {
+  void should_pass_if_actual_and_expected_are_both_null() {
     String actual = null;
     String expected = null;
     assertThat(actual).isEqualToNormalizingNewlines(expected);
   }
 
   @Test
-  void compare_null_and_empty() {
+  void should_fail_if_actual_is_null_and_expected_is_not() {
     String actual = null;
     String expected = "";
 
@@ -76,7 +76,7 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
   }
 
   @Test
-  void compare_empty_and_null() {
+  void should_fail_if_actual_is_not_null_but_expected_is_null() {
     String actual = "";
     String expected = null;
 


### PR DESCRIPTION
Improving the null-safety in isEqualToNormalizingNewlines to avoid NPE errors when actual and/or expected are null. 

#### Check List:
* Fixes #2775
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
