### PR TITLE
Fix AbstractAsset#satisfies(Consumer...) double evaluation

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -866,13 +866,16 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   // in order to avoid compiler warning in user code
   protected SELF satisfiesForProxy(Consumer<? super ACTUAL>[] assertionsGroups) throws AssertionError {
     checkArgument(stream(assertionsGroups).allMatch(java.util.Objects::nonNull), "No assertions group should be null");
-    if (stream(assertionsGroups).allMatch(this::satisfiesAssertions)) return myself;
     // some assertions groups were not met! let's report all the errors
     List<AssertionError> assertionErrors = stream(assertionsGroups).map(this::catchOptionalAssertionError)
                                                                    .filter(Optional::isPresent)
                                                                    .map(Optional::get)
                                                                    .collect(toList());
-    throw multipleAssertionsError(assertionErrors);
+    if (assertionErrors.isEmpty()) {
+      return myself;
+    } else {
+      throw multipleAssertionsError(assertionErrors);
+    }
   }
 
   private Optional<AssertionError> catchOptionalAssertionError(Consumer<? super ACTUAL> assertions) {

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_satisfiesAnyOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_satisfiesAnyOf_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+class AbstractAssert_satisfiesAnyOf_Test {
+
+  @Test
+  void should_run_consumers_only_once() {
+    // GIVEN
+    AbstractStringAssert<?> assertion = assertThat("actualValue");
+
+    AtomicInteger invocationCount = new AtomicInteger();
+    Consumer<String> failingConsumer = s -> {
+      invocationCount.incrementAndGet();
+      assertThat(s).isEqualTo("anotherValue");
+    };
+
+    // WHEN
+    assertThatThrownBy(() -> assertion.satisfiesAnyOf(failingConsumer))
+      .hasBeenThrown();
+
+    // THEN
+    then(invocationCount).hasValue(1);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_satisfies_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractAssert_satisfies_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+class AbstractAssert_satisfies_Test {
+
+  @Test
+  void should_run_consumers_only_once() {
+    // GIVEN
+    AbstractStringAssert<?> assertion = assertThat("actualValue");
+
+    AtomicInteger invocationCount = new AtomicInteger();
+    Consumer<String> failingConsumer = s -> {
+      invocationCount.incrementAndGet();
+      assertThat(s).isEqualTo("anotherValue");
+    };
+
+    // WHEN
+    assertThatThrownBy(() -> assertion.satisfies(failingConsumer))
+      .hasBeenThrown();
+
+    // THEN
+    then(invocationCount).hasValue(1);
+  }
+}


### PR DESCRIPTION
Fixes #2846

#### Check List:
* Fixes #2846
* Unit tests : No. I assume that satisfies behavior is already checked and adding a specific check for double evaluation is not required. I can add this test if you wish.
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
