### PR TITLE
Comparables::assertIsBetween String alloc. removed

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/internal/Comparables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Comparables.java
@@ -356,10 +356,11 @@ public class Comparables {
     // to fail when start = end with different precision, ex: [10.0, 10.00].
     boolean inclusiveBoundsCheck = inclusiveEnd && inclusiveStart && !isGreaterThan(start, end);
     boolean strictBoundsCheck = !inclusiveEnd && !inclusiveStart && isLessThan(start, end);
-    String operator = inclusiveEnd && inclusiveStart ? "less than" : "less than or equal to";
-    String boundsCheckErrorMessage = format("The end value <%s> must not be %s the start value <%s>%s!", end, operator, start,
-                                            (comparisonStrategy.isStandard() ? "" : " (using " + comparisonStrategy + ")"));
-    checkArgument(inclusiveBoundsCheck || strictBoundsCheck, boundsCheckErrorMessage);
+    checkArgument(inclusiveBoundsCheck || strictBoundsCheck, () -> {
+      String operator = inclusiveEnd && inclusiveStart ? "less than" : "less than or equal to";
+      return format("The end value <%s> must not be %s the start value <%s>%s!", end, operator, start,
+                    (comparisonStrategy.isStandard() ? "" : " (using " + comparisonStrategy + ")"));
+    });
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/util/Preconditions.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/Preconditions.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.util;
 
+import java.util.function.Supplier;
+
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -111,7 +113,7 @@ public final class Preconditions {
     checkArgument(filterOperator != null, "The expected value should not be null.%n"
         + "If you were trying to filter on a null value, please use filteredOnNull(String propertyOrFieldName) instead");
   }
-  
+
   /**
    * Ensures the truth of an expression involving one or more parameters to the calling method.
    * <p>
@@ -127,6 +129,18 @@ public final class Preconditions {
    */
   public static void checkArgument(boolean expression, String errorMessageTemplate, Object... errorMessageArgs) {
     if (!expression) throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
+  }
+
+  /**
+   * Ensures the truth of an expression using a supplier to fetch the error message in case of a failure.
+   *
+   * @param expression a boolean expression
+   * @param errorMessage a supplier to build the error message in case of failure. Must not be null.
+   * @throws IllegalArgumentException if {@code expression} is false
+   * @throws NullPointerException if the check fails and {@code errorMessage} is null (don't let this happen).
+   */
+  public static void checkArgument(boolean expression, Supplier<String> errorMessage) {
+    if (!expression) throw new IllegalArgumentException(errorMessage.get());
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/util/Preconditions_checkArgument_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/Preconditions_checkArgument_Test.java
@@ -12,9 +12,13 @@
  */
 package org.assertj.core.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 class Preconditions_checkArgument_Test {
 
@@ -28,5 +32,23 @@ class Preconditions_checkArgument_Test {
   @Test
   void should_not_throw_if_expression_is_true() {
     Preconditions.checkArgument(true, "Invalid parameter %s", "foo");
+  }
+
+  @Test
+  void should_call_message_supplier_once_if_expression_is_false() {
+    AtomicInteger callCount = new AtomicInteger();
+    String str = "Super secret message!!!";
+    Supplier<String> msg = () -> {
+      int nCalls = callCount.incrementAndGet();
+      assertThat(nCalls).isEqualTo(1);
+      return str;
+    };
+    assertThatIllegalArgumentException().isThrownBy(() -> Preconditions.checkArgument(false, msg)).withMessage(str);
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  void should_never_call_message_supplier_if_expression_is_true() {
+    Preconditions.checkArgument(true, () -> {throw new AssertionError();});
   }
 }


### PR DESCRIPTION
`Comparables::checkBoundsValidity`, which is used by `Comparables::assertIsBetween`, does build an error message String even if the assertion does not fail. This results in noticeable overhead. The JVM can hardly eliminate the String building since `start.toString()`, `operator.toString()` and `end.toString()` may have side effects.

This PR moves the String building inside a `Supplier<String>` which is only evaluated on failure.
