### PR TITLE
add Descriptable#describedAs(Supplier<String>)

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Descriptable.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Descriptable.java
@@ -90,7 +90,7 @@ public interface Descriptable<SELF> {
    * @throws IllegalStateException if the descriptionSupplier is {@code null} when evaluated.
    */
   default SELF as(final Supplier<String> descriptionSupplier) {
-    return describedAs(new LazyTextDescription(descriptionSupplier));
+    return describedAs(descriptionSupplier);
   }
 
   /**
@@ -129,6 +129,40 @@ public interface Descriptable<SELF> {
    */
   default SELF describedAs(String description, Object... args) {
     return describedAs(new TextDescription(description, args));
+  }
+
+  /**
+   * Lazily specifies the description of the assertion that is going to be called, the given description is <b>not</b> evaluated
+   * if the assertion succeeds.
+   * <p>
+   * The description must be set <b>before</b> calling the assertion otherwise it is ignored as the failing assertion breaks
+   * the chained call by throwing an AssertionError.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // set an incorrect age to Mr Frodo which we all know is 33 years old.
+   * frodo.setAge(50);
+   *
+   * // the lazy test description is <b>not</b> evaluated as the assertion succeeds
+   * assertThat(frodo.getAge()).as(() -&gt; &quot;check Frodo's age&quot;).isEqualTo(50);
+   *
+   * try
+   * {
+   *   // the lazy test description is evaluated as the assertion fails
+   *   assertThat(frodo.getAge()).as(() -&gt; &quot;check Frodo's age&quot;).isEqualTo(33);
+   * }
+   * catch (AssertionError e)
+   * {
+   *   assertThat(e).hasMessage(&quot;[check Frodo's age]\n
+   *                             expected: 33\n
+   *                              but was: 50&quot;);
+   * }</code></pre>
+   *
+   * @param descriptionSupplier the description {@link Supplier}.
+   * @return {@code this} object.
+   * @throws IllegalStateException if the descriptionSupplier is {@code null} when evaluated.
+   */
+  default SELF describedAs(final Supplier<String> descriptionSupplier) {
+    return describedAs(new LazyTextDescription(descriptionSupplier));
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/Condition_describedAs_Description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Condition_describedAs_Description_Test.java
@@ -50,7 +50,8 @@ class Condition_describedAs_Description_Test {
 
   @Test
   void should_set_empty_description_if_description_is_null() {
-    condition.describedAs(null);
+    String message = null;
+    condition.describedAs(message);
     assertThat(condition.description.value()).isEmpty();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/api/ConcreteAssert.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/api/ConcreteAssert.kt
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api
+
+import org.assertj.core.internal.Objects
+import org.assertj.core.util.VisibleForTesting
+import org.opentest4j.AssertionFailedError
+
+/**
+ * @author Alex Ruiz
+ * @author Joel Costigliola
+ */
+class ConcreteAssert(actual: Any?) :
+  AbstractAssert<ConcreteAssert, Any?>(actual, ConcreteAssert::class.java) {
+  /**
+   * Not a really relevant assertion, the goal is to show how to write a new assertion with a specific error message
+   * that honors the description set by the assertion user.
+   */
+  fun checkNull(): ConcreteAssert {
+    // set a specific error message
+    val info = writableAssertionInfo
+    info.overridingErrorMessage("specific error message")
+    Objects.instance().assertNull(info, actual)
+    // return the current assertion for method chaining
+    return this
+  }
+
+  fun failIfTrue(fail: Boolean): ConcreteAssert {
+    // set a specific error message
+    if (fail) {
+      failWithMessage("%s error message", "predefined")
+    }
+    // return the current assertion for method chaining
+    return this
+  }
+
+  @VisibleForTesting
+  public override fun failWithMessage(errorMessage: String, vararg arguments: Any) {
+    super.failWithMessage(errorMessage, *arguments)
+  }
+
+  @VisibleForTesting
+  public override fun failWithActualExpectedAndMessage(
+    actual: Any,
+    expected: Any,
+    errorMessage: String,
+    vararg arguments: Any
+  ) {
+    super.failWithActualExpectedAndMessage(actual, expected, errorMessage, *arguments)
+  }
+
+  @VisibleForTesting
+  public override fun failure(errorMessage: String, vararg arguments: Any): AssertionError {
+    return super.failure(errorMessage, *arguments)
+  }
+
+  @VisibleForTesting
+  public override fun failureWithActualExpected(
+    actual: Any,
+    expected: Any,
+    errorMessage: String,
+    vararg arguments: Any
+  ): AssertionFailedError {
+    return super.failureWithActualExpected(actual, expected, errorMessage, *arguments) as AssertionFailedError
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/tests/kotlin/Assertions_describedAs_text_supplier_Test.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/tests/kotlin/Assertions_describedAs_text_supplier_Test.kt
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.tests.kotlin
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.BDDAssertions
+import org.assertj.core.api.ConcreteAssert
+import org.assertj.core.util.AssertionsUtil
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Supplier
+
+/**
+ * See [org.assertj.core.api.abstract_.AbstractAssert_as_with_description_text_supplier_Test].
+ * `as` is a keyword in Kotlin, so we use `describedAs` instead.
+ */
+internal class Assertions_describedAs_text_supplier_Test {
+
+  @Test
+  fun descriptionText_should_evaluate_lazy_description() {
+    // GIVEN
+    val assertions = ConcreteAssert("foo")
+    // WHEN
+    assertions.describedAs { "description" }
+    // THEN
+    BDDAssertions.then(assertions.descriptionText()).isEqualTo("description")
+  }
+
+
+  @Test
+  fun should_not_evaluate_description_when_assertion_succeeds() {
+    // GIVEN
+    val evaluated = AtomicBoolean(false)
+    val descriptionSupplier = spiedSupplier(evaluated)
+    // WHEN
+    assertThat(true).describedAs(descriptionSupplier).isTrue
+    // THEN
+    BDDAssertions.then(evaluated).isFalse
+  }
+
+  @Test
+  fun should_evaluate_description_when_assertion_fails() {
+    // GIVEN
+    val evaluated = AtomicBoolean(false)
+    val descriptionSupplier = spiedSupplier(evaluated)
+    // WHEN
+    AssertionsUtil.expectAssertionError {
+      assertThat(true).describedAs(descriptionSupplier).isFalse()
+    }
+    // THEN
+    BDDAssertions.then(evaluated).isTrue
+  }
+
+  @Test
+  fun should_return_this() {
+    // GIVEN
+    val assertions = ConcreteAssert("foo")
+    // WHEN
+    val returnedAssertions = assertions.describedAs { "description" }
+    // THEN
+    BDDAssertions.then(returnedAssertions).isSameAs(assertions)
+  }
+
+  @Test
+  fun should_throw_evaluate_lazy_description() {
+    // GIVEN
+    val assertions = ConcreteAssert("foo")
+    val descriptionSupplier: Supplier<String>? = null
+    // WHEN
+    val throwable = Assertions.catchThrowable {
+      assertions.describedAs(
+        descriptionSupplier
+      ).descriptionText()
+    }
+    // THEN
+    BDDAssertions.then(throwable).isInstanceOf(IllegalStateException::class.java)
+      .hasMessage("the descriptionSupplier should not be null")
+  }
+
+  private fun spiedSupplier(evaluated: AtomicBoolean) =
+    Supplier {
+      evaluated.set(true)
+      "description"
+    }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/util/AssertionsUtil.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/core/util/AssertionsUtil.kt
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.util
+
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+
+object AssertionsUtil {
+  fun expectAssertionError(shouldRaiseAssertionError: ThrowingCallable?): AssertionError {
+    val error = Assertions.catchThrowableOfType(
+      shouldRaiseAssertionError,
+      AssertionError::class.java
+    )
+    Assertions.assertThat(error).`as`("The code under test should have raised an AssertionError").isNotNull
+    return error
+  }
+}


### PR DESCRIPTION
`describedAs(Supplier<String>)` makes it eaiser to use lazy descriptions from Kotlin

This is a follow-up to #2061

An alternative option might be to make `Description implements Supplier<String>` and migrate to `Supplier<String>` instead of `Description`, however, that is a more involved change.