### PR TITLE
Reuse spies in `Path` tests

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
@@ -13,12 +13,14 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 
 import java.nio.file.Path;
 
 import org.assertj.core.api.AssertionInfo;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -26,29 +28,29 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public abstract class PathsBaseTest {
 
+  protected static final AssertionInfo INFO = someInfo();
+
+  protected static Paths underTest = Paths.instance();
+
+  protected static NioFilesWrapper nioFilesWrapper = spy(underTest.nioFilesWrapper);
+  protected static Failures failures = spy(underTest.failures);
+  protected static Diff diff = spy(underTest.diff);
+  protected static BinaryDiff binaryDiff = spy(underTest.binaryDiff);
+
   @TempDir
   protected Path tempDir;
 
-  protected Failures failures;
-  protected Paths paths;
-  protected NioFilesWrapper nioFilesWrapper;
-  protected AssertionInfo info;
+  @BeforeAll
+  static void injectSpies() {
+    underTest.nioFilesWrapper = nioFilesWrapper;
+    underTest.failures = failures;
+    underTest.diff = diff;
+    underTest.binaryDiff = binaryDiff;
+  }
 
-  protected Diff diff;
-  protected BinaryDiff binaryDiff;
-
-  @BeforeEach
-  void setUp() {
-    paths = Paths.instance();
-    nioFilesWrapper = spy(paths.nioFilesWrapper);
-    paths.nioFilesWrapper = nioFilesWrapper;
-    failures = spy(paths.failures);
-    paths.failures = failures;
-    diff = spy(paths.diff);
-    paths.diff = diff;
-    binaryDiff = spy(paths.binaryDiff);
-    paths.binaryDiff = binaryDiff;
-    info = someInfo();
+  @AfterEach
+  void resetSpies() {
+    reset(nioFilesWrapper, failures, diff, binaryDiff);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
@@ -34,7 +34,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     // GIVEN
     Path other = tempDir.resolve("other");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWithRaw(info, null, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWithRaw(INFO, null, other));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -44,7 +44,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertEndsWithRaw(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertEndsWithRaw(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("the expected end path should not be null");
@@ -56,7 +56,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = tempDir.resolve("other");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldEndWith(actual, other).create());
   }
@@ -67,7 +67,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = Paths.get("actual");
     // WHEN/THEN
-    paths.assertEndsWithRaw(info, actual, other);
+    underTest.assertEndsWithRaw(INFO, actual, other);
   }
 
   @Test
@@ -77,7 +77,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     Path other = Paths.get("file");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldEndWith(actual, other).create());
   }
@@ -88,7 +88,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = Paths.get("actual", "..", "actual", ".");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldEndWith(actual, other).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
@@ -37,7 +37,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     // GIVEN
     Path other = tempDir.resolve("other");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWith(info, null, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWith(INFO, null, other));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -47,7 +47,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertEndsWith(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertEndsWith(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("the expected end path should not be null");
@@ -61,7 +61,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(actual.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertEndsWith(info, actual, other));
+    Throwable thrown = catchThrowable(() -> underTest.assertEndsWith(INFO, actual, other));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -73,7 +73,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = tempDir.resolve("other");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertEndsWith(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertEndsWith(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldEndWith(actual, other).create());
   }
@@ -84,7 +84,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = Paths.get("actual");
     // WHEN/THEN
-    paths.assertEndsWith(info, actual, other);
+    underTest.assertEndsWith(INFO, actual, other);
   }
 
   @Test
@@ -94,7 +94,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     Path other = Paths.get("file");
     // WHEN/THEN
-    paths.assertEndsWith(info, actual, other);
+    underTest.assertEndsWith(INFO, actual, other);
   }
 
   @Test
@@ -103,7 +103,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = Paths.get("actual", "..", "actual", ".");
     // WHEN/THEN
