### PR TITLE
Throw org.opentest4j.AssertionFailedError for containsExactly

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -460,7 +460,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.9.8</version>
+        <version>1.9.9</version>
         <dependencies>
           <dependency>
             <groupId>org.pitest</groupId>

--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -460,7 +460,7 @@
       <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
-        <version>1.9.9</version>
+        <version>1.9.8</version>
         <dependencies>
           <dependency>
             <groupId>org.pitest</groupId>

--- a/assertj-core/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Arrays.java
@@ -74,6 +74,7 @@ import static org.assertj.core.util.Arrays.isArray;
 import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.Arrays.sizeOf;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
+import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
@@ -287,11 +288,11 @@ public class Arrays {
         Object actualElement = Array.get(actual, i);
         Object expectedElement = Array.get(values, i);
         if (!areEqual(actualElement, expectedElement))
-          throw failures.failure(info, elementsDifferAtIndex(actualElement, expectedElement, i, comparisonStrategy));
+          throw failures.failure(info, elementsDifferAtIndex(actualElement, expectedElement, i, comparisonStrategy), asList(actual), asList(values));
       }
       return;
     }
-    throw failures.failure(info, shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected, comparisonStrategy));
+    throw failures.failure(info, shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected, comparisonStrategy), asList(actual), asList(values));
   }
 
   void assertContainsExactlyInAnyOrder(AssertionInfo info, Failures failures, Object actual, Object values) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1161,7 +1161,7 @@ public class Iterables {
   }
 
   private AssertionError shouldContainExactlyWithIndexAssertionError(Iterable<?> actual, Object[] values,
-                                                                                 List<IndexedDiff> indexedDiffs, AssertionInfo info) {
+                                                                     List<IndexedDiff> indexedDiffs, AssertionInfo info) {
     return failures.failure(info, shouldContainExactlyWithIndexes(actual, list(values), indexedDiffs, comparisonStrategy), actual, list(values));
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1161,13 +1161,13 @@ public class Iterables {
   }
 
   private AssertionError shouldContainExactlyWithIndexAssertionError(Iterable<?> actual, Object[] values,
-                                                                     List<IndexedDiff> indexedDiffs, AssertionInfo info) {
-    return failures.failure(info, shouldContainExactlyWithIndexes(actual, list(values), indexedDiffs, comparisonStrategy));
+                                                                                 List<IndexedDiff> indexedDiffs, AssertionInfo info) {
+    return failures.failure(info, shouldContainExactlyWithIndexes(actual, list(values), indexedDiffs, comparisonStrategy), actual, list(values));
   }
 
   private AssertionError shouldContainExactlyWithDiffAssertionError(IterableDiff<Object> diff, Iterable<?> actual,
                                                                     Object[] values, AssertionInfo info) {
-    return failures.failure(info, shouldContainExactly(actual, list(values), diff.missing, diff.unexpected, comparisonStrategy));
+    return failures.failure(info, shouldContainExactly(actual, list(values), diff.missing, diff.unexpected, comparisonStrategy), actual, list(values));
   }
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {

--- a/assertj-core/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/booleanarrays/BooleanArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    boolean[] expected = arrayOf(false, true);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(false, true)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(true, false, 0));
+    verify(failures).failure(info, elementsDifferAtIndex(true, false, 0), asList(actual), asList(expected));
   }
 
   @Test
@@ -89,7 +90,7 @@ class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
-                             shouldContainExactly(actual, asList(expected), newArrayList(true), newArrayList(false)));
+                             shouldContainExactly(actual, asList(expected), newArrayList(true), newArrayList(false)), asList(actual), asList(expected));
   }
 
   @Test
@@ -102,7 +103,7 @@ class BooleanArrays_assertContainsExactly_Test extends BooleanArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
-                             shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList(true)));
+                             shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList(true)), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    byte[] expected = arrayOf(6, 10, 8);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -88,7 +89,7 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((byte) 20), newArrayList((byte) 10)));
+                                                        newArrayList((byte) 20), newArrayList((byte) 10)), asList(actual), asList(expected));
   }
 
   @Test
@@ -100,7 +101,7 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((byte) 10), newArrayList()));
+                                                        newArrayList((byte) 10), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -152,7 +153,7 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((byte) 20), newArrayList((byte) 10),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -165,7 +166,7 @@ class ByteArrays_assertContainsExactly_Test extends ByteArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((byte) 10), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/bytearrays/ByteArrays_assertContainsExactly_with_Integer_Arguments_Test.java
@@ -25,6 +25,7 @@ import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
+import static org.junit.jupiter.params.shadow.com.univocity.parsers.common.ArgumentUtils.toByteArray;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
@@ -51,11 +52,12 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    int[] expected = IntArrays.arrayOf(6, 10, 8);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, IntArrays.arrayOf(6, 10, 8)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1));
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1), asList(actual), asList(toByteArray(expected)));
   }
 
   @Test
