### PR TITLE
Rename public API methods containing 'NewLine' to 'Newline'

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -878,19 +878,19 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} contains all the given values ignoring new line differences.
+   * Verifies that the actual {@code CharSequence} contains all the given values ignoring newline differences.
    * <p>
    * You can use one or several {@code CharSequence}s as in this example:
    *
    * <pre><code class='java'> // assertions succeed:
-   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewLines(&quot;alf&quot;)
-   *                                 .containsIgnoringNewLines(&quot;alf&quot;, &quot;grey&quot;)
-   *                                 .containsIgnoringNewLines(&quot;thegrey&quot;)
-   *                                 .containsIgnoringNewLines(&quot;thegr\ney&quot;)
-   *                                 .containsIgnoringNewLines(&quot;t\nh\ne\ng\nr\ney&quot;);
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewlines(&quot;alf&quot;)
+   *                                 .containsIgnoringNewlines(&quot;alf&quot;, &quot;grey&quot;)
+   *                                 .containsIgnoringNewlines(&quot;thegrey&quot;)
+   *                                 .containsIgnoringNewlines(&quot;thegr\ney&quot;)
+   *                                 .containsIgnoringNewlines(&quot;t\nh\ne\ng\nr\ney&quot;);
    * // assertions fail:
-   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewLines(&quot;alF&quot;)
-   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewLines(&quot;t\nh\ne\ng\nr\t\r\ney&quot;)</code></pre>
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewlines(&quot;alF&quot;)
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;).containsIgnoringNewlines(&quot;t\nh\ne\ng\nr\t\r\ney&quot;)</code></pre>
    * 
    * @param values the values to look for.
    * @return {@code this} assertion object.
@@ -899,9 +899,18 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
    * @throws AssertionError if the actual {@code CharSequence} does not contain all the given values.
    */
