### PR TITLE
Improve null handling for isEqualToNormalizingNewlines

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -671,6 +671,9 @@ public class Strings {
    * @throws AssertionError if the given {@code CharSequence}s are equal after normalizing newlines.
    */
   public void assertIsEqualToNormalizingNewlines(AssertionInfo info, CharSequence actual, CharSequence expected) {
+    if (actual == null && expected == null) return;
+    if (actual == null || expected == null)
+      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
     String actualNormalized = normalizeNewlines(actual);
     String expectedNormalized = normalizeNewlines(expected);
     if (!actualNormalized.equals(expectedNormalized))

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -45,6 +45,11 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
   }
 
   @Test
+  void should_pass_if_both_strings_are_null() {
+    strings.assertIsEqualToNormalizingNewlines(someInfo(), null, null);
+  }
+
+  @Test
   void should_fail_if_newlines_are_different_in_both_strings() {
     String actual = "Lord of the Rings\r\n\r\nis cool";
     String expected = "Lord of the Rings\nis cool";
@@ -54,6 +59,26 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected),
                              "Lord of the Rings\n\nis cool", expected);
+  }
+
+  @Test
+  void should_fail_if_actual_is_null_and_the_expected_not() {
+    String actual = null;
+    String expected = "Lord of the Rings\nis cool";
+    Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected),
+      actual, expected);
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_null_and_the_expected_is() {
+    String actual = "Lord of the Rings\nis cool";
+    String expected = null;
+    Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected),
+      actual, expected);
   }
 
 }


### PR DESCRIPTION
Fixes #2775

#### Check List:
* Fixes #2775
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
