### PR TITLE
Reuse mocks and spies in `File` tests

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/internal/FilesBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/FilesBaseTest.java
@@ -12,32 +12,25 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -51,51 +44,47 @@ public class FilesBaseTest {
 
   protected static final AssertionInfo INFO = someInfo();
 
-  @TempDir
-  protected File tempDir;
-  protected File actual;
-  protected Failures failures;
-  protected Files files;
-  protected Files unMockedFiles;
-  protected Failures unMockedFailures;
-  protected Diff diff;
-  protected Delta<String> delta;
-  protected BinaryDiff binaryDiff;
-  protected NioFilesWrapper nioFilesWrapper;
+  protected static Files underTest = new Files();
+
+  protected static NioFilesWrapper nioFilesWrapper = mock(NioFilesWrapper.class);
+  protected static Failures failures = spy(underTest.failures);
+  protected static Diff diff = mock(Diff.class);
+  protected static BinaryDiff binaryDiff = mock(BinaryDiff.class);
+  protected static File actual = mock(File.class);
 
   @SuppressWarnings("unchecked")
-  @BeforeEach
-  public void setUp() {
-    actual = mock(File.class);
-    failures = spy(new Failures());
-    unMockedFailures = spy(new Failures());
-    files = new Files();
-    unMockedFiles = new Files();
-    files.failures = failures;
-    unMockedFiles.failures = unMockedFailures;
-    diff = mock(Diff.class);
-    delta = mock(Delta.class);
-    when(delta.toString()).thenReturn("Extra lines at line 2 : [line1a, line1b]");
-    files.diff = diff;
-    binaryDiff = mock(BinaryDiff.class);
-    files.binaryDiff = binaryDiff;
-    nioFilesWrapper = mock(NioFilesWrapper.class);
-    files.nioFilesWrapper = nioFilesWrapper;
+  protected static Delta<String> delta = mock(Delta.class);
+
+  protected Files unMockedFiles;
+
+  @TempDir
+  protected File tempDir;
+
+  @BeforeAll
+  static void injectMocks() {
+    underTest.nioFilesWrapper = nioFilesWrapper;
+    underTest.failures = failures;
+    underTest.diff = diff;
+    underTest.binaryDiff = binaryDiff;
   }
 
-  protected static void failIfStreamIsOpen(InputStream stream) {
-    try {
-      assertThat(stream.read()).as("Stream should be closed").isNegative();
-    } catch (IOException e) {
-      assertThat(e).hasNoCause().hasMessage("Stream closed");
-    }
+  @BeforeEach
+  void resetMocks() {
+    reset(nioFilesWrapper, failures, diff, binaryDiff, delta, actual);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    unMockedFiles = new Files();
+    unMockedFiles.failures = failures;
+    when(delta.toString()).thenReturn("Extra lines at line 2 : [line1a, line1b]");
   }
 
   protected static void mockPathMatcher(File actual) {
     FileSystem fileSystem = mock(FileSystem.class);
     given(fileSystem.getPathMatcher(anyString())).will(invocation -> {
       String regex = invocation.getArgument(0).toString().split(":")[1];
-      Pattern pattern = Pattern.compile("^" + regex + "$", Pattern.CASE_INSENSITIVE);
+      Pattern pattern = Pattern.compile("^" + regex + "$", CASE_INSENSITIVE);
       return (PathMatcher) path -> Optional.ofNullable(path.getFileName())
                                            .map(Path::toString)
                                            .filter(pattern.asPredicate())
@@ -108,58 +97,6 @@ public class FilesBaseTest {
       given(path.toFile()).willReturn(actual);
     }
     given(path.getFileSystem()).willReturn(fileSystem);
-  }
-
-  protected File mockFile(String... names) {
-    String name = names[names.length - 1];
-    File file = mock(File.class);
-    given(file.getName()).willReturn(name);
-    given(file.toString()).willReturn(name);
-    // mock as AssertJ file representation uses getAbsolutePath()
-    given(file.getAbsolutePath()).willReturn(name);
-
-    Path path = mock(Path.class);
-    given(path.getFileName()).willReturn(path);
-    given(path.toString()).willReturn(name);
-
-    given(file.toPath()).willReturn(path);
-    given(path.toFile()).willReturn(file);
-
-    FileSystem fileSystem = mock(FileSystem.class);
-    given(path.getFileSystem()).willReturn(fileSystem);
-    return file;
-  }
-
-  protected File mockRegularFile(String... names) {
-    File path = mockFile(names);
-    given(path.exists()).willReturn(true);
-    given(path.isFile()).willReturn(true);
-    try {
-      given(nioFilesWrapper.newInputStream(path.toPath())).willReturn(new ByteArrayInputStream(new byte[0]));
-    } catch (IOException e) {
-      throw new UncheckedIOException("error during nioFilesWrapper mock recording", e);
-    }
-    return path;
-  }
-
-  protected File mockDirectory(List<File> directoryFiles, String... names) {
-    File file = mockFile(names);
-    given(file.exists()).willReturn(true);
-    given(file.isDirectory()).willReturn(true);
-    // sets parent of all directoryFiles to file
-    directoryFiles.forEach(f -> given(f.getParentFile()).willReturn(file));
-    // re-implement listFiles(FileFilter) ... :(
-    Map<String, File> filesByName = directoryFiles.stream().collect(LinkedHashMap::new, // for consistent ordering
-                                                                    (map, item) -> map.put(item.getName(), item),
-                                                                    Map::putAll);
-    given(file.listFiles(any(FileFilter.class))).will(invocation -> {
-      FileFilter filter = invocation.getArgument(0);
-      return filesByName.keySet().stream()
-                        .map(name -> filesByName.get(name))
-                        .filter(fileWithName -> filter.accept(fileWithName))
-                        .toArray(File[]::new);
-    });
-    return file;
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
@@ -13,14 +13,16 @@
 package org.assertj.core.internal;
 
 import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 
 import java.nio.file.Path;
 
 import org.assertj.core.api.AssertionInfo;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -48,7 +50,20 @@ public abstract class PathsBaseTest {
     underTest.binaryDiff = binaryDiff;
   }
 
-  @AfterEach
+  @AfterAll
+  static void removeSpies() {
+    underTest.nioFilesWrapper = getSpiedInstance(nioFilesWrapper);
+    underTest.failures = getSpiedInstance(failures);
+    underTest.diff = getSpiedInstance(diff);
+    underTest.binaryDiff = getSpiedInstance(binaryDiff);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getSpiedInstance(Object spy) {
+    return (T) mockingDetails(spy).getMockCreationSettings().getSpiedInstance();
+  }
+
+  @BeforeEach
   void resetSpies() {
     reset(nioFilesWrapper, failures, diff, binaryDiff);
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/File_assertHasSize_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/File_assertHasSize_Test.java
@@ -46,7 +46,7 @@ class File_assertHasSize_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> files.assertHasSizeInBytes(INFO, actual, 17));
+    AssertionError assertionError = expectAssertionError(() -> underTest.assertHasSizeInBytes(INFO, actual, 17));
     // THEN
     assertThat(assertionError).hasMessage(actualIsNull());
   }
@@ -56,7 +56,7 @@ class File_assertHasSize_Test extends FilesBaseTest {
     // GIVEN
     long expectedSizeInBytes = 36L;
     // WHEN
-    expectAssertionError(() -> files.assertHasSizeInBytes(INFO, actual, expectedSizeInBytes));
+    expectAssertionError(() -> underTest.assertHasSizeInBytes(INFO, actual, expectedSizeInBytes));
     // THEN
     verify(failures).failure(INFO, shouldHaveSize(actual, expectedSizeInBytes));
   }
@@ -66,13 +66,13 @@ class File_assertHasSize_Test extends FilesBaseTest {
     // GIVEN
     File notAFile = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasSizeInBytes(INFO, notAFile, 36L));
+    expectAssertionError(() -> underTest.assertHasSizeInBytes(INFO, notAFile, 36L));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(notAFile));
   }
 
   @Test
   void should_pass_if_actual_has_expected_size() {
-    files.assertHasSizeInBytes(INFO, actual, actual.length());
+    underTest.assertHasSizeInBytes(INFO, actual, actual.length());
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanRead_Test.java
@@ -38,7 +38,7 @@ class Files_assertCanRead_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertCanRead(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertCanRead(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -48,7 +48,7 @@ class Files_assertCanRead_Test extends FilesBaseTest {
     // GIVEN
     File nonExistentFile = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertCanRead(INFO, nonExistentFile));
+    expectAssertionError(() -> underTest.assertCanRead(INFO, nonExistentFile));
     // THEN
     verify(failures).failure(INFO, shouldBeReadable(nonExistentFile));
   }
@@ -56,7 +56,7 @@ class Files_assertCanRead_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_can_read() {
     File actual = new File("src/test/resources/actual_file.txt");
-    files.assertCanRead(INFO, actual);
+    underTest.assertCanRead(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanWrite_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertCanWrite_Test.java
@@ -39,7 +39,7 @@ class Files_assertCanWrite_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertCanWrite(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertCanWrite(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Files_assertCanWrite_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertCanWrite(INFO, actual));
+    expectAssertionError(() -> underTest.assertCanWrite(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeWritable(actual));
   }
@@ -57,7 +57,7 @@ class Files_assertCanWrite_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_can_write() {
     File actual = newFile(tempDir.getAbsolutePath() + "to_write.txt");
-    files.assertCanWrite(INFO, actual);
+    underTest.assertCanWrite(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertDoesNotExist_Test.java
@@ -38,7 +38,7 @@ class Files_assertDoesNotExist_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertDoesNotExist(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertDoesNotExist(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -48,7 +48,7 @@ class Files_assertDoesNotExist_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("src/test/resources/actual_file.txt");
     // WHEN
-    expectAssertionError(() -> files.assertDoesNotExist(INFO, actual));
+    expectAssertionError(() -> underTest.assertDoesNotExist(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldNotExist(actual));
   }
@@ -56,6 +56,6 @@ class Files_assertDoesNotExist_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_does_not_exist() {
     File actual = new File("xyz");
-    files.assertDoesNotExist(INFO, actual);
+    underTest.assertDoesNotExist(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertExists_Test.java
@@ -38,7 +38,7 @@ class Files_assertExists_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertExists(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertExists(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -48,7 +48,7 @@ class Files_assertExists_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertExists(INFO, actual));
+    expectAssertionError(() -> underTest.assertExists(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldExist(actual));
   }
@@ -56,6 +56,6 @@ class Files_assertExists_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_exists() {
     File actual = new File("src/test/resources/actual_file.txt");
-    files.assertExists(INFO, actual);
+    underTest.assertExists(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasBinaryContent_Test.java
@@ -57,7 +57,7 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     // GIVEN
     byte[] expectedContent = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasBinaryContent(INFO, actual, expectedContent),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasBinaryContent(INFO, actual, expectedContent),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The binary content to compare to should not be null");
@@ -68,7 +68,7 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasBinaryContent(INFO, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, actual, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -78,7 +78,7 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     // GIVEN
     File notAFile = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasBinaryContent(INFO, notAFile, expected));
+    expectAssertionError(() -> underTest.assertHasBinaryContent(INFO, notAFile, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(notAFile));
   }
@@ -99,7 +99,7 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(binaryDiff.diff(actual, expected)).thenThrow(cause);
     // THEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasBinaryContent(INFO, actual, expected),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasBinaryContent(INFO, actual, expected),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -116,6 +116,6 @@ class Files_assertHasBinaryContent_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasBinaryContent(INFO, actual, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveBinaryContent(actual, diff));
+    verify(failures).failure(INFO, shouldHaveBinaryContent(actual, diff));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -60,7 +60,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
     // GIVEN
     String expectedContent = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasContent(INFO, actual, expectedContent, charset),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasContent(INFO, actual, expectedContent, charset),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The text to compare to should not be null");
@@ -71,7 +71,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasContent(INFO, actual, expected, charset));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasContent(INFO, actual, expected, charset));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -81,7 +81,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
     // GIVEN
     File notAFile = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasContent(INFO, notAFile, expected, charset));
+    expectAssertionError(() -> underTest.assertHasContent(INFO, notAFile, expected, charset));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(notAFile));
   }
@@ -89,7 +89,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
   @Test
   void should_pass_if_file_has_text_content() {
     String expected = "actual";
-    files.assertHasContent(INFO, actual, expected, charset);
+    underTest.assertHasContent(INFO, actual, expected, charset);
   }
 
   @Test
@@ -98,7 +98,7 @@ class Files_assertHasContent_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(diff.diff(actual, expected, charset)).thenThrow(cause);
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasContent(INFO, actual, expected, charset),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasContent(INFO, actual, expected, charset),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -112,6 +112,6 @@ class Files_assertHasContent_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasContent(INFO, actual, expected, charset));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveContent(actual, charset, diffs));
+    verify(failures).failure(INFO, shouldHaveContent(actual, charset, diffs));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmBytes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmBytes_Test.java
@@ -57,7 +57,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -67,7 +67,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldExist(actual));
   }
@@ -77,7 +77,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/tmp");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -89,7 +89,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     actual.setReadable(false);
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeReadable(actual));
   }
@@ -99,7 +99,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     MessageDigest digest = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The message digest algorithm should not be null");
@@ -110,7 +110,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     byte[] expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, algorithm, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The binary representation of digest to compare to should not be null");
@@ -123,7 +123,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     IOException cause = new IOException();
     given(nioFilesWrapper.newInputStream(any())).willThrow(cause);
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, algorithm, expected),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -134,7 +134,8 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // GIVEN
     String unknownDigestAlgorithm = "UnknownDigestAlgorithm";
     // WHEN
-    IllegalStateException ise = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, unknownDigestAlgorithm, expected),
+    IllegalStateException ise = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, unknownDigestAlgorithm,
+                                                                                     expected),
                                                      IllegalStateException.class);
     // THEN
     then(ise).hasMessage("Unable to find digest implementation for: <UnknownDigestAlgorithm>");
@@ -152,7 +153,7 @@ class Files_assertHasDigest_AlgorithmBytes_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveDigest(actual, digestDiff));
+    verify(failures).failure(INFO, shouldHaveDigest(actual, digestDiff));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmString_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_AlgorithmString_Test.java
@@ -58,7 +58,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -68,7 +68,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldExist(actual));
   }
