### PR TITLE
Return cache in `setup-java` action

### DIFF
--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-#          cache: 'maven'
+          cache: 'maven'
 
       - name: Checkout `${{ github.base_ref }}` into subfolder
         uses: actions/checkout@v3
@@ -94,7 +94,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-#          cache: 'maven'
+          cache: 'maven'
 
       - name: Compare with the latest release
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-#          cache: 'maven'
+          cache: 'maven'
       - name: Test
         # Note: arguments with a period or bang in them have to be single quoted to prevent
         # confusing the PowerShell instance on Windows runners.
@@ -60,7 +60,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-#          cache: 'maven'
+          cache: 'maven'
       - name: Test with Sonar
         run: >
           ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc sonar:sonar

--- a/.github/workflows/pitest-receive-pr.yml
+++ b/.github/workflows/pitest-receive-pr.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-#          cache: 'maven'
+          cache: 'maven'
       - name: run pitest
         # pitest has been bound to a profile called pitest for normal running
         # we add config to analyse only changes made within a PR and treat surviving mutants as check errors


### PR DESCRIPTION
Returns cache from `actions/setup-java`.

According to https://github.com/actions/setup-java/issues/305 should be fixed.

* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)