-    paths.assertEndsWith(info, actual, other);
+    underTest.assertEndsWith(INFO, actual, other);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
@@ -30,7 +30,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertExistsNoFollowLinks(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertExistsNoFollowLinks(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -40,7 +40,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertExistsNoFollowLinks(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertExistsNoFollowLinks(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExistNoFollowLinks(actual).create());
   }
@@ -50,7 +50,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertExistsNoFollowLinks(info, actual);
+    underTest.assertExistsNoFollowLinks(INFO, actual);
   }
 
   @Test
@@ -59,7 +59,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
     Path target = createFile(tempDir.resolve("target"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
-    paths.assertExistsNoFollowLinks(info, actual);
+    underTest.assertExistsNoFollowLinks(INFO, actual);
   }
 
   @Test
@@ -68,7 +68,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
     Path target = tempDir.resolve("non-existent");
     Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
-    paths.assertExistsNoFollowLinks(info, actual);
+    underTest.assertExistsNoFollowLinks(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
@@ -30,7 +30,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertExists(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertExists(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -40,7 +40,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertExists(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertExists(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -50,7 +50,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertExists(info, actual);
+    underTest.assertExists(INFO, actual);
   }
 
   @Test
@@ -59,7 +59,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
     Path target = createFile(tempDir.resolve("target"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
-    paths.assertExists(info, actual);
+    underTest.assertExists(INFO, actual);
   }
 
   @Test
@@ -68,7 +68,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
     Path target = tempDir.resolve("non-existent");
     Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertExists(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertExists(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasBinaryContent_Test.java
@@ -40,7 +40,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasBinaryContent(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasBinaryContent(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The binary content to compare to should not be null");
@@ -51,7 +51,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     // GIVEN
     byte[] expected = "expected".getBytes();
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasBinaryContent(info, null, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, null, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -62,7 +62,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     byte[] expected = "expected".getBytes();
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasBinaryContent(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -75,7 +75,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     actual.toFile().setReadable(false);
     byte[] expected = "expected".getBytes();
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasBinaryContent(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -86,7 +86,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     Path actual = Files.write(tempDir.resolve("actual"), "Content".getBytes());
     byte[] expected = "Content".getBytes();
     // WHEN/THEN
-    paths.assertHasBinaryContent(info, actual, expected);
+    underTest.assertHasBinaryContent(INFO, actual, expected);
   }
 
   @Test
@@ -96,9 +96,9 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     byte[] expected = "Another content".getBytes();
     BinaryDiffResult diff = binaryDiff.diff(actual, expected);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasBinaryContent(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, actual, expected));
     // THEN
-    then(error).hasMessage(shouldHaveBinaryContent(actual, diff).create(info.description(), info.representation()));
+    then(error).hasMessage(shouldHaveBinaryContent(actual, diff).create(INFO.description(), INFO.representation()));
   }
 
   @Test
@@ -109,7 +109,7 @@ class Paths_assertHasBinaryContent_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     willThrow(exception).given(binaryDiff).diff(actual, expected);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasBinaryContent(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasBinaryContent(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasMessage("Unable to verify binary contents of path:<%s>", actual)

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test.java
@@ -51,7 +51,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = null;
     byte[] expected = {};
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The message digest algorithm should not be null");
@@ -64,7 +64,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The binary representation of digest to compare to should not be null");
@@ -77,7 +77,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -89,7 +89,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -101,7 +101,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -115,7 +115,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -129,7 +129,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newInputStream(actual);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -142,7 +142,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = digest.digest("Another content".getBytes());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldHaveDigest(actual, new DigestDiff(toHex(digest.digest(readAllBytes(actual))),
                                                                    toHex(expected),
@@ -156,7 +156,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends Paths
     MessageDigest digest = MessageDigest.getInstance("MD5");
     byte[] expected = digest.digest(readAllBytes(actual));
     // WHEN/THEN
-    paths.assertHasDigest(info, actual, digest, expected);
+    underTest.assertHasDigest(INFO, actual, digest, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_String_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_String_Test.java
@@ -51,7 +51,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = null;
     String expected = "";
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The message digest algorithm should not be null");
@@ -64,7 +64,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The string representation of digest to compare to should not be null");
@@ -77,7 +77,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -89,7 +89,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -101,7 +101,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -115,7 +115,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -129,7 +129,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newInputStream(actual);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, digest, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -142,7 +142,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = toHex(digest.digest("Another content".getBytes()));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(shouldHaveDigest(actual, new DigestDiff(toHex(digest.digest(readAllBytes(actual))),
                                                                    expected,
@@ -156,7 +156,7 @@ class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBase
     MessageDigest digest = MessageDigest.getInstance("MD5");
     String expected = toHex(digest.digest(readAllBytes(actual)));
     // WHEN/THEN
-    paths.assertHasDigest(info, actual, digest, expected);
+    underTest.assertHasDigest(INFO, actual, digest, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_String_and_Byte_array_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_String_and_Byte_array_Test.java
@@ -51,7 +51,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = null;
     byte[] expected = {};
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The message digest algorithm should not be null");
@@ -64,7 +64,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "invalid";
     byte[] expected = {};
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(IllegalStateException.class)
                 .hasMessage("Unable to find digest implementation for: <invalid>")
@@ -78,7 +78,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The binary representation of digest to compare to should not be null");
@@ -91,7 +91,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -103,7 +103,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -115,7 +115,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -129,7 +129,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = {};
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -143,7 +143,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newInputStream(actual);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -157,7 +157,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     MessageDigest digest = MessageDigest.getInstance(algorithm);
     byte[] expected = digest.digest("Another content".getBytes());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldHaveDigest(actual, new DigestDiff(toHex(digest.digest(readAllBytes(actual))),
                                                                    toHex(expected),
@@ -171,7 +171,7 @@ class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTes
     String algorithm = "MD5";
     byte[] expected = MessageDigest.getInstance(algorithm).digest(readAllBytes(actual));
     // WHEN/THEN
-    paths.assertHasDigest(info, actual, algorithm, expected);
+    underTest.assertHasDigest(INFO, actual, algorithm, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_String_and_String_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasDigest_with_String_and_String_Test.java
@@ -51,7 +51,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = null;
     String expected = "";
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The message digest algorithm should not be null");
@@ -64,7 +64,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "invalid";
     String expected = "";
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(IllegalStateException.class)
                 .hasMessage("Unable to find digest implementation for: <invalid>")
@@ -78,7 +78,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The string representation of digest to compare to should not be null");
@@ -91,7 +91,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -103,7 +103,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -115,7 +115,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -129,7 +129,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = "";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -143,7 +143,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newInputStream(actual);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -157,7 +157,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     MessageDigest digest = MessageDigest.getInstance(algorithm);
     String expected = toHex(digest.digest("Another content".getBytes()));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasDigest(info, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(shouldHaveDigest(actual, new DigestDiff(toHex(digest.digest(readAllBytes(actual))),
                                                                    expected,
@@ -171,7 +171,7 @@ class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
     String algorithm = "MD5";
     String expected = toHex(MessageDigest.getInstance(algorithm).digest(readAllBytes(actual)));
     // WHEN/THEN
-    paths.assertHasDigest(info, actual, algorithm, expected);
+    underTest.assertHasDigest(INFO, actual, algorithm, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasExtension_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasExtension_Test.java
@@ -38,7 +38,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = null;
     String expected = "txt";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasExtension(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     String expected = "txt";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasExtension(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -60,7 +60,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("directory"));
     String expected = "txt";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasExtension(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -71,7 +71,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("file.txt"));
     String expected = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasExtension(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The expected extension should not be null.");
@@ -84,7 +84,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve(filename));
     String expected = "log";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasExtension(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveExtension(actual, expected).create());
   }
@@ -95,7 +95,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("file.txt"));
     String expected = "log";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasExtension(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveExtension(actual, "txt", expected).create());
   }
@@ -106,7 +106,7 @@ class Paths_assertHasExtension_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("file.txt"));
     String expected = "txt";
     // WHEN/THEN
-    paths.assertHasExtension(info, actual, expected);
+    underTest.assertHasExtension(INFO, actual, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
@@ -34,7 +34,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = null;
     String filename = "actual";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasFileName(info, actual, filename));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasFileName(INFO, actual, filename));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -45,7 +45,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("actual");
     String filename = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasFileName(info, actual, filename));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasFileName(INFO, actual, filename));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("expected fileName should not be null");
@@ -57,7 +57,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("actual");
     String filename = "filename";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasFileName(info, null, filename));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasFileName(INFO, null, filename));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -68,7 +68,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("actual");
     String filename = "actual";
     // WHEN/THEN
-    paths.assertHasFileName(info, actual, filename);
+    underTest.assertHasFileName(INFO, actual, filename);
   }
 
   @Test
@@ -77,7 +77,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     String filename = "actual";
     // WHEN/THEN
-    paths.assertHasFileName(info, actual, filename);
+    underTest.assertHasFileName(INFO, actual, filename);
   }
 
   @Test
@@ -86,7 +86,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     String filename = "actual";
     // WHEN/THEN
-    paths.assertHasFileName(info, actual, filename);
+    underTest.assertHasFileName(INFO, actual, filename);
   }
 
   @Test
@@ -95,7 +95,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
     Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir);
     String filename = "actual";
     // WHEN/THEN
-    paths.assertHasFileName(info, actual, filename);
+    underTest.assertHasFileName(INFO, actual, filename);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileSystem_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileSystem_Test.java
@@ -42,7 +42,7 @@ class Paths_assertHasFileSystem_Test extends PathsBaseTest {
     // GIVEN
     FileSystem expectedFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasFileSystem(info, null, expectedFileSystem));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasFileSystem(INFO, null, expectedFileSystem));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -54,7 +54,7 @@ class Paths_assertHasFileSystem_Test extends PathsBaseTest {
     FileSystem actualFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     given(actualPath.getFileSystem()).willReturn(actualFileSystem);
     // WHEN
-    Throwable error = catchThrowable(() -> paths.assertHasFileSystem(info, actualPath, null));
+    Throwable error = catchThrowable(() -> underTest.assertHasFileSystem(INFO, actualPath, null));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("The expected file system should not be null");
@@ -67,7 +67,7 @@ class Paths_assertHasFileSystem_Test extends PathsBaseTest {
     given(actualPath.getFileSystem()).willReturn(null);
     FileSystem expectedFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     // WHEN
-    Throwable error = catchThrowable(() -> paths.assertHasFileSystem(info, actualPath, expectedFileSystem));
+    Throwable error = catchThrowable(() -> underTest.assertHasFileSystem(INFO, actualPath, expectedFileSystem));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("The actual file system should not be null");
@@ -81,7 +81,7 @@ class Paths_assertHasFileSystem_Test extends PathsBaseTest {
     given(actualPath.getFileSystem()).willReturn(actualFileSystem);
     FileSystem expectedFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasFileSystem(info, actualPath, expectedFileSystem));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasFileSystem(INFO, actualPath, expectedFileSystem));
     // THEN
     then(error).hasMessage(shouldHaveFileSystem(actualPath, expectedFileSystem).create())
                .isInstanceOf(AssertionFailedError.class)
@@ -97,6 +97,6 @@ class Paths_assertHasFileSystem_Test extends PathsBaseTest {
     FileSystem actualFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     given(actualPath.getFileSystem()).willReturn(actualFileSystem);
     // WHEN/THEN
-    paths.assertHasFileSystem(info, actualPath, actualFileSystem);
+    underTest.assertHasFileSystem(INFO, actualPath, actualFileSystem);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoExtension_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoExtension_Test.java
@@ -36,7 +36,7 @@ class Paths_assertHasNoExtension_Test extends PathsBaseTest {
     // GIVEN
     Path actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertHasNoExtension_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -56,7 +56,7 @@ class Paths_assertHasNoExtension_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -66,7 +66,7 @@ class Paths_assertHasNoExtension_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("file.txt"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldHaveNoExtension(actual, "txt").create());
   }
@@ -77,7 +77,7 @@ class Paths_assertHasNoExtension_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve(filename));
     // WHEN/THEN
-    paths.assertHasNoExtension(info, actual);
+    underTest.assertHasNoExtension(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
@@ -30,7 +30,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoParentRaw(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParentRaw(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -40,7 +40,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoParentRaw(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParentRaw(INFO, actual));
     // THEN
     then(error).hasMessage(shouldHaveNoParent(actual).create());
   }
@@ -50,7 +50,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.getRoot();
     // WHEN/THEN
-    paths.assertHasNoParentRaw(info, actual);
+    underTest.assertHasNoParentRaw(INFO, actual);
   }
 
   @Test
@@ -59,7 +59,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
     Path root = tempDir.getRoot();
     Path actual = createSymbolicLink(tempDir.resolve("actual"), root);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoParentRaw(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParentRaw(INFO, actual));
     // THEN
     then(error).hasMessage(shouldHaveNoParent(actual).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
@@ -34,7 +34,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoParent(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParent(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(actual.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasNoParent(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasNoParent(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -57,7 +57,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual")).toRealPath();
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasNoParent(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParent(INFO, actual));
     // THEN
     then(error).hasMessage(shouldHaveNoParent(actual).create());
   }
@@ -67,7 +67,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.getRoot();
     // WHEN/THEN
-    paths.assertHasNoParent(info, actual);
+    underTest.assertHasNoParent(INFO, actual);
   }
 
   @Test
@@ -76,7 +76,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
     Path root = tempDir.getRoot();
     Path actual = createSymbolicLink(tempDir.resolve("actual"), root);
     // WHEN/THEN
-    paths.assertHasNoParent(info, actual);
+    underTest.assertHasNoParent(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
@@ -34,7 +34,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     // GIVEN
     Path expected = tempDir.resolve("expected");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParentRaw(info, null, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, null, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -44,7 +44,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("actual");
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasParentRaw(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasParentRaw(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("expected parent path should not be null");
@@ -56,7 +56,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     Path actual = tempDir.getRoot();
     Path expected = tempDir.resolve("expected");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParentRaw(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, expected).create());
   }
@@ -67,7 +67,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParentRaw(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, actual.getParent(), expected).create());
   }
@@ -78,7 +78,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path expected = tempDir;
     // WHEN
-    paths.assertHasParentRaw(info, actual, expected);
+    underTest.assertHasParentRaw(INFO, actual, expected);
   }
 
   @Test
@@ -88,7 +88,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     Path file = createFile(expected.resolve("file"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParentRaw(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, actual.getParent(), expected).create());
   }
@@ -100,7 +100,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     Path expected = createSymbolicLink(tempDir.resolve("expected"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParentRaw(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, actual.getParent(), expected).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
@@ -37,7 +37,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     // GIVEN
     Path expected = tempDir.resolve("expected");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParent(info, null, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParent(INFO, null, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -47,7 +47,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("actual");
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasParent(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasParent(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("expected parent path should not be null");
@@ -59,7 +59,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     Path actual = tempDir.getRoot();
     Path expected = tempDir.resolve("expected");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParent(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParent(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, expected).create());
   }
@@ -72,7 +72,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(actual.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasParent(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasParent(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -86,7 +86,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(expected.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasParent(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasParent(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -98,7 +98,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual")).toRealPath();
     Path expected = createFile(tempDir.resolve("expected")).toRealPath();
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasParent(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParent(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveParent(actual, actual.getParent(), expected).create());
   }
@@ -109,7 +109,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual")).toRealPath();
     Path expected = tempDir.toRealPath();
     // WHEN/THEN
-    paths.assertHasParent(info, actual, expected);
+    underTest.assertHasParent(INFO, actual, expected);
   }
 
   @Test
@@ -119,7 +119,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     Path file = createFile(expected.resolve("file"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN/THEN
-    paths.assertHasParent(info, actual, expected);
+    underTest.assertHasParent(INFO, actual, expected);
   }
 
   @Test
@@ -129,7 +129,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     Path expected = createSymbolicLink(tempDir.resolve("expected"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN/THEN
-    paths.assertHasParent(info, actual, expected);
+    underTest.assertHasParent(INFO, actual, expected);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameBinaryContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameBinaryContentAs_Test.java
@@ -43,7 +43,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameBinaryContentAs(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The given Path to compare actual content to should not be null");
@@ -55,7 +55,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path expected = tempDir.resolve("non-existent");
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The given Path <%s> to compare actual content to should exist", expected);
@@ -69,7 +69,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     Path expected = createFile(tempDir.resolve("expected"));
     expected.toFile().setReadable(false);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The given Path <%s> to compare actual content to should be readable", expected);
@@ -80,7 +80,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     // GIVEN
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameBinaryContentAs(info, null, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameBinaryContentAs(INFO, null, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -91,7 +91,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -104,7 +104,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     actual.toFile().setReadable(false);
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -122,7 +122,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     Path actual = Files.write(tempDir.resolve("actual"), content.getBytes(actualCharset));
     Path expected = Files.write(tempDir.resolve("expected"), content.getBytes(expectedCharset));
     // WHEN/THEN
-    paths.assertHasSameBinaryContentAs(info, actual, expected);
+    underTest.assertHasSameBinaryContentAs(INFO, actual, expected);
   }
 
   @ParameterizedTest
@@ -139,9 +139,9 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     Path expected = Files.write(tempDir.resolve("expected"), expectedContent.getBytes(expectedCharset));
     BinaryDiffResult diff = binaryDiff.diff(actual, expectedContent.getBytes(expectedCharset));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
-    then(error).hasMessage(shouldHaveBinaryContent(actual, diff).create(info.description(), info.representation()));
+    then(error).hasMessage(shouldHaveBinaryContent(actual, diff).create(INFO.description(), INFO.representation()));
   }
 
   @Test
@@ -152,7 +152,7 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     willThrow(exception).given(binaryDiff).diff(actual, "Content".getBytes());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameBinaryContentAs(info, actual, expected));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameFileSystemAsPath_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameFileSystemAsPath_Test.java
@@ -41,7 +41,7 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     // GIVEN
     Path expectedPath = mock(Path.class, withSettings().stubOnly());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameFileSystemAs(info, null, expectedPath));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameFileSystemAs(INFO, null, expectedPath));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -51,7 +51,7 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     // GIVEN
     Path actualPath = mock(Path.class, withSettings().stubOnly());
     // WHEN
-    Throwable error = catchThrowable(() -> paths.assertHasSameFileSystemAs(info, actualPath, null));
+    Throwable error = catchThrowable(() -> underTest.assertHasSameFileSystemAs(INFO, actualPath, null));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("The expected path should not be null");
@@ -67,7 +67,7 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     given(expectedPath.getFileSystem()).willReturn(null);
 
     // WHEN
-    Throwable error = catchThrowable(() -> paths.assertHasSameFileSystemAs(info, actualPath, expectedPath));
+    Throwable error = catchThrowable(() -> underTest.assertHasSameFileSystemAs(INFO, actualPath, expectedPath));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("The expected file system should not be null");
@@ -82,7 +82,7 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     FileSystem expectedFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     given(expectedPath.getFileSystem()).willReturn(expectedFileSystem);
     // WHEN
-    Throwable error = catchThrowable(() -> paths.assertHasSameFileSystemAs(info, actualPath, expectedPath));
+    Throwable error = catchThrowable(() -> underTest.assertHasSameFileSystemAs(INFO, actualPath, expectedPath));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("The actual file system should not be null");
@@ -98,7 +98,7 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     FileSystem expectedFileSystem = mock(FileSystem.class, withSettings().stubOnly());
     given(expectedPath.getFileSystem()).willReturn(expectedFileSystem);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameFileSystemAs(info, actualPath, expectedPath));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameFileSystemAs(INFO, actualPath, expectedPath));
     // THEN
     then(error).hasMessage(shouldHaveSameFileSystemAs(actualPath, expectedPath).create())
                .isInstanceOf(AssertionFailedError.class)
@@ -116,6 +116,6 @@ class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
     Path expectedPath = mock(Path.class, withSettings().stubOnly());
     given(expectedPath.getFileSystem()).willReturn(actualFileSystem);
     // WHEN/THEN
-    paths.assertHasSameFileSystemAs(info, actualPath, expectedPath);
+    underTest.assertHasSameFileSystemAs(INFO, actualPath, expectedPath);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameTextualContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameTextualContentAs_Test.java
@@ -47,7 +47,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, null, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, null, CHARSET));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The given Path to compare actual content to should not be null");
@@ -59,7 +59,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path expected = tempDir.resolve("non-existent");
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, expected, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected, CHARSET));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The given Path <%s> to compare actual content to should exist", expected);
@@ -73,7 +73,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     Path expected = createFile(tempDir.resolve("expected"));
     expected.toFile().setReadable(false);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, expected, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected, CHARSET));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The given Path <%s> to compare actual content to should be readable", expected);
@@ -84,7 +84,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     // GIVEN
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameTextualContentAs(info, null, CHARSET, expected,
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameTextualContentAs(INFO, null, CHARSET, expected,
                                                                                           CHARSET));
     // THEN
     then(error).hasMessage(actualIsNull());
@@ -96,7 +96,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, expected,
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected,
                                                                                           CHARSET));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
@@ -110,7 +110,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     actual.toFile().setReadable(false);
     Path expected = createFile(tempDir.resolve("expected"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, expected,
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected,
                                                                                           CHARSET));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
@@ -130,7 +130,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     Path actual = Files.write(tempDir.resolve("actual"), content.getBytes(actualCharset));
     Path expected = Files.write(tempDir.resolve("expected"), content.getBytes(expectedCharset));
     // WHEN/THEN
-    paths.assertHasSameTextualContentAs(info, actual, actualCharset, expected, expectedCharset);
+    underTest.assertHasSameTextualContentAs(INFO, actual, actualCharset, expected, expectedCharset);
   }
 
   @ParameterizedTest
@@ -146,10 +146,10 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     Path expected = Files.write(tempDir.resolve("expected"), expectedContent.getBytes(expectedCharset));
     List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSameTextualContentAs(info, actual, actualCharset,
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameTextualContentAs(INFO, actual, actualCharset,
                                                                                           expected, expectedCharset));
     // THEN
-    then(error).hasMessage(shouldHaveSameContent(actual, expected, diffs).create(info.description(), info.representation()));
+    then(error).hasMessage(shouldHaveSameContent(actual, expected, diffs).create(INFO.description(), INFO.representation()));
   }
 
   @Test
@@ -160,7 +160,7 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     willThrow(exception).given(diff).diff(actual, CHARSET, expected, CHARSET);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSameTextualContentAs(info, actual, CHARSET, expected, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected, CHARSET));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
@@ -36,7 +36,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, null, 0L));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSize(INFO, null, 0L));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, 0L));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSize(INFO, actual, 0L));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -56,7 +56,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, 0L));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSize(INFO, actual, 0L));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -68,7 +68,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(nioFilesWrapper.size(actual)).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasSize(info, actual, 0L));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasSize(INFO, actual, 0L));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -79,7 +79,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
     // WHEN/THEN
-    paths.assertHasSize(info, actual, 7L);
+    underTest.assertHasSize(INFO, actual, 7L);
   }
 
   @Test
@@ -87,7 +87,7 @@ class Paths_assertHasSize_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, 6L));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSize(INFO, actual, 6L));
     // THEN
     then(error).hasMessage(shouldHaveSize(actual, 6L).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasTextualContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasTextualContent_Test.java
@@ -49,7 +49,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasTextualContent(info, actual, null, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasTextualContent(INFO, actual, null, CHARSET));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The text to compare to should not be null");
@@ -60,7 +60,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     // GIVEN
     String expected = "expected";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasTextualContent(info, null, expected, CHARSET));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, null, expected, CHARSET));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -71,7 +71,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     String expected = "expected";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasTextualContent(info, actual, expected, CHARSET));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -84,7 +84,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     actual.toFile().setReadable(false);
     String expected = "expected";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasTextualContent(info, actual, expected, CHARSET));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -95,7 +95,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     Path actual = Files.write(tempDir.resolve("actual"), "Content".getBytes(CHARSET));
     String expected = "Content";
     // WHEN/THEN