@@ -78,7 +78,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/tmp");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -90,7 +90,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     actual.setReadable(false);
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, algorithm, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeReadable(actual));
   }
@@ -100,7 +100,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     MessageDigest digest = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The message digest algorithm should not be null");
@@ -111,7 +111,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     byte[] expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, algorithm, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The binary representation of digest to compare to should not be null");
@@ -124,7 +124,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     IOException cause = new IOException();
     given(nioFilesWrapper.newInputStream(any())).willThrow(cause);
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, algorithm, expected),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, algorithm, expected),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -135,7 +135,8 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // GIVEN
     String unknownDigestAlgorithm = "UnknownDigestAlgorithm";
     // WHEN
-    IllegalStateException ise = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, unknownDigestAlgorithm, expected),
+    IllegalStateException ise = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, unknownDigestAlgorithm,
+                                                                                     expected),
                                                      IllegalStateException.class);
     // THEN
     then(ise).hasMessage("Unable to find digest implementation for: <UnknownDigestAlgorithm>");
@@ -153,7 +154,7 @@ class Files_assertHasDigest_AlgorithmString_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasDigest(INFO, actual, algorithm, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveDigest(actual, digestDiff));
+    verify(failures).failure(INFO, shouldHaveDigest(actual, digestDiff));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestBytes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestBytes_Test.java
@@ -58,7 +58,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -68,7 +68,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldExist(actual));
   }
