### PR TITLE
Deprecate `ObjectAssert(AtomicReference)`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/ObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ObjectAssert.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Assertion methods for {@link Object}s.
@@ -31,8 +32,13 @@ public class ObjectAssert<ACTUAL> extends AbstractObjectAssert<ObjectAssert<ACTU
   public ObjectAssert(ACTUAL actual) {
     super(actual, ObjectAssert.class);
   }
-  
+
+  /**
+   * @deprecated use {@code assertThat(actual.get())} or {@link AtomicReferenceAssert#hasValueSatisfying(Consumer)}.
+   */
+  @Deprecated
   public ObjectAssert(AtomicReference<ACTUAL> actual) {
-    this(actual == null ? null: actual.get());
+    this(actual == null ? null : actual.get());
   }
+
 }


### PR DESCRIPTION
Fixes #1536.