-    paths.assertHasTextualContent(info, actual, expected, CHARSET);
+    underTest.assertHasTextualContent(INFO, actual, expected, CHARSET);
   }
 
   @Test
@@ -105,9 +105,9 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     String expected = "Another content";
     List<Delta<String>> diffs = diff.diff(actual, expected, CHARSET);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasTextualContent(info, actual, expected, CHARSET));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
     // THEN
-    then(error).hasMessage(shouldHaveContent(actual, CHARSET, diffs).create(info.description(), info.representation()));
+    then(error).hasMessage(shouldHaveContent(actual, CHARSET, diffs).create(INFO.description(), INFO.representation()));
   }
 
   @Test
@@ -118,7 +118,7 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     willThrow(exception).given(diff).diff(actual, expected, CHARSET);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertHasTextualContent(info, actual, expected, CHARSET));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasMessage("Unable to verify text contents of path:<%s>", actual)

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsAbsolute_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsAbsolute_Test.java
@@ -31,7 +31,7 @@ class Paths_assertIsAbsolute_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsAbsolute(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsAbsolute(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -42,7 +42,7 @@ class Paths_assertIsAbsolute_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Paths.get("relative");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsAbsolute(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsAbsolute(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeAbsolutePath(actual).create());
   }
@@ -57,7 +57,7 @@ class Paths_assertIsAbsolute_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.getRoot().resolve("foo").resolve("bar");
     // WHEN/THEN
-    paths.assertIsAbsolute(info, actual);
+    underTest.assertIsAbsolute(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
@@ -34,7 +34,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsCanonical(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsCanonical(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(actual.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsCanonical(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsCanonical(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -58,7 +58,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
     Path file = createFile(tempDir.resolve("file"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsCanonical(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsCanonical(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeCanonicalPath(actual).create());
   }
@@ -68,7 +68,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual")).toRealPath();
     // WHEN/THEN
-    paths.assertIsCanonical(info, actual);
+    underTest.assertIsCanonical(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_Predicate_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_Predicate_Test.java
@@ -46,7 +46,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     Predicate<Path> filter = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The paths filter should not be null");
@@ -58,7 +58,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path actual = null;
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -69,7 +69,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path actual = tempDir.resolve("non-existent");
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -80,7 +80,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path actual = createFile(tempDir.resolve("file"));
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -93,7 +93,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -105,7 +105,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(directoryShouldContain(actual, emptyList(), "the given filter").create());
   }
@@ -117,7 +117,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     createFile(actual.resolve("file"));
     Predicate<Path> filter = Files::isRegularFile;
     // WHEN/THEN
-    paths.assertIsDirectoryContaining(info, actual, filter);
+    underTest.assertIsDirectoryContaining(INFO, actual, filter);
   }
 
   @Test
@@ -127,7 +127,7 @@ class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTes
     Path directory = createDirectory(actual.resolve("directory"));
     Predicate<Path> filter = Files::isRegularFile;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(directoryShouldContain(actual, list(directory), "the given filter").create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
@@ -46,7 +46,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     String syntaxAndPattern = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The syntax and pattern should not be null");
@@ -58,7 +58,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = null;
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -69,7 +69,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = tempDir.resolve("non-existent");
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -80,7 +80,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("file"));
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -93,7 +93,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -105,7 +105,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(directoryShouldContain(actual, emptyList(), "the 'glob:**' pattern").create());
   }
@@ -123,7 +123,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     createDirectory(actual.resolve("directory"));
     createFile(actual.resolve("file"));
     // WHEN/THEN
-    paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern);
+    underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern);
   }
 
   @ParameterizedTest
@@ -138,7 +138,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     Path directory = createDirectory(actual.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(directoryShouldContain(actual, list(directory), "the '" + syntaxAndPattern + "' pattern").create());
   }
@@ -156,7 +156,7 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
     Path directory = createDirectory(actual.resolve("directory"));
     createFile(directory.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(directoryShouldContain(actual, list(directory), "the '" + syntaxAndPattern + "' pattern").create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_Predicate_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_Predicate_Test.java
@@ -45,7 +45,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path actual = createDirectory(tempDir.resolve("actual"));
     Predicate<Path> filter = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The paths filter should not be null");
@@ -57,7 +57,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path actual = null;
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -68,7 +68,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path actual = tempDir.resolve("non-existent");
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -79,7 +79,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path actual = createFile(tempDir.resolve("file"));
     Predicate<Path> filter = path -> true;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -92,7 +92,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -104,7 +104,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path actual = createDirectory(tempDir.resolve("actual"));
     Predicate<Path> filter = path -> true;
     // WHEN/THEN
-    paths.assertIsDirectoryNotContaining(info, actual, filter);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, filter);
   }
 
   @Test
@@ -114,7 +114,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     Path file = createFile(actual.resolve("file"));
     Predicate<Path> filter = Files::isRegularFile;
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, filter));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, filter));
     // THEN
     then(error).hasMessage(directoryShouldNotContain(actual, list(file), "the given filter").create());
   }