@@ -78,7 +78,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/tmp");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -90,7 +90,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     actual.setReadable(false);
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeReadable(actual));
   }
@@ -100,7 +100,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     MessageDigest digest = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The message digest algorithm should not be null");
@@ -111,7 +111,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     byte[] expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The binary representation of digest to compare to should not be null");
@@ -124,7 +124,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     IOException cause = new IOException();
     given(nioFilesWrapper.newInputStream(any())).willThrow(cause);
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -135,7 +135,8 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // GIVEN
     String unknownDigestAlgorithm = "UnknownDigestAlgorithm";
     // WHEN
-    IllegalStateException ise = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, unknownDigestAlgorithm, expected),
+    IllegalStateException ise = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, unknownDigestAlgorithm,
+                                                                                     expected),
                                                      IllegalStateException.class);
     // THEN
     then(ise).hasMessage("Unable to find digest implementation for: <UnknownDigestAlgorithm>");
@@ -152,7 +153,7 @@ class Files_assertHasDigest_DigestBytes_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasDigest(INFO, actual, digest, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveDigest(actual, digestDiff));
+    verify(failures).failure(INFO, shouldHaveDigest(actual, digestDiff));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestString_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasDigest_DigestString_Test.java
@@ -59,7 +59,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -69,7 +69,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldExist(actual));
   }
