### PR TITLE
test: add usingRecursiveComparison tests

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_usingRecursiveComparison_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_usingRecursiveComparison_Test.java
@@ -13,11 +13,15 @@
 package org.assertj.core.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.*;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 class AbstractAssert_usingRecursiveComparison_Test {
 
@@ -56,4 +60,87 @@ class AbstractAssert_usingRecursiveComparison_Test {
     then(recursiveAssertion.info.overridingErrorMessage()).isEqualTo(errorMessage);
   }
 
+  @Test
+  void should_honor_ignored_fields() {
+    // GIVEN
+    Data actual = new Data(new Data.InnerData("match", "nonMatch"), null);
+    Data expected = new Data(new Data.InnerData("match", "hctaMnon"), null);
+    RecursiveComparisonConfiguration conf = new RecursiveComparisonConfiguration();
+    conf.ignoreFields("field1.field12");
+    AbstractAssert<?, ?> assertion = assertThat(actual);
+    // WHEN
+    RecursiveComparisonAssert<?> recursiveAssertion = assertion.usingRecursiveComparison(conf);
+    // THEN
+    thenCode(() -> recursiveAssertion.isEqualTo(expected)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_honor_ignored_fields_regex_in_inner_list() {
+    // GIVEN
+    Data actual = new Data(null, Collections.singletonList(new Data.InnerData("match", "nonMatch")));
+    Data expected = new Data(null, Collections.singletonList(new Data.InnerData("match", "hctaMnon")));
+    RecursiveComparisonConfiguration conf = new RecursiveComparisonConfiguration();
+    conf.ignoreFieldsMatchingRegexes(".*field12");
+    AbstractAssert<?, ?> assertion = assertThat(actual);
+    // WHEN
+    RecursiveComparisonAssert<?> recursiveAssertion = assertion.usingRecursiveComparison(conf);
+    // THEN
+    thenCode(() -> recursiveAssertion.isEqualTo(expected)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_honor_ignored_fields_regex() {
+    // GIVEN
+    Data actual = new Data(new Data.InnerData("match", "nonMatch"), null);
+    Data expected = new Data(new Data.InnerData("match", "hctaMnon"), null);
+    RecursiveComparisonConfiguration conf = new RecursiveComparisonConfiguration();
+    conf.ignoreFieldsMatchingRegexes(".*field12");
+    AbstractAssert<?, ?> assertion = assertThat(actual);
+    // WHEN
+    RecursiveComparisonAssert<?> recursiveAssertion = assertion.usingRecursiveComparison(conf);
+    // THEN
+    thenCode(() -> recursiveAssertion.isEqualTo(expected)).doesNotThrowAnyException();
+  }
+
+  static class Data {
+    private InnerData field1;
+
+    public Data(InnerData field1, List<InnerData> field2) {
+      this.field1 = field1;
+    }
+
+    public InnerData getField1() {
+      return field1;
+    }
+
+    public void setField1(InnerData field1) {
+      this.field1 = field1;
+    }
+
+    static class InnerData {
+      private String field11;
+      private String field12;
+
+      public InnerData(String field11, String field12) {
+        this.field11 = field11;
+        this.field12 = field12;
+      }
+
+      public String getField12() {
+        return field12;
+      }
+
+      public void setField12(String field12) {
+        this.field12 = field12;
+      }
+
+      public String getField11() {
+        return field11;
+      }
+
+      public void setField11(String field11) {
+        this.field11 = field11;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Note, I created those tests, when investigated, why my RecursiveComparisonConfiguration with ignoreFieldsMatchingRegexes doesn't work. My regex was `"\\w*[iI]d"`, which doesn't work on lists, because fields named like `list[0].field`