### PR TITLE
Skip duplicate workflow executions

### DIFF
--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -8,6 +8,12 @@ on:
     paths:
       - 'assertj-core/**'
 
+concurrency:
+  # Cancel concurrently-running workflow for push and pull_request events
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   verify-with-base:
     name: Verify with target branch

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -2,6 +2,12 @@ name: Cross-Version
 
 on: [push, pull_request]
 
+concurrency:
+  # Cancel concurrently-running workflow for push and pull_request events
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
 
   test_java:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,12 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  # Cancel concurrently-running workflow for push and pull_request events
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
 
   test_os:


### PR DESCRIPTION
#### Check List:
* Fixes #2810
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Cancel workflow runs based on workflow path and branch name. If `push` and `pull_request` events happen, will keep only PR workflow running.

`github.head_ref` has branch name in PR context. `github.ref_name` is the same for push event.

Details: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context