@@ -79,7 +79,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/tmp");
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -91,7 +91,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     actual.setReadable(false);
     // WHEN
-    expectAssertionError(() -> files.assertHasDigest(INFO, actual, digest, expected));
+    expectAssertionError(() -> underTest.assertHasDigest(INFO, actual, digest, expected));
     // THEN
     verify(failures).failure(INFO, shouldBeReadable(actual));
   }
@@ -101,7 +101,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     MessageDigest digest = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The message digest algorithm should not be null");
@@ -112,7 +112,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     byte[] expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The binary representation of digest to compare to should not be null");
@@ -125,7 +125,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     IOException cause = new IOException();
     given(nioFilesWrapper.newInputStream(any())).willThrow(cause);
     // WHEN
-    Throwable error = catchThrowableOfType(() -> files.assertHasDigest(INFO, actual, digest, expected),
+    Throwable error = catchThrowableOfType(() -> underTest.assertHasDigest(INFO, actual, digest, expected),
                                            UncheckedIOException.class);
     // THEN
     then(error).hasCause(cause);
@@ -136,7 +136,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // GIVEN
     String unknownDigestAlgorithm = "UnknownDigestAlgorithm";
     // WHEN
-    Throwable error = catchThrowable(() -> files.assertHasDigest(INFO, actual, unknownDigestAlgorithm, expected));
+    Throwable error = catchThrowable(() -> underTest.assertHasDigest(INFO, actual, unknownDigestAlgorithm, expected));
     // THEN
     then(error).isInstanceOf(IllegalStateException.class)
                .hasMessage("Unable to find digest implementation for: <UnknownDigestAlgorithm>");
@@ -153,7 +153,7 @@ class Files_assertHasDigest_DigestString_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertHasDigest(INFO, actual, digest, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveDigest(actual, digestDiff));
+    verify(failures).failure(INFO, shouldHaveDigest(actual, digestDiff));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasExtension_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasExtension_Test.java
@@ -44,7 +44,7 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     // GIVEN
     String expected = "txt";
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasExtension(INFO, null, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, null, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -54,7 +54,7 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("file.txt");
     // WHEN
-    Throwable thrown = catchThrowable(() -> files.assertHasExtension(INFO, actual, null));
+    Throwable thrown = catchThrowable(() -> underTest.assertHasExtension(INFO, actual, null));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class)
                 .hasMessage("The expected extension should not be null.");
@@ -65,7 +65,7 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = tempDir;
     // WHEN
-    expectAssertionError(() -> files.assertHasExtension(INFO, actual, expectedExtension));
+    expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expectedExtension));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -75,7 +75,7 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/file.png");
     // WHEN
-    expectAssertionError(() -> files.assertHasExtension(INFO, actual, expectedExtension));
+    expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expectedExtension));
     // THEN
     verify(failures).failure(INFO, shouldHaveExtension(actual, "png", expectedExtension));
   }
@@ -87,7 +87,7 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     File actual = newFile(tempDir.getAbsolutePath() + "/" + filename);
     String expected = "log";
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasExtension(INFO, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasExtension(INFO, actual, expected));
     // THEN
     then(error).hasMessage(shouldHaveExtension(actual, expected).create());
   }
@@ -97,6 +97,6 @@ class Files_assertHasExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/file.java");
     // WHEN/THEN
-    files.assertHasExtension(INFO, actual, expectedExtension);
+    underTest.assertHasExtension(INFO, actual, expectedExtension);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasName_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasName_Test.java
@@ -41,7 +41,7 @@ class Files_assertHasName_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasName(INFO, actual, expectedName));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasName(INFO, actual, expectedName));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -51,7 +51,7 @@ class Files_assertHasName_Test extends FilesBaseTest {
     // GIVEN
     String expectedName = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasName(INFO, actual, expectedName),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasName(INFO, actual, expectedName),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The expected name should not be null.");
@@ -62,7 +62,7 @@ class Files_assertHasName_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/not_expected.name");
     // WHEN
-    expectAssertionError(() -> files.assertHasName(INFO, actual, expectedName));
+    expectAssertionError(() -> underTest.assertHasName(INFO, actual, expectedName));
     // THEN
     verify(failures).failure(INFO, shouldHaveName(actual, expectedName));
   }
@@ -70,6 +70,6 @@ class Files_assertHasName_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_has_expected_name() {
     File actual = newFile(tempDir.getAbsolutePath() + "/expected.name");
-    files.assertHasName(INFO, actual, expectedName);
+    underTest.assertHasName(INFO, actual, expectedName);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasNoExtension_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasNoExtension_Test.java
@@ -33,7 +33,7 @@ class Files_assertHasNoExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasNoExtension(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -43,7 +43,7 @@ class Files_assertHasNoExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("non-existent");
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasNoExtension(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeFile(actual).create());
   }
@@ -53,7 +53,7 @@ class Files_assertHasNoExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = tempDir;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasNoExtension(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldBeFile(actual).create());
   }
@@ -63,7 +63,7 @@ class Files_assertHasNoExtension_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/text.txt");
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasNoExtension(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoExtension(INFO, actual));
     // THEN
     then(error).hasMessage(shouldHaveNoExtension(actual, "txt").create());
   }
