### PR TITLE
Add integration test infrastructure for Kotlin

### DIFF
--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/pom.xml
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.assertj</groupId>
+    <artifactId>assertj-integration-tests</artifactId>
+    <version>3.24.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>assertj-core-kotlin</artifactId>
+
+  <name>AssertJ Core Integration Tests - Kotlin</name>
+
+  <properties>
+    <kotlin.version>1.7.10</kotlin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>src/**/*.kt</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/tests/kotlin/Assertions_assertThat_Test.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/tests/kotlin/Assertions_assertThat_Test.kt
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.tests.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class Assertions_assertThat_Test {
+
+    @Test
+    internal fun intarray () {
+        val x: IntArray = intArrayOf(1, 2, 3)
+        assertThat(x).contains(1, 2, 3)
+    }
+
+    @Test
+    internal fun `immutable list`() {
+        val list = listOf("Viserys", "Rhaenyra", "Daemon")
+        assertThat(list).contains("Viserys", "Rhaenyra", "Daemon")
+        assertThat(list).hasSize(3).anySatisfy {
+            assertThat(it).isNotEqualTo("Corlys")
+            assertThat(it).hasSize(6)
+        }
+    }
+
+    @Test
+    internal fun `mutable list`() {
+        val list = mutableListOf("Viserys", "Rhaenyra", "Daemon")
+        assertThat(list).contains("Viserys", "Rhaenyra", "Daemon")
+    }
+}

--- a/assertj-tests/assertj-integration-tests/pom.xml
+++ b/assertj-tests/assertj-integration-tests/pom.xml
@@ -15,6 +15,7 @@
 
   <modules>
     <module>assertj-core-junit4-with-opentest4j</module>
+    <module>assertj-core-kotlin</module>
     <module>assertj-core-osgi</module>
     <module>assertj-core-testng-with-junit4</module>
   </modules>


### PR DESCRIPTION
fixes #2757 

I've added a very first kotlin test (for sure we have to extend/fine tune it laster on).

see

```
[INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ assertj-core-kotlin ---
[INFO] Surefire report directory: /home/runner/work/assertj/assertj/assertj-tests/assertj-integration-tests/assertj-core-kotlin/target/surefire-reports
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.assertj.core.tests.kotlin.Assertions_assertThat_Test
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.12 s - in org.assertj.core.tests.kotlin.Assertions_assertThat_Test
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
```

and

```
[INFO] Reactor Summary for AssertJ Build 3.24.0-SNAPSHOT:
[INFO] 
[INFO] AssertJ Build ...................................... SUCCESS [  9.548 s]
[INFO] AssertJ Parent ..................................... SUCCESS [  1.171 s]
[INFO] AssertJ Core ....................................... SUCCESS [03:20 min]
[INFO] AssertJ Tests ...................................... SUCCESS [  0.049 s]
[INFO] AssertJ Integration Tests .......................... SUCCESS [  0.010 s]
[INFO] AssertJ Core Integration Tests - JUnit 4 with opentest4j SUCCESS [  3.232 s]
[INFO] AssertJ Core Integration Tests - Kotlin ............ SUCCESS [  9.090 s]
[INFO] AssertJ Core Integration Tests - OSGi .............. SUCCESS [  6.536 s]
[INFO] AssertJ Core Integration Tests - TestNG with JUnit 4 SUCCESS [  1.956 s]
[INFO] AssertJ Core Integration Tests - Groovy ............ SUCCESS [  3.977 s]
[INFO] AssertJ Performance Tests .......................... SUCCESS [  1.631 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```