-  public SELF containsIgnoringNewLines(final CharSequence... values) {
-    strings.assertContainsIgnoringNewLines(info, actual, values);
+  public SELF containsIgnoringNewlines(final CharSequence... values) {
+    strings.assertContainsIgnoringNewlines(info, actual, values);
     return myself;
+  }
+
+  /**
+   * @deprecated Use {@link #containsIgnoringNewlines(CharSequence...)} instead.
+   * @since 3.24.0
+   */
+  @Deprecated(since = "3.24.0")
+  public SELF containsIgnoringNewLines(final CharSequence... values) {
+    return this.containsIgnoringNewlines(values);
   }
 
   /**
@@ -1799,29 +1808,38 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} is equal to the given one after both strings new lines (\n, \r\n) have been removed.
+   * Verifies that the actual {@code CharSequence} is equal to the given one after both strings newlines (\n, \r\n) have been removed.
    * <p>
    * Example:
    * <pre><code class='java'> // assertions will pass
-   * assertThat("Some textWith new lines").isEqualToIgnoringNewLines("Some text\nWith new lines")
-   *                                      .isEqualToIgnoringNewLines("Some text\r\nWith new lines")
-   *                                      .isEqualToIgnoringNewLines("Some text\n\nWith new lines");
+   * assertThat("Some textWith new lines").isEqualToIgnoringNewlines("Some text\nWith new lines")
+   *                                      .isEqualToIgnoringNewlines("Some text\r\nWith new lines")
+   *                                      .isEqualToIgnoringNewlines("Some text\n\nWith new lines");
    *
-   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewLines("Some text\nWith new lines")
-   *                                        .isEqualToIgnoringNewLines("Some text\r\nWith new lines")
-   *                                        .isEqualToIgnoringNewLines("Some text\n\nWith new lines");
+   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewlines("Some text\nWith new lines")
+   *                                        .isEqualToIgnoringNewlines("Some text\r\nWith new lines")
+   *                                        .isEqualToIgnoringNewlines("Some text\n\nWith new lines");
    *
    * // assertions will fail
-   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewLines("Some text With new lines");
-   * assertThat("Some text\r\nWith new lines").isEqualToIgnoringNewLines("Some text With new lines");</code></pre>
+   * assertThat("Some text\nWith new lines").isEqualToIgnoringNewlines("Some text With new lines");
+   * assertThat("Some text\r\nWith new lines").isEqualToIgnoringNewlines("Some text With new lines");</code></pre>
    *
    * @param expected the given {@code CharSequence} to compare the actual {@code CharSequence} to.
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code CharSequence} is not equal to the given one after new lines have been removed.
    */
-  public SELF isEqualToIgnoringNewLines(CharSequence expected) {
-    strings.assertIsEqualToIgnoringNewLines(info, actual, expected);
+  public SELF isEqualToIgnoringNewlines(CharSequence expected) {
+    strings.assertIsEqualToIgnoringNewlines(info, actual, expected);
     return myself;
+  }
+
+  /**
+   * @deprecated Use {@link #isEqualToIgnoringNewlines(CharSequence)} instead.
+   * @since 3.24.0
+   */
+  @Deprecated(since = "3.24.0")
+  public SELF isEqualToIgnoringNewLines(CharSequence expected) {
+    return this.isEqualToIgnoringNewlines(expected);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -545,10 +545,10 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if actual {@code CharSequence} doesn't have sequence
    */
-  public void assertContainsIgnoringNewLines(final AssertionInfo info, final CharSequence actual, final CharSequence... values) {
+  public void assertContainsIgnoringNewlines(final AssertionInfo info, final CharSequence actual, final CharSequence... values) {
     doCommonCheckForCharSequence(info, actual, values);
-    final String actualNoNewLines = removeNewLines(actual);
-    Set<CharSequence> notFound = stream(values).filter(value -> !stringContains(actualNoNewLines, removeNewLines(value)))
+    final String actualNoNewLines = removeNewlines(actual);
+    Set<CharSequence> notFound = stream(values).filter(value -> !stringContains(actualNoNewLines, removeNewlines(value)))
                                                .collect(toCollection(LinkedHashSet::new));
     if (notFound.isEmpty()) return;
     throw failures.failure(info, containsIgnoringNewLines(actual, values, notFound, comparisonStrategy));
@@ -1335,9 +1335,9 @@ public class Strings {
    * @param actual the actual {@code CharSequence} (new lines will be ignored).
    * @param expected the expected {@code CharSequence} (new lines will be ignored).
    */
-  public void assertIsEqualToIgnoringNewLines(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    String actualWithoutNewLines = removeNewLines(actual);
-    String expectedWithoutNewLines = removeNewLines(expected);
+  public void assertIsEqualToIgnoringNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
+    String actualWithoutNewLines = removeNewlines(actual);
+    String expectedWithoutNewLines = removeNewlines(expected);
     if (!actualWithoutNewLines.equals(expectedWithoutNewLines))
       throw failures.failure(info, shouldBeEqualIgnoringNewLines(actual, expected), actual, expected);
   }
@@ -1382,7 +1382,7 @@ public class Strings {
     }
   }
 
-  private static String removeNewLines(CharSequence text) {
+  private static String removeNewlines(CharSequence text) {
     String normalizedText = normalizeNewlines(text);
     return normalizedText.replace("\n", EMPTY_STRING);
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewlines_CharSequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewlines_CharSequence_Test.java
@@ -17,14 +17,14 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.CharSequenceAssert;
 import org.assertj.core.api.CharSequenceAssertBaseTest;
 
-class CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test extends CharSequenceAssertBaseTest {
+class CharSequenceAssert_containsIgnoringNewlines_CharSequence_Test extends CharSequenceAssertBaseTest {
   @Override
   protected CharSequenceAssert invoke_api_method() {
-    return assertions.containsIgnoringNewLines("Al", "Bob");
+    return assertions.containsIgnoringNewlines("Al", "Bob");
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(strings).assertContainsIgnoringNewLines(getInfo(assertions), getActual(assertions), "Al", "Bob");
+    verify(strings).assertContainsIgnoringNewlines(getInfo(assertions), getActual(assertions), "Al", "Bob");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_isEqualToIgnoringNewlines_Test.java
@@ -17,15 +17,15 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.CharSequenceAssert;
 import org.assertj.core.api.CharSequenceAssertBaseTest;
 
-class CharSequenceAssert_isEqualToIgnoringNewLines_Test extends CharSequenceAssertBaseTest {
+class CharSequenceAssert_isEqualToIgnoringNewlines_Test extends CharSequenceAssertBaseTest {
 
   @Override
   protected CharSequenceAssert invoke_api_method() {
-    return assertions.isEqualToIgnoringNewLines("yoda");
+    return assertions.isEqualToIgnoringNewlines("yoda");
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(strings).assertIsEqualToIgnoringNewLines(getInfo(assertions), getActual(assertions), "yoda");
+    verify(strings).assertIsEqualToIgnoringNewlines(getInfo(assertions), getActual(assertions), "yoda");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewlines_Test.java
@@ -32,9 +32,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link Strings#assertContainsIgnoringNewLines(AssertionInfo, CharSequence, CharSequence...)} </code>.
+ * Tests for <code>{@link Strings#assertContainsIgnoringNewlines(AssertionInfo, CharSequence, CharSequence...)} </code>.
  */
-public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest {
+class Strings_assertContainsIgnoringNewlines_Test extends StringsBaseTest {
 
   private static final StandardComparisonStrategy STANDARD_COMPARISON = StandardComparisonStrategy.instance();
   private static final WritableAssertionInfo INFO = someInfo();
@@ -46,7 +46,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     // GIVEN
     String actual = "Alice\nand\nBob";
     // WHEN / THEN
-    strings.assertContainsIgnoringNewLines(INFO, actual, value);
+    strings.assertContainsIgnoringNewlines(INFO, actual, value);
   }
 
   @Test
@@ -55,7 +55,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Alice\nand\nBob";
     String[] values = array("Ali", "ce", "\na", "nd", "\r\nBob");
     // WHEN / THEN
-    strings.assertContainsIgnoringNewLines(INFO, actual, values);
+    strings.assertContainsIgnoringNewlines(INFO, actual, values);
   }
 
   @Test
@@ -64,7 +64,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Al";
     String value = "Bob";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewlines(INFO, actual, value));
     // THEN
     then(assertionError).hasMessage(containsIgnoringNewLines("Al", array("Bob"), set("Bob"), STANDARD_COMPARISON).create());
   }
@@ -75,7 +75,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Al";
     String value = "al";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewlines(INFO, actual, value));
     // THEN
     then(assertionError).hasMessage(containsIgnoringNewLines("Al", array("al"), set("al"), STANDARD_COMPARISON).create());
   }
@@ -86,7 +86,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Alice\nand\nbob";
     String value = "and\nBob";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewlines(INFO, actual, value));
     // THEN
     then(assertionError).hasMessage(containsIgnoringNewLines("Alice\nand\nbob", array("and\nBob"), set("and\nBob"),
                                                              STANDARD_COMPARISON).create());
@@ -98,7 +98,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Al";
     String value = null;
     // WHEN / THEN
-    assertThatNullPointerException().isThrownBy(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value))
+    assertThatNullPointerException().isThrownBy(() -> strings.assertContainsIgnoringNewlines(INFO, actual, value))
                                     .withMessage(charSequenceToLookForIsNull());
   }
 
@@ -108,7 +108,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = null;
     String value = "Bob";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewlines(INFO, actual, value));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -119,7 +119,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Alice";
     String[] values = array("Al", "ice", "Bob");
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, values));
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewlines(INFO, actual, values));
     // THEN
     then(assertionError).hasMessage(containsIgnoringNewLines(actual, values, set("Bob"), STANDARD_COMPARISON).create());
   }
@@ -130,7 +130,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     // GIVEN
     String actual = "Alice\nand\nBob";
     // WHEN / THEN
-    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO, actual, value);
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewlines(INFO, actual, value);
   }
 
   @Test