@@ -74,7 +74,7 @@ class Files_assertHasNoExtension_Test extends FilesBaseTest {
     // GIVEN / WHEN
     File actual = newFile(tempDir.getAbsolutePath() + "/" + filename);
     // THEN
-    files.assertHasNoExtension(INFO, actual);
+    underTest.assertHasNoExtension(INFO, actual);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasNoParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasNoParent_Test.java
@@ -37,7 +37,7 @@ class Files_assertHasNoParent_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasNoParent(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasNoParent(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -47,7 +47,7 @@ class Files_assertHasNoParent_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("x/y/z");
     // WHEN
-    expectAssertionError(() -> files.assertHasNoParent(INFO, actual));
+    expectAssertionError(() -> underTest.assertHasNoParent(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldHaveNoParent(actual));
   }
@@ -55,6 +55,6 @@ class Files_assertHasNoParent_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_has_no_parent() {
     File actual = new File("xyz");
-    files.assertHasNoParent(INFO, actual);
+    underTest.assertHasNoParent(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasParent_Test.java
@@ -45,7 +45,7 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertHasParent(INFO, actual, expectedParent));
+    AssertionError error = expectAssertionError(() -> underTest.assertHasParent(INFO, actual, expectedParent));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -55,7 +55,7 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     // GIVEN
     File expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertHasParent(INFO, actual, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertHasParent(INFO, actual, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The expected parent file should not be null.");
@@ -66,7 +66,7 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     // GIVEN
     File withoutParent = new File("without-parent");
     // WHEN
-    expectAssertionError(() -> files.assertHasParent(INFO, withoutParent, expectedParent));
+    expectAssertionError(() -> underTest.assertHasParent(INFO, withoutParent, expectedParent));
     // THEN
     verify(failures).failure(INFO, shouldHaveParent(withoutParent, expectedParent));
   }
@@ -76,24 +76,24 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     // GIVEN
     File expectedParent = new File("./expected-parent");
     // WHEN
-    expectAssertionError(() -> files.assertHasParent(INFO, actual, expectedParent));
+    expectAssertionError(() -> underTest.assertHasParent(INFO, actual, expectedParent));
     // THEN
     verify(failures).failure(INFO, shouldHaveParent(actual, expectedParent));
   }
 
   @Test
   void should_pass_if_actual_has_expected_parent() {
-    files.assertHasParent(INFO, actual, expectedParent);
+    underTest.assertHasParent(INFO, actual, expectedParent);
   }
 
   @Test
   void should_pass_if_actual_has_expected_parent_when_actual_form_is_absolute() {
-    files.assertHasParent(INFO, actual.getAbsoluteFile(), expectedParent);
+    underTest.assertHasParent(INFO, actual.getAbsoluteFile(), expectedParent);
   }
 
   @Test
   void should_pass_if_actual_has_expected_parent_when_actual_form_is_canonical() throws Exception {
-    files.assertHasParent(INFO, actual.getCanonicalFile(), expectedParent);
+    underTest.assertHasParent(INFO, actual.getCanonicalFile(), expectedParent);
   }
 
   @Test
@@ -104,7 +104,7 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     when(actual.getParentFile()).thenReturn(actualParent);
     when(actualParent.getCanonicalFile()).thenThrow(new IOException());
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasParent(INFO, actual, actualParent),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasParent(INFO, actual, actualParent),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasMessageStartingWith("Unable to get canonical form of");
@@ -115,7 +115,7 @@ class Files_assertHasParent_Test extends FilesBaseTest {
     File expectedParent = mock(File.class);
     when(expectedParent.getCanonicalFile()).thenThrow(new IOException());
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertHasParent(INFO, actual, expectedParent),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertHasParent(INFO, actual, expectedParent),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasMessageStartingWith("Unable to get canonical form of");

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
@@ -33,6 +33,7 @@ import org.assertj.core.internal.BinaryDiffResult;
 import org.assertj.core.internal.FilesBaseTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
 class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
 
   private static File actual;
@@ -64,7 +65,7 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // GIVEN
     File expected = null;
     // WHEN
-    NullPointerException npe = catchThrowableOfType(() -> files.assertSameBinaryContentAs(INFO, actual, expected),
+    NullPointerException npe = catchThrowableOfType(() -> underTest.assertSameBinaryContentAs(INFO, actual, expected),
                                                     NullPointerException.class);
     // THEN
     then(npe).hasMessage("The file to compare to should not be null");
@@ -75,7 +76,7 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertSameBinaryContentAs(INFO, actual, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertSameBinaryContentAs(INFO, actual, expected));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -85,7 +86,7 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // GIVEN
     File notAFile = new File("xyz");
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertSameBinaryContentAs(INFO, notAFile, expected));
+    AssertionError error = expectAssertionError(() -> underTest.assertSameBinaryContentAs(INFO, notAFile, expected));
     // THEN
     then(error).hasMessage(shouldBeFile(notAFile).create());
   }
@@ -95,7 +96,7 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // GIVEN
     File notAFile = new File("xyz");
     // WHEN
-    IllegalArgumentException iae = catchThrowableOfType(() -> files.assertSameBinaryContentAs(INFO, actual, notAFile),
+    IllegalArgumentException iae = catchThrowableOfType(() -> underTest.assertSameBinaryContentAs(INFO, actual, notAFile),
                                                         IllegalArgumentException.class);
     // THEN
     then(iae).hasMessage("Expected file:<'%s'> should be an existing file", notAFile);
@@ -107,7 +108,7 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     IOException cause = new IOException();
     given(binaryDiff.diff(actual, expectedBytes)).willThrow(cause);
     // WHEN
-    UncheckedIOException uioe = catchThrowableOfType(() -> files.assertSameBinaryContentAs(INFO, actual, expected),
+    UncheckedIOException uioe = catchThrowableOfType(() -> underTest.assertSameBinaryContentAs(INFO, actual, expected),
                                                      UncheckedIOException.class);
     // THEN
     then(uioe).hasCause(cause);
@@ -121,6 +122,6 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertSameBinaryContentAs(INFO, actual, expected));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveBinaryContent(actual, diff));
+    verify(failures).failure(INFO, shouldHaveBinaryContent(actual, diff));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsAbsolute_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsAbsolute_Test.java
@@ -38,7 +38,7 @@ class Files_assertIsAbsolute_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsAbsolute(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsAbsolute(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -48,7 +48,7 @@ class Files_assertIsAbsolute_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsAbsolute(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsAbsolute(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeAbsolutePath(actual));
   }
@@ -56,6 +56,6 @@ class Files_assertIsAbsolute_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_is_absolute_path() {
     File actual = new File(tempDir.getAbsolutePath() + "/file.txt");
-    files.assertIsAbsolute(INFO, actual);
+    underTest.assertIsAbsolute(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_Predicate_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_Predicate_Test.java
@@ -54,7 +54,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     newFile(actual.getAbsolutePath() + "/Test.java");
 
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
   }
 
   @Test
@@ -65,7 +65,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     newFile(actual.getAbsolutePath() + "/Utils.java");
 
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
   }
 
   @Test
@@ -78,7 +78,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     newFile(actual.getAbsolutePath() + "/Utils.java");
     newFile(actual.getAbsolutePath() + "/application.yml");
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE);
   }
 
   @Test
@@ -86,7 +86,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     // GIVEN
     Predicate<File> filter = null;
     // THEN
-    assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, filter))
+    assertThatNullPointerException().isThrownBy(() -> underTest.assertIsDirectoryContaining(INFO, null, filter))
                                     .withMessage("The files filter should not be null");
   }
 
@@ -95,7 +95,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -105,7 +105,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -115,7 +115,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -130,7 +130,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     mockPathMatcher(actual);
     // WHEN
-    Throwable error = catchThrowable(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    Throwable error = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("Directory listing should not be null");
@@ -141,7 +141,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, directoryShouldContain(actual, emptyList(), "the given filter"));
   }