@@ -89,7 +91,7 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((byte) 20), newArrayList((byte) 10)));
+                                                        newArrayList((byte) 20), newArrayList((byte) 10)), asList(actual), asList(expected));
   }
 
   @Test
@@ -101,7 +103,7 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((byte) 10), newArrayList()));
+                                                        newArrayList((byte) 10), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -116,11 +118,12 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
   @Test
   void should_pass_if_actual_contains_given_values_exactly_in_different_order_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
+    int[] expected = IntArrays.arrayOf(-6, 10, 8);
 
-    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, IntArrays.arrayOf(-6, 10, 8)));
+    Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex((byte) 8, (byte) 10, 1, absValueComparisonStrategy), asList(actual), asList(toByteArray(expected)));
   }
 
   @Test
@@ -152,7 +155,7 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((byte) 20), newArrayList((byte) 10),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -165,7 +168,7 @@ class ByteArrays_assertContainsExactly_with_Integer_Arguments_Test extends ByteA
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((byte) 10), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/chararrays/CharArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    char[] expected = arrayOf('a', 'c', 'b');
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf('a', 'c', 'b')));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1));
+    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -88,7 +89,7 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList('e'), newArrayList('c')));
+                                                        newArrayList('e'), newArrayList('c')), asList(actual), asList(expected));
   }
 
   @Test
@@ -100,7 +101,7 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList('c'), newArrayList()));
+                                                        newArrayList('c'), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1, caseInsensitiveComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex('b', 'c', 1, caseInsensitiveComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -154,7 +155,7 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
                              shouldContainExactly(actual, asList(expected), newArrayList('e'), newArrayList('c'),
-                                                        caseInsensitiveComparisonStrategy));
+                                                        caseInsensitiveComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -167,7 +168,7 @@ class CharArrays_assertContainsExactly_Test extends CharArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList('c'), newArrayList(),
-                                                        caseInsensitiveComparisonStrategy));
+                                                        caseInsensitiveComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    float[] expected = arrayOf(6f, 10f, 8f);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6f, 10f, 8f)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1));
+    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -88,7 +89,7 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(20f), newArrayList(10f)));
+                                                        newArrayList(20f), newArrayList(10f)), asList(actual), asList(expected));
   }
 
   @Test
@@ -100,7 +101,7 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(10f), newArrayList()));
+                                                        newArrayList(10f), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex(8f, 10f, 1, absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -152,7 +153,7 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(20f), newArrayList(10f),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -165,6 +166,6 @@ class FloatArrays_assertContainsExactly_Test extends FloatArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(10f), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertContainsExactly_Test.java
@@ -56,11 +56,12 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    int[] expected = arrayOf(6, 10, 8);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1));
+    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -94,7 +95,7 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(20), newArrayList(10)));
+                                                        newArrayList(20), newArrayList(10)), asList(actual), asList(expected));
   }
 
   @Test
@@ -106,7 +107,7 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(10), newArrayList()));
+                                                        newArrayList(10), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -126,7 +127,7 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex(8, 10, 1, absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -158,7 +159,7 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
                              shouldContainExactly(actual, asList(expected), newArrayList(20), newArrayList(10),
-                                                  absValueComparisonStrategy));
+                                                  absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -171,7 +172,7 @@ class IntArrays_assertContainsExactly_Test extends IntArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(10), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -105,7 +105,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // THEN
     List<String> notFound = list("Han");
     List<String> notExpected = list("Leia");
-    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), notFound, notExpected));
+    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), notFound, notExpected), actual, asList(expected));
   }
 
   @Test
@@ -117,7 +117,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // THEN
     List<IndexedDiff> indexDiffs = list(new IndexedDiff("Yoda", "Leia", 1),
                                         new IndexedDiff("Leia", "Yoda", 2));
-    verify(failures).failure(INFO, shouldContainExactlyWithIndexes(actual, list(expected), indexDiffs));
+    verify(failures).failure(INFO, shouldContainExactlyWithIndexes(actual, list(expected), indexDiffs), actual, list(expected));
   }
 
   @Test
@@ -128,7 +128,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // WHEN
     expectAssertionError(() -> iterables.assertContainsExactly(INFO, actual, expected));
     // THEN
-    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), emptyList(), list("Luke")));
+    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), emptyList(), list("Luke")), actual, asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -147,7 +147,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // WHEN
     expectAssertionError(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(INFO, actual, expected));
     // THEN
-    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), list("Han"), list("Leia"), comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), list("Han"), list("Leia"), comparisonStrategy), actual, asList(expected));
   }
 
   @Test
@@ -159,7 +159,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // THEN
     List<IndexedDiff> indexDiffs = list(new IndexedDiff("Yoda", "Leia", 1),
                                         new IndexedDiff("Leia", "Yoda", 2));
-    verify(failures).failure(INFO, shouldContainExactlyWithIndexes(actual, list(expected), indexDiffs, comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainExactlyWithIndexes(actual, list(expected), indexDiffs, comparisonStrategy), actual, list(expected));
   }
 
   @Test
