### PR TITLE
Allow Java 20 with Groovy tests

### DIFF
--- a/assertj-tests/assertj-integration-tests/pom.xml
+++ b/assertj-tests/assertj-integration-tests/pom.xml
@@ -14,22 +14,11 @@
   <name>AssertJ Integration Tests</name>
 
   <modules>
+    <module>assertj-core-groovy</module>
     <module>assertj-core-junit4-with-opentest4j</module>
     <module>assertj-core-kotlin</module>
     <module>assertj-core-osgi</module>
     <module>assertj-core-testng-with-junit4</module>
   </modules>
-
-  <profiles>
-    <profile>
-      <id>it-groovy</id>
-      <activation>
-        <jdk>(,20)</jdk>
-      </activation>
-      <modules>
-        <module>assertj-core-groovy</module>
-      </modules>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
The underlying ASM has been upgraded to version 9.4 in #2815 which supports Java 20 bytecode.