@@ -153,7 +153,7 @@ class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
     File file = newFile(actual.getAbsolutePath() + "/Test.class");
     List<File> items = list(file);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, directoryShouldContain(actual, items, "the given filter"));
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_SyntaxAndPattern_Test.java
@@ -54,7 +54,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     newFile(actual.getAbsolutePath() + "/Test.java");
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
   }
 
   @Test
@@ -64,7 +64,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     newFile(actual.getAbsolutePath() + "/Test.java");
     newFile(actual.getAbsolutePath() + "/Utils.java");
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
   }
 
   @Test
@@ -77,7 +77,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     newFile(actual.getAbsolutePath() + "/Utils.java");
     newFile(actual.getAbsolutePath() + "/application.yml");
     // WHEN/THEN
-    files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
+    underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN);
   }
 
   @Test
@@ -85,7 +85,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     // GIVEN
     String pathMatcherPattern = null;
     // THEN
-    assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryContaining(INFO, null, pathMatcherPattern))
+    assertThatNullPointerException().isThrownBy(() -> underTest.assertIsDirectoryContaining(INFO, null, pathMatcherPattern))
                                     .withMessage("The syntax and pattern should not be null");
   }
 
@@ -94,7 +94,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -104,7 +104,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -114,7 +114,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -129,7 +129,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     mockPathMatcher(actual);
     // WHEN
-    Throwable error = catchThrowable(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    Throwable error = catchThrowable(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("Directory listing should not be null");
@@ -140,7 +140,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, directoryShouldContain(actual, emptyList(), JAVA_SOURCE_PATTERN_DESCRIPTION));
   }
@@ -152,7 +152,7 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     File file = newFile(actual.getAbsolutePath() + "/Test.class");
     List<File> items = list(file);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, directoryShouldContain(actual, items, JAVA_SOURCE_PATTERN_DESCRIPTION));
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_Predicate_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_Predicate_Test.java
@@ -52,7 +52,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     newFile(actual.getAbsolutePath() + "/Test.class");
     // THEN
-    files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE);
   }
 
   @Test
@@ -60,7 +60,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // THEN
-    files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE);
   }
 
   @Test
@@ -68,7 +68,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     // GIVEN
     Predicate<File> filter = null;
     // THEN
-    assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, filter))
+    assertThatNullPointerException().isThrownBy(() -> underTest.assertIsDirectoryNotContaining(INFO, null, filter))
                                     .withMessage("The files filter should not be null");
   }
 
@@ -77,7 +77,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -87,7 +87,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -97,7 +97,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -112,7 +112,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     mockPathMatcher(actual);
     // WHEN
-    Throwable error = catchThrowable(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    Throwable error = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("Directory listing should not be null");
@@ -125,7 +125,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     File file = newFile(actual.getAbsolutePath() + "/Test.java");
     List<File> items = list(file);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, items, "the given filter"));
   }
@@ -138,7 +138,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     File file2 = newFile(actual.getAbsolutePath() + "/Utils.java");
     List<File> items = list(file1, file2);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, items, "the given filter"));
   }
@@ -153,7 +153,7 @@ class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest 
     newFile(actual.getAbsolutePath() + "/Utils.class");
     newFile(actual.getAbsolutePath() + "/application.yml");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, list(file1, file2), "the given filter"));
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test.java
@@ -53,7 +53,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     newFile(actual.getAbsolutePath() + "/Test.class");
     // THEN