@@ -170,7 +170,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     // WHEN
     expectAssertionError(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsExactly(INFO, actual, expected));
     // THEN
-    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), emptyList(), list("Luke"), comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainExactly(actual, asList(expected), emptyList(), list("Luke"), comparisonStrategy), actual, asList(expected));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/longarrays/LongArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    long[] expected = arrayOf(6L, 10L, 8L);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6L, 10L, 8L)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1));
+    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -88,7 +89,7 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(20L), newArrayList(10L)));
+                                                        newArrayList(20L), newArrayList(10L)), asList(actual), asList(expected));
   }
 
   @Test
@@ -100,7 +101,7 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList(10L), newArrayList()));
+                                                        newArrayList(10L), newArrayList()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex(8L, 10L, 1, absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -152,7 +153,7 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(20L), newArrayList(10L),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -165,7 +166,7 @@ class LongArrays_assertContainsExactly_Test extends LongArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(10L), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
@@ -92,7 +92,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList("Han"), newArrayList("Leia")));
+                                                        newArrayList("Han"), newArrayList("Leia")), asList(actual), asList(expected));
   }
 
   @Test
@@ -103,7 +103,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -117,7 +117,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList(), newArrayList("Luke"),
-                                                        StandardComparisonStrategy.instance()));
+                                                        StandardComparisonStrategy.instance()), asList(actual), asList(expected));
   }
 
   @Test
@@ -139,7 +139,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList("extra"), newArrayList(),
-                                                        StandardComparisonStrategy.instance()));
+                                                        StandardComparisonStrategy.instance()), asList(actual), asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
                              shouldContainExactly(actual, asList(expected), newArrayList("Han"), newArrayList("Leia"),
-                                                  caseInsensitiveStringComparisonStrategy));
+                                                  caseInsensitiveStringComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -173,7 +173,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, caseInsensitiveStringComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, caseInsensitiveStringComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -187,7 +187,7 @@ class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
                              shouldContainExactly(actual, asList(expected), newArrayList(), newArrayList("Luke"),
-                                                  caseInsensitiveStringComparisonStrategy));
+                                                  caseInsensitiveStringComparisonStrategy), asList(actual), asList(expected));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
@@ -50,11 +50,12 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
   @Test
   void should_fail_if_actual_contains_given_values_exactly_but_in_different_order() {
     AssertionInfo info = someInfo();
+    short[] expected = arrayOf(6, 10, 8);
 
-    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, arrayOf(6, 10, 8)));
+    Throwable error = catchThrowable(() -> arrays.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1));
+    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1), asList(actual), asList(expected));
   }
 
   @Test
@@ -88,7 +89,7 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((short) 20), newArrayList((short) 10)));
+                                                        newArrayList((short) 20), newArrayList((short) 10)),  asList(actual),  asList(expected));
   }
 
   @Test
@@ -100,7 +101,7 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
 
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
-                                                        newArrayList((short) 10), newArrayList()));
+                                                        newArrayList((short) 10), newArrayList()),  asList(actual),  asList(expected));
   }
 
   // ------------------------------------------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertContainsExactly(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1, absValueComparisonStrategy));
+    verify(failures).failure(info, elementsDifferAtIndex((short) 8, (short) 10, 1, absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
   @Test
@@ -152,7 +153,7 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((short) 20), newArrayList((short) 10),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy),  asList(actual),  asList(expected));
   }
 
   @Test
@@ -165,7 +166,7 @@ class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainExactly(actual, asList(expected),
                                                         newArrayList((short) 10), newArrayList(),
-                                                        absValueComparisonStrategy));
+                                                        absValueComparisonStrategy), asList(actual), asList(expected));
   }
 
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2697 
* Unit tests :  Yes (edited existing ones).
* Javadoc with a code example (on API only) :  NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your  #PR.

**Changes:**

Calling a new failure method inside Iterables that eventually invokes assertionFailedError from AssertionErrorCreator with the expected and actual values needed for the "Click to see difference" feature when AssertionFailedError is thrown. 

Also made modifications on Iterables_assertContainsExactly_tests to call the same failure method.

**New changes:**

Implementation for arrays.

* Rewritten array tests to make sure they call the right failure method.
* assertContainsExactly calls failure method with actual and expected values.
* Actual and expected values are converted to a list when the failure method is called so they show the right values when the 
  toString method is called under water.
* The click to see differences feature will show the actual and expected values side by side.
* Fixing format at Iterables.

--------------------------------------------------------------------------------------------------------------------------------------------

**Results**

**Old:**

![image](https://user-images.githubusercontent.com/113503359/198300776-927418dd-c87c-4695-a880-3a5dedde2afb.png)


**New:**

![image](https://user-images.githubusercontent.com/113503359/198299596-58c647a2-5dce-412d-ad27-25ce1ec84b9e.png)




