### PR TITLE
Use getParameterCount rather than getParameterTypes().length

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/ClassBasedNavigableIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ClassBasedNavigableIterableAssert.java
@@ -59,7 +59,7 @@ public class ClassBasedNavigableIterableAssert<SELF extends ClassBasedNavigableI
       Constructor<?>[] declaredConstructors = assertClass.getDeclaredConstructors();
       // find a matching Assert constructor for E or one of its subclass.
       for (Constructor<?> constructor : declaredConstructors) {
-        if (constructor.getParameterTypes().length == 1 && constructor.getParameterTypes()[0].isAssignableFrom(clazz)) {
+        if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0].isAssignableFrom(clazz)) {
           @SuppressWarnings("unchecked")
           ELEMENT_ASSERT newAssert = (ELEMENT_ASSERT) constructor.newInstance(value);
           return newAssert.as(description);

--- a/assertj-core/src/main/java/org/assertj/core/api/ClassBasedNavigableListAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ClassBasedNavigableListAssert.java
@@ -56,7 +56,7 @@ public class ClassBasedNavigableListAssert<SELF extends ClassBasedNavigableListA
       Constructor<?>[] declaredConstructors = assertClass.getDeclaredConstructors();
       // find a matching Assert constructor for E or one of its subclass.
       for (Constructor<?> constructor : declaredConstructors) {
-        if (constructor.getParameterTypes().length == 1 && constructor.getParameterTypes()[0].isAssignableFrom(clazz)) {
+        if (constructor.getParameterCount() == 1 && constructor.getParameterTypes()[0].isAssignableFrom(clazz)) {
           @SuppressWarnings("unchecked")
           ELEMENT_ASSERT newAssert = (ELEMENT_ASSERT) constructor.newInstance(value);
           return newAssert.as(description);


### PR DESCRIPTION
The issue with `java.lang.reflect.Constructor#getParameterTypes()` is that each time it creates a new array by `clone` method.
It does not make sense to do it in order to only get number of parameter types

#### Check List:
* Unit tests : NO
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