-    files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN);
   }
 
   @Test
@@ -61,7 +61,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // THEN
-    files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN);
+    underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN);
   }
 
   @Test
@@ -69,7 +69,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     // GIVEN
     String pathMatcherPattern = null;
     // THEN
-    assertThatNullPointerException().isThrownBy(() -> files.assertIsDirectoryNotContaining(INFO, null, pathMatcherPattern))
+    assertThatNullPointerException().isThrownBy(() -> underTest.assertIsDirectoryNotContaining(INFO, null, pathMatcherPattern))
                                     .withMessage("The syntax and pattern should not be null");
   }
 
@@ -78,7 +78,8 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual,
+                                                                                               JAVA_SOURCE_PATTERN));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -88,7 +89,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -98,7 +99,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -113,7 +114,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     mockPathMatcher(actual);
     // WHEN
-    Throwable error = catchThrowable(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    Throwable error = catchThrowable(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     then(error).isInstanceOf(NullPointerException.class)
                .hasMessage("Directory listing should not be null");
@@ -126,7 +127,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     File file = newFile(actual.getAbsolutePath() + "/Test.java");
     List<File> items = list(file);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, items, JAVA_SOURCE_PATTERN_DESCRIPTION));
   }
@@ -139,7 +140,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     File file2 = newFile(actual.getAbsolutePath() + "/Utils.java");
     List<File> items = list(file1, file2);
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, items, JAVA_SOURCE_PATTERN_DESCRIPTION));
   }
@@ -154,7 +155,7 @@ class Files_assertIsDirectoryNotContaining_SyntaxAndPattern_Test extends FilesBa
     newFile(actual.getAbsolutePath() + "/Utils.class");
     newFile(actual.getAbsolutePath() + "/application.yml");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