@@ -126,7 +126,7 @@ class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBase
     createDirectory(actual.resolve("directory"));
     Predicate<Path> filter = Files::isRegularFile;
     // WHEN/THEN
-    paths.assertIsDirectoryNotContaining(info, actual, filter);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, filter);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
@@ -45,7 +45,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     String syntaxAndPattern = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The syntax and pattern should not be null");
@@ -57,7 +57,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = null;
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -68,7 +68,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = tempDir.resolve("non-existent");
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -79,7 +79,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = createFile(tempDir.resolve("file"));
     String syntaxAndPattern = "glob:**";
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -92,7 +92,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);
@@ -104,7 +104,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     String syntaxAndPattern = "glob:**";
     // WHEN/THEN
-    paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern);
   }
 
   @ParameterizedTest
@@ -119,7 +119,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     Path file = createFile(actual.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(directoryShouldNotContain(actual, list(file), "the '" + syntaxAndPattern + "' pattern").create());
   }
@@ -136,7 +136,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path actual = createDirectory(tempDir.resolve("actual"));
     createDirectory(actual.resolve("directory"));
     // WHEN/THEN
-    paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern);
   }
 
   @ParameterizedTest
@@ -152,7 +152,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
     Path directory = createDirectory(actual.resolve("directory"));
     createFile(directory.resolve("file"));
     // WHEN/THEN
