### PR TITLE
build: Use Bnd feature to write resolved bndrun files to output folder

### DIFF
--- a/assertj-guava/pom.xml
+++ b/assertj-guava/pom.xml
@@ -132,8 +132,9 @@
               <goal>resolve</goal>
             </goals>
             <configuration>
+              <outputBndrunDir>${project.build.directory}</outputBndrunDir>
               <bndruns>
-                <bndrun>verify.bndrun</bndrun>
+                <include>verify.bndrun</include>
               </bndruns>
               <bundles>
                 <bundle>target/${project.build.finalName}.jar</bundle>

--- a/assertj-guava/verify.bndrun
+++ b/assertj-guava/verify.bndrun
@@ -27,17 +27,4 @@
     order=sortbynameversion,\
     begin=-1
 
-# The version ranges will change as the version of
-# AssertJ and/or its dependencies change.
--runbundles: \
-	assertj-core;version='[3.24.0,3.24.1)',\
-	assertj-guava;version='[3.24.0,3.24.1)',\
-	com.google.guava;version='[31.1.0,31.1.1)',\
-	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
-	junit-jupiter-api;version='[5.9.1,5.9.2)',\
-	junit-jupiter-engine;version='[5.9.1,5.9.2)',\
-	junit-platform-commons;version='[1.9.1,1.9.2)',\
-	junit-platform-engine;version='[1.9.1,1.9.2)',\
-	junit-platform-launcher;version='[1.9.1,1.9.2)',\
-	net.bytebuddy.byte-buddy;version='[1.12.20,1.12.21)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+# -runbundles is calculated by the bnd-resolver-maven-plugin

--- a/assertj-tests/assertj-integration-tests/assertj-core-osgi/pom.xml
+++ b/assertj-tests/assertj-integration-tests/assertj-core-osgi/pom.xml
@@ -75,8 +75,9 @@
               <goal>resolve</goal>
             </goals>
             <configuration>
+              <outputBndrunDir>${project.build.directory}</outputBndrunDir>
               <bndruns>
-                <bndrun>verify.bndrun</bndrun>
+                <include>verify.bndrun</include>
               </bndruns>
               <bundles>
                 <bundle>${osgi.bundle}</bundle>
@@ -105,8 +106,9 @@
               <goal>testing</goal>
             </goals>
             <configuration>
+              <bndrunDir>${project.build.directory}</bndrunDir>
               <bndruns>
-                <bndrun>verify.bndrun</bndrun>
+                <include>verify.bndrun</include>
               </bndruns>
               <bundles>
                 <bundle>${osgi.bundle}</bundle>

--- a/assertj-tests/assertj-integration-tests/assertj-core-osgi/verify.bndrun
+++ b/assertj-tests/assertj-integration-tests/assertj-core-osgi/verify.bndrun
@@ -27,15 +27,4 @@
     order=sortbynameversion,\
     begin=-1
 
-# The version ranges will change as the version of
-# AssertJ and/or its dependencies change.
--runbundles: \
-	assertj-core;version='[3.24.0,3.24.1)',\
-	assertj-core-osgi-tests;version='[3.24.0,3.24.1)',\
-	junit-jupiter-api;version='[5.9.1,5.9.2)',\
-	junit-jupiter-engine;version='[5.9.1,5.9.2)',\
-	junit-platform-commons;version='[1.9.1,1.9.2)',\
-	junit-platform-engine;version='[1.9.1,1.9.2)',\
-	junit-platform-launcher;version='[1.9.1,1.9.2)',\
-	net.bytebuddy.byte-buddy;version='[1.12.20,1.12.21)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+# -runbundles is calculated by the bnd-resolver-maven-plugin


### PR DESCRIPTION
Bnd 6.4.0 allows writing and reading bndrun files from different folders. So we change to use this feature so that the resolver plugin writes the resolved bndrun file to the target folder and the testing plugin uses the resolved bndrun file from the target folder.

This change means that running the maven build does not modify checked in source (bndrun files).


#### Check List:
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