+    expectAssertionError(() -> underTest.assertIsDirectoryNotContaining(INFO, actual, JAVA_SOURCE_PATTERN));
     // THEN
     verify(failures).failure(INFO, directoryShouldNotContain(actual, list(file1, file2), JAVA_SOURCE_PATTERN_DESCRIPTION));
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectory_Test.java
@@ -39,7 +39,7 @@ class Files_assertIsDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectory(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Files_assertIsDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/file.txt");
     // WHEN
-    expectAssertionError(() -> files.assertIsDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -57,6 +57,6 @@ class Files_assertIsDirectory_Test extends FilesBaseTest {
   @Test
   void should_pass_if_actual_is_directory() {
     File actual = tempDir;
-    files.assertIsDirectory(INFO, actual);
+    underTest.assertIsDirectory(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyDirectory_Test.java
@@ -43,7 +43,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // THEN
-    files.assertIsEmptyDirectory(INFO, actual);
+    underTest.assertIsEmptyDirectory(INFO, actual);
   }
 
   @Test
@@ -53,7 +53,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     File file = newFile(actual.getAbsolutePath() + "/Test.java");
     List<File> items = list(file);
     // WHEN
-    expectAssertionError(() -> files.assertIsEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeEmptyDirectory(actual, items));
   }
@@ -63,7 +63,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsEmptyDirectory(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -73,7 +73,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -83,7 +83,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -97,7 +97,7 @@ class Files_assertIsEmptyDirectory_Test extends FilesBaseTest {
     given(actual.isDirectory()).willReturn(true);
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     // WHEN
-    Throwable error = catchThrowableOfType(() -> files.assertIsEmptyDirectory(INFO, actual), NullPointerException.class);
+    Throwable error = catchThrowableOfType(() -> underTest.assertIsEmptyDirectory(INFO, actual), NullPointerException.class);
     // THEN
     then(error).hasMessage("Directory listing should not be null");
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsEmptyFile_Test.java
@@ -39,7 +39,7 @@ class Files_assertIsEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    files.assertIsEmptyFile(INFO, actual);
+    underTest.assertIsEmptyFile(INFO, actual);
     // THEN
     verifyNoInteractions(failures);
   }
@@ -49,7 +49,7 @@ class Files_assertIsEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("src/test/resources/actual_file.txt");
     // WHEN
-    expectAssertionError(() -> files.assertIsEmptyFile(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeEmpty(actual));
   }
@@ -59,7 +59,7 @@ class Files_assertIsEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // WHEN
-    expectAssertionError(() -> files.assertIsEmptyFile(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -69,7 +69,7 @@ class Files_assertIsEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsEmptyFile(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsFile_Test.java
@@ -39,7 +39,7 @@ class Files_assertIsFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> files.assertIsFile(INFO, actual));
+    AssertionError assertionError = expectAssertionError(() -> underTest.assertIsFile(INFO, actual));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Files_assertIsFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsFile(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsFile(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -59,6 +59,6 @@ class Files_assertIsFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // THEN
-    files.assertIsFile(INFO, actual);
+    underTest.assertIsFile(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyDirectory_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyDirectory_Test.java
@@ -47,7 +47,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     newFile(actual.getAbsolutePath() + "/Test.java");
     // THEN
-    files.assertIsNotEmptyDirectory(INFO, actual);
+    underTest.assertIsNotEmptyDirectory(INFO, actual);
   }
 
   @Test
@@ -55,7 +55,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // WHEN
-    expectAssertionError(() -> files.assertIsNotEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldNotBeEmpty());
   }
@@ -65,7 +65,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsNotEmptyDirectory(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -75,7 +75,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertIsNotEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -85,7 +85,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsNotEmptyDirectory(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsNotEmptyDirectory(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeDirectory(actual));
   }
@@ -99,7 +99,7 @@ class Files_assertIsNotEmptyDirectory_Test extends FilesBaseTest {
     given(actual.isDirectory()).willReturn(true);
     given(actual.listFiles(any(FileFilter.class))).willReturn(null);
     // WHEN
-    Throwable error = catchThrowableOfType(() -> files.assertIsNotEmptyDirectory(INFO, actual), NullPointerException.class);
+    Throwable error = catchThrowableOfType(() -> underTest.assertIsNotEmptyDirectory(INFO, actual), NullPointerException.class);
     // THEN
     assertThat(error).hasMessage("Directory listing should not be null");
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyFile_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsNotEmptyFile_Test.java
@@ -39,7 +39,7 @@ class Files_assertIsNotEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("src/test/resources/actual_file.txt");
     // WHEN
-    files.assertIsNotEmptyFile(INFO, actual);
+    underTest.assertIsNotEmptyFile(INFO, actual);
     // THEN
     verifyNoInteractions(failures);
   }
@@ -49,7 +49,7 @@ class Files_assertIsNotEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsNotEmptyFile(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldNotBeEmpty(actual));
   }
@@ -59,7 +59,7 @@ class Files_assertIsNotEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFolder(tempDir.getAbsolutePath() + "/folder");
     // WHEN
-    expectAssertionError(() -> files.assertIsNotEmptyFile(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(actual));
   }
@@ -69,7 +69,7 @@ class Files_assertIsNotEmptyFile_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsNotEmptyFile(INFO, actual));
+    AssertionError error = expectAssertionError(() -> underTest.assertIsNotEmptyFile(INFO, actual));
     // THEN
     then(error).hasMessage(actualIsNull());
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertIsRelative_Test.java
@@ -39,7 +39,7 @@ class Files_assertIsRelative_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> files.assertIsRelative(INFO, actual));
+    AssertionError assertionError = expectAssertionError(() -> underTest.assertIsRelative(INFO, actual));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -49,7 +49,7 @@ class Files_assertIsRelative_Test extends FilesBaseTest {
     // GIVEN
     File actual = newFile(tempDir.getAbsolutePath() + "/Test.java");
     // WHEN
-    expectAssertionError(() -> files.assertIsRelative(INFO, actual));
+    expectAssertionError(() -> underTest.assertIsRelative(INFO, actual));
     // THEN
     verify(failures).failure(INFO, shouldBeRelativePath(actual));
   }
@@ -59,6 +59,6 @@ class Files_assertIsRelative_Test extends FilesBaseTest {
     // GIVEN
     File actual = new File("src/test/resources/actual_file.txt");
     // THEN
-    files.assertIsRelative(INFO, actual);
+    underTest.assertIsRelative(INFO, actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -59,8 +59,8 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
 
   @Test
   void should_throw_error_if_expected_is_null() {
-    assertThatNullPointerException().isThrownBy(() -> files.assertSameContentAs(INFO, actual, defaultCharset(),
-                                                                                null, defaultCharset()))
+    assertThatNullPointerException().isThrownBy(() -> underTest.assertSameContentAs(INFO, actual, defaultCharset(),
+                                                                                    null, defaultCharset()))
                                     .withMessage("The file to compare to should not be null");
   }
 
@@ -68,7 +68,7 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
   void should_throw_error_if_expected_is_not_file() {
     assertThatIllegalArgumentException().isThrownBy(() -> {
       File notAFile = new File("xyz");
-      files.assertSameContentAs(INFO, actual, defaultCharset(), notAFile, defaultCharset());
+      underTest.assertSameContentAs(INFO, actual, defaultCharset(), notAFile, defaultCharset());
     }).withMessage("Expected file:<'xyz'> should be an existing file");
   }
 
@@ -77,8 +77,8 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
     // GIVEN
     File actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> files.assertSameContentAs(INFO, actual, defaultCharset(),
-                                                                                         expected, defaultCharset()));
+    AssertionError assertionError = expectAssertionError(() -> underTest.assertSameContentAs(INFO, actual, defaultCharset(),
+                                                                                             expected, defaultCharset()));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -89,7 +89,7 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
 
     File notAFile = new File("xyz");
     // WHEN
-    expectAssertionError(() -> files.assertSameContentAs(INFO, notAFile, defaultCharset(), expected, defaultCharset()));
+    expectAssertionError(() -> underTest.assertSameContentAs(INFO, notAFile, defaultCharset(), expected, defaultCharset()));
     // THEN
     verify(failures).failure(INFO, shouldBeFile(notAFile));
   }
@@ -106,10 +106,10 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
     IOException cause = new IOException();
     when(diff.diff(actual, defaultCharset(), expected, defaultCharset())).thenThrow(cause);
 
-    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> files.assertSameContentAs(INFO, actual,
-                                                                                                     defaultCharset(),
-                                                                                                     expected,
-                                                                                                     defaultCharset()))
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> underTest.assertSameContentAs(INFO, actual,
+                                                                                                         defaultCharset(),
+                                                                                                         expected,
+                                                                                                         defaultCharset()))
                                                          .withCause(cause);
   }
 
@@ -122,7 +122,7 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertSameContentAs(INFO, actual, defaultCharset(), expected, defaultCharset()));
     // THEN
-    verify(unMockedFailures).failure(INFO, shouldHaveSameContent(actual, expected, diffs));
+    verify(failures).failure(INFO, shouldHaveSameContent(actual, expected, diffs));
   }
 
   @Test


### PR DESCRIPTION
Similarly to #2826, `FilesBaseTest` mocks and spies are reset instead of being recreated before each test execution.