-    paths.assertIsDirectoryNotContaining(info, actual, syntaxAndPattern);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectory_Test.java
@@ -31,7 +31,7 @@ class Paths_assertIsDirectory_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectory(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectory(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -41,7 +41,7 @@ class Paths_assertIsDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -51,7 +51,7 @@ class Paths_assertIsDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -61,7 +61,7 @@ class Paths_assertIsDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertIsDirectory(info, actual);
+    underTest.assertIsDirectory(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsEmptyDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsEmptyDirectory_Test.java
@@ -40,7 +40,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyDirectory(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -50,7 +50,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -60,7 +60,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -70,7 +70,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertIsEmptyDirectory(info, actual);
+    underTest.assertIsEmptyDirectory(INFO, actual);
   }
 
   @Test
@@ -79,7 +79,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     Path file = createFile(actual.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeEmptyDirectory(actual, singletonList(file)).create());
   }
@@ -91,7 +91,7 @@ class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsEmptyDirectory(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsEmptyFile_Test.java
@@ -36,7 +36,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyFile(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -56,7 +56,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -66,7 +66,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertIsEmptyFile(info, actual);
+    underTest.assertIsEmptyFile(INFO, actual);
   }
 
   @Test
@@ -74,7 +74,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeEmpty(actual).create());
   }
@@ -86,7 +86,7 @@ class Paths_assertIsEmptyFile_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(nioFilesWrapper.size(actual)).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsEmptyFile(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsExecutable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsExecutable_Test.java
@@ -32,7 +32,7 @@ class Paths_assertIsExecutable_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsExecutable(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsExecutable(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -42,7 +42,7 @@ class Paths_assertIsExecutable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsExecutable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsExecutable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -53,7 +53,7 @@ class Paths_assertIsExecutable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsExecutable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsExecutable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeExecutable(actual).create());
   }
@@ -64,7 +64,7 @@ class Paths_assertIsExecutable_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     actual.toFile().setExecutable(true);
     // WHEN/THEN
-    paths.assertIsExecutable(info, actual);
+    underTest.assertIsExecutable(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNormalized_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNormalized_Test.java
@@ -32,7 +32,7 @@ class Paths_assertIsNormalized_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNormalized(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNormalized(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertIsNormalized_Test extends PathsBaseTest {
   })
   void should_fail_on_unix_if_actual_is_not_normalized(Path actual) {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNormalized(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNormalized(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeNormalized(actual).create());
   }
@@ -60,7 +60,7 @@ class Paths_assertIsNormalized_Test extends PathsBaseTest {
   })
   void should_fail_on_windows_if_actual_is_not_normalized(Path actual) {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNormalized(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNormalized(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeNormalized(actual).create());
   }
@@ -74,7 +74,7 @@ class Paths_assertIsNormalized_Test extends PathsBaseTest {
   })
   void should_pass_on_unix_if_actual_is_normalized(Path actual) {
     // WHEN/THEN
-    paths.assertIsNormalized(info, actual);
+    underTest.assertIsNormalized(INFO, actual);
   }
 
   @ParameterizedTest
@@ -86,7 +86,7 @@ class Paths_assertIsNormalized_Test extends PathsBaseTest {
   })
   void should_pass_on_windows_if_actual_is_normalized(Path actual) {
     // WHEN/THEN
-    paths.assertIsNormalized(info, actual);
+    underTest.assertIsNormalized(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNotEmptyDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNotEmptyDirectory_Test.java
@@ -39,7 +39,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyDirectory(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -59,7 +59,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("file"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeDirectory(actual).create());
   }
@@ -70,7 +70,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
     Path actual = createDirectory(tempDir.resolve("actual"));
     createFile(actual.resolve("file"));
     // WHEN/THEN
-    paths.assertIsNotEmptyDirectory(info, actual);
+    underTest.assertIsNotEmptyDirectory(INFO, actual);
   }
 
   @Test
@@ -78,7 +78,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyDirectory(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(shouldNotBeEmpty(actual).create());
   }
@@ -90,7 +90,7 @@ class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
     IOException cause = new IOException("boom!");
     willThrow(cause).given(nioFilesWrapper).newDirectoryStream(any(), any());
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsNotEmptyDirectory(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(cause);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNotEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsNotEmptyFile_Test.java
@@ -36,7 +36,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyFile(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -46,7 +46,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -56,7 +56,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -66,7 +66,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
     // WHEN/THEN
-    paths.assertIsNotEmptyFile(info, actual);
+    underTest.assertIsNotEmptyFile(INFO, actual);
   }
 
   @Test
@@ -74,7 +74,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsNotEmptyFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldNotBeEmpty(actual).create());
   }
@@ -86,7 +86,7 @@ class Paths_assertIsNotEmptyFile_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(nioFilesWrapper.size(actual)).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertIsNotEmptyFile(info, actual));
+    Throwable thrown = catchThrowable(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsReadable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsReadable_Test.java
@@ -32,7 +32,7 @@ class Paths_assertIsReadable_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsReadable(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsReadable(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -42,7 +42,7 @@ class Paths_assertIsReadable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsReadable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsReadable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -54,7 +54,7 @@ class Paths_assertIsReadable_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     actual.toFile().setReadable(false);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsReadable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsReadable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeReadable(actual).create());
   }
@@ -64,7 +64,7 @@ class Paths_assertIsReadable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertIsReadable(info, actual);
+    underTest.assertIsReadable(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRegularFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRegularFile_Test.java
@@ -31,7 +31,7 @@ class Paths_assertIsRegularFile_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsRegularFile(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsRegularFile(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -41,7 +41,7 @@ class Paths_assertIsRegularFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsRegularFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsRegularFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -51,7 +51,7 @@ class Paths_assertIsRegularFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("directory"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsRegularFile(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsRegularFile(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeRegularFile(actual).create());
   }
@@ -61,7 +61,7 @@ class Paths_assertIsRegularFile_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
     // WHEN/THEN
-    paths.assertIsRegularFile(info, actual);
+    underTest.assertIsRegularFile(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRelative_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsRelative_Test.java
@@ -28,7 +28,7 @@ class Paths_assertIsRelative_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsRelative(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsRelative(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -38,7 +38,7 @@ class Paths_assertIsRelative_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.getRoot().resolve("absolute");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsRelative(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsRelative(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeRelativePath(actual).create());
   }
@@ -48,7 +48,7 @@ class Paths_assertIsRelative_Test extends PathsBaseTest {
     // GIVEN
     Path actual = Paths.get("relative");
     // WHEN/THEN
-    paths.assertIsRelative(info, actual);
+    underTest.assertIsRelative(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
@@ -31,7 +31,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsSymbolicLink(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsSymbolicLink(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -41,7 +41,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsSymbolicLink(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsSymbolicLink(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExistNoFollowLinks(actual).create());
   }
@@ -51,7 +51,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsSymbolicLink(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsSymbolicLink(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeSymbolicLink(actual).create());
   }
@@ -61,7 +61,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir.resolve("target"));
     // WHEN/THEN
-    paths.assertIsSymbolicLink(info, actual);
+    underTest.assertIsSymbolicLink(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsWritable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsWritable_Test.java
@@ -30,7 +30,7 @@ class Paths_assertIsWritable_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsWritable(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsWritable(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -40,7 +40,7 @@ class Paths_assertIsWritable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsWritable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsWritable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldExist(actual).create());
   }
@@ -51,7 +51,7 @@ class Paths_assertIsWritable_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     actual.toFile().setWritable(false);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertIsWritable(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsWritable(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeWritable(actual).create());
   }
@@ -61,7 +61,7 @@ class Paths_assertIsWritable_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN/THEN
-    paths.assertIsWritable(info, actual);
+    underTest.assertIsWritable(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
@@ -30,7 +30,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertDoesNotExist(info, null));
+    AssertionError error = expectAssertionError(() -> underTest.assertDoesNotExist(INFO, null));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -40,7 +40,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertDoesNotExist(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertDoesNotExist(INFO, actual));
     // THEN
     then(error).hasMessage(shouldNotExist(actual).create());
   }
@@ -50,7 +50,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
     // GIVEN
     Path actual = tempDir.resolve("non-existent");
     // WHEN/THEN
-    paths.assertDoesNotExist(info, actual);
+    underTest.assertDoesNotExist(INFO, actual);
   }
 
   @Test
@@ -59,7 +59,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
     Path target = tempDir.resolve("non-existent");
     Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertDoesNotExist(info, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertDoesNotExist(INFO, actual));
     // THEN
     then(error).hasMessage(shouldNotExist(actual).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
@@ -34,7 +34,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     // GIVEN
     Path other = createFile(tempDir.resolve("other"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWithRaw(info, null, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, null, other));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -44,7 +44,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertStartsWithRaw(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertStartsWithRaw(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("the expected start path should not be null");
@@ -56,7 +56,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = createFile(tempDir.resolve("other"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldStartWith(actual, other).create());
   }
@@ -67,7 +67,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     Path other = createDirectory(tempDir.resolve("other")).toRealPath();
     Path actual = createFile(other.resolve("actual")).toRealPath();
     // WHEN/THEN
-    paths.assertStartsWithRaw(info, actual, other);
+    underTest.assertStartsWithRaw(INFO, actual, other);
   }
 
   @Test
@@ -77,7 +77,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     Path file = createFile(other.resolve("file"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldStartWith(actual, other).create());
   }
@@ -89,7 +89,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     Path other = createSymbolicLink(tempDir.resolve("other"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWithRaw(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldStartWith(actual, other).create());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
@@ -37,7 +37,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     // GIVEN
     Path other = createFile(tempDir.resolve("other"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWith(info, null, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWith(INFO, null, other));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -47,7 +47,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     // GIVEN
     Path actual = createFile(tempDir.resolve("actual"));
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertStartsWith(info, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertStartsWith(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("the expected start path should not be null");
@@ -61,7 +61,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(actual.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertStartsWith(info, actual, other));
+    Throwable thrown = catchThrowable(() -> underTest.assertStartsWith(INFO, actual, other));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -75,7 +75,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     IOException exception = new IOException("boom!");
     given(other.toRealPath()).willThrow(exception);
     // WHEN
-    Throwable thrown = catchThrowable(() -> paths.assertStartsWith(info, actual, other));
+    Throwable thrown = catchThrowable(() -> underTest.assertStartsWith(INFO, actual, other));
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
@@ -87,7 +87,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     Path actual = createFile(tempDir.resolve("actual"));
     Path other = createFile(tempDir.resolve("other"));
     // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertStartsWith(info, actual, other));
+    AssertionError error = expectAssertionError(() -> underTest.assertStartsWith(INFO, actual, other));
     // THEN
     then(error).hasMessage(shouldStartWith(actual, other).create());
   }
@@ -98,7 +98,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     Path other = createDirectory(tempDir.resolve("other")).toRealPath();
     Path actual = createFile(other.resolve("actual")).toRealPath();
     // WHEN/THEN
-    paths.assertStartsWith(info, actual, other);
+    underTest.assertStartsWith(INFO, actual, other);
   }
 
   @Test
@@ -108,7 +108,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     Path file = createFile(other.resolve("file"));
     Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN/THEN
-    paths.assertStartsWith(info, actual, other);
+    underTest.assertStartsWith(INFO, actual, other);
   }
 
   @Test
@@ -118,7 +118,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     Path other = createSymbolicLink(tempDir.resolve("other"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN/THEN
-    paths.assertStartsWith(info, actual, other);
+    underTest.assertStartsWith(INFO, actual, other);
   }
 
 }


### PR DESCRIPTION
Inspired by https://github.com/jacoco/jacoco/issues/1344#issuecomment-1185540609:

> Also looks like due to the mocking of Paths tons of classes are generated by Mockito every time. Maybe this can be avoided or the mocked instance can be shared across test cases.

I refactored the way spies are created in "PathsBaseTest" and this was a huge performance improvement, so the file system impact described in #2567 is most likely negligible.