@@ -139,7 +139,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Alice\nand\nBob";
     String[] values = array("Al", "iCe", "and", "Bob");
     // WHEN / THEN
-    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO, actual, values);
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewlines(INFO, actual, values);
   }
 
   @Test
@@ -148,7 +148,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Al";
     String value = "Bob";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO,
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewlines(INFO,
                                                                                                                                            actual,
                                                                                                                                            value));
     // THEN
@@ -161,7 +161,7 @@ public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest
     String actual = "Alice";
     String[] values = array("Al", "ice", "\r\nBob");
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO,
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewlines(INFO,
                                                                                                                                            actual,
                                                                                                                                            values));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToIgnoringNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToIgnoringNewlines_Test.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link Strings#assertIsEqualToIgnoringNewLines(AssertionInfo, CharSequence, CharSequence)}</code>.
+ * Tests for <code>{@link Strings#assertIsEqualToIgnoringNewlines(AssertionInfo, CharSequence, CharSequence)}</code>.
  *
  * @author Daniel Weber
  */
-class Strings_assertIsEqualToIgnoringNewLines_Test extends StringsBaseTest {
+class Strings_assertIsEqualToIgnoringNewlines_Test extends StringsBaseTest {
 
   private static final String ACTUAL_WITHOUT_NEW_LINES = "Some textWith new lines";
   private static final String ACTUAL_ON_UNIX = "Some text\nWith new lines";
@@ -41,7 +41,7 @@ class Strings_assertIsEqualToIgnoringNewLines_Test extends StringsBaseTest {
     // GIVEN
     String actual = "Some text\nWith new lines";
     // WHEN
-    strings.assertIsEqualToIgnoringNewLines(someInfo(), actual, expected);
+    strings.assertIsEqualToIgnoringNewlines(someInfo(), actual, expected);
   }
 
   @ParameterizedTest
@@ -50,7 +50,7 @@ class Strings_assertIsEqualToIgnoringNewLines_Test extends StringsBaseTest {
     // GIVEN
     String expected = "Some text With new lines";
     // WHEN
-    expectAssertionError(() -> strings.assertIsEqualToIgnoringNewLines(someInfo(), actual, expected));
+    expectAssertionError(() -> strings.assertIsEqualToIgnoringNewlines(someInfo(), actual, expected));
     // THEN
     verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLines(actual, expected), actual, expected);
   }


### PR DESCRIPTION
#### Check List:
* Fixes #2754
* Unit tests : NO (see below)
* Javadoc with a code example (on API only) : NO (Updated existing JavaDoc on lowercase methods, no duplicate JavaDoc on deprecated uppercase methods)
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md), I think. This is my first PR for this project. If not, let me know 🙂 

### Changes: 
* `Strings`:
  - **Renamed** `assertContainsIgnoringNewLines` (uppercase) to `assertContainsIgnoringNewlines` (lowercase). I thought that since this classes is in the `internal` package, I could safely rename the method, instead of keeping the uppercase one around for backward compatibility.
* `AbstractCharSequenceAssert`: 
  - **Added** `containsIgnoringNewlines` (lowercase)
  - **Deprecated** `containsIgnoringNewLines` (uppercase), keeping this one around for backward compatibility
  - **Added** `isEqualIgnoringNewlines` (lowercase)
  - **Deprecated** `isEqualIgnoringNewLines` (uppercase), keeping this one around for backward compatibility
* Unit tests: Updated for the exisiting public methods, didn't add any new unit tests for the deprecated methods. If required, I can add them. 

### Please note
* SonarLint throws up warnings about blocking issues: the uppercase and lowercase method names are confusing. 
* I have not copied the JavaDoc from the lowercase methods to the uppercase methods. 

### Not changed: 
* Errors concerning the aforementioned assertions: 
  - Class `ShouldBeEqualIgnoringNewLines` and its factory method `shouldBeEqualIgnoringNewLines`;
  - Class `ShouldBeEqualIgnoringNewLineDifferences` and its factory method `shouldBeEqualIgnoringNewLineDifferences`.

These can be changed, but I'm not sure how to name them. Change only the factory methods? Add a lowercase factory method? Duplicate the entire class (to lowercase) and deprecate the uppercase one?

