### PR TITLE
Make nestable condition factory accept conditions on super types

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
+++ b/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
@@ -142,12 +142,12 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
     return new NestableCondition<ACTUAL, ACTUAL>(descriptionPrefix, stream(conditions));
   }
 
-  private NestableCondition(String descriptionPrefix, Stream<Condition<? super NESTED>> conditions, Function<? super ACTUAL, ? extends NESTED> extractor) {
+  private NestableCondition(String descriptionPrefix, Stream<? extends Condition<? super NESTED>> conditions, Function<? super ACTUAL, ? extends NESTED> extractor) {
     super(compose(conditions, extractor));
     this.descriptionPrefix = descriptionPrefix;
   }
 
-  private NestableCondition(String descriptionPrefix, Stream<Condition<? super ACTUAL>> conditions) {
+  private NestableCondition(String descriptionPrefix, Stream<? extends Condition<? super ACTUAL>> conditions) {
     super(conditions.collect(toList()));
     this.descriptionPrefix = descriptionPrefix;
   }
@@ -162,7 +162,7 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
     return descriptionPrefix;
   }
 
-  private static <ACTUAL, NESTED> List<Condition<? super ACTUAL>> compose(Stream<Condition<? super NESTED>> conditions,
+  private static <ACTUAL, NESTED> List<Condition<? super ACTUAL>> compose(Stream<? extends Condition<? super NESTED>> conditions,
                                                                   Function<? super ACTUAL, ? extends NESTED> extractor) {
     return conditions.map(condition -> compose(condition, extractor)).collect(toList());
   }

--- a/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
+++ b/assertj-core/src/main/java/org/assertj/core/condition/NestableCondition.java
@@ -125,8 +125,8 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
    * @param <NESTED> the type of object nested into {@literal K}
    */
   @SafeVarargs
-  public static <ACTUAL, NESTED> Condition<ACTUAL> nestable(String descriptionPrefix, Function<ACTUAL, NESTED> extractor,
-                                                            Condition<NESTED>... conditions) {
+  public static <ACTUAL, NESTED> Condition<ACTUAL> nestable(String descriptionPrefix, Function<? super ACTUAL, ? extends NESTED> extractor,
+                                                            Condition<? super NESTED>... conditions) {
     return new NestableCondition<>(descriptionPrefix, stream(conditions), extractor);
   }
 
@@ -138,16 +138,16 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
    * @param <ACTUAL> the type of object the resulting condition accepts
    */
   @SafeVarargs
-  public static <ACTUAL> Condition<ACTUAL> nestable(String descriptionPrefix, Condition<ACTUAL>... conditions) {
-    return new NestableCondition<>(descriptionPrefix, stream(conditions));
+  public static <ACTUAL> Condition<ACTUAL> nestable(String descriptionPrefix, Condition<? super ACTUAL>... conditions) {
+    return new NestableCondition<ACTUAL, ACTUAL>(descriptionPrefix, stream(conditions));
   }
 
-  private NestableCondition(String descriptionPrefix, Stream<Condition<NESTED>> conditions, Function<ACTUAL, NESTED> extractor) {
+  private NestableCondition(String descriptionPrefix, Stream<Condition<? super NESTED>> conditions, Function<? super ACTUAL, ? extends NESTED> extractor) {
     super(compose(conditions, extractor));
     this.descriptionPrefix = descriptionPrefix;
   }
 
-  private NestableCondition(String descriptionPrefix, Stream<Condition<ACTUAL>> conditions) {
+  private NestableCondition(String descriptionPrefix, Stream<Condition<? super ACTUAL>> conditions) {
     super(conditions.collect(toList()));
     this.descriptionPrefix = descriptionPrefix;
   }
@@ -162,12 +162,12 @@ public class NestableCondition<ACTUAL, NESTED> extends Join<ACTUAL> {
     return descriptionPrefix;
   }
 
-  private static <ACTUAL, NESTED> List<Condition<ACTUAL>> compose(Stream<Condition<NESTED>> conditions,
-                                                                  Function<ACTUAL, NESTED> extractor) {
+  private static <ACTUAL, NESTED> List<Condition<? super ACTUAL>> compose(Stream<Condition<? super NESTED>> conditions,
+                                                                  Function<? super ACTUAL, ? extends NESTED> extractor) {
     return conditions.map(condition -> compose(condition, extractor)).collect(toList());
   }
 
-  private static <ACTUAL, NESTED> Condition<ACTUAL> compose(Condition<NESTED> condition, Function<ACTUAL, NESTED> extractor) {
+  private static <ACTUAL, NESTED> Condition<ACTUAL> compose(Condition<? super NESTED> condition, Function<? super ACTUAL, ? extends NESTED> extractor) {
     return new Condition<ACTUAL>() {
       @Override
       public boolean matches(ACTUAL value) {

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableConditionFixtures.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableConditionFixtures.java
@@ -63,6 +63,12 @@ class NestableConditionFixtures {
     return nestable("customer", conditions);
   }
 
+  static Condition<ValueCustomer> value(Integer expected) {
+    return verboseCondition(valueCustomer -> expected.equals(valueCustomer.value),
+      "value: " + expected,
+      valueCustomer -> " but was " + valueCustomer.value);
+  }
+
   @SafeVarargs
   static Condition<Address> country(Condition<Country>... conditions) {
     return nestable("country", address -> address.country, conditions);
@@ -76,6 +82,15 @@ class Customer {
   Customer(Name name, Address address) {
     this.name = name;
     this.address = address;
+  }
+}
+
+class ValueCustomer extends Customer {
+  final Integer value;
+
+  ValueCustomer(Name name, Address address, Integer value) {
+    super(name, address);
+    this.value = value;
   }
 }
 

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
@@ -13,12 +13,16 @@
 package org.assertj.core.condition;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.condition.NestableCondition.nestable;
 import static org.assertj.core.condition.NestableConditionFixtures.address;
 import static org.assertj.core.condition.NestableConditionFixtures.customer;
 import static org.assertj.core.condition.NestableConditionFixtures.first;
 import static org.assertj.core.condition.NestableConditionFixtures.firstLine;
 import static org.assertj.core.condition.NestableConditionFixtures.name;
 import static org.assertj.core.condition.NestableConditionFixtures.postcode;
+import static org.assertj.core.condition.NestableConditionFixtures.value;
+
+import java.util.function.Function;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
@@ -74,5 +78,36 @@ class NestableCondition_matches_Test {
 
     // THEN
     then(condition.matches(boris)).isFalse();
+  }
+
+  @Test
+  void should_accept_conditions_on_supertypes() {
+    // GIVEN
+    final ValueCustomer boris = new ValueCustomer(new Name("Boris", "Johnson"),
+                                                  new Address("10, Downing Street",
+                                                              "SW1A 2AA",
+                                                              new Country("United Kingdom")),
+                                                  12);
+    Condition<ValueCustomer> valueCustomer = nestable("value customer", name(
+                                                                         first("Boris")),
+                                                  value(12));
+
+    // THEN
+    then(valueCustomer.matches(boris)).isTrue();
+  }
+
+  @Test
+  void should_accept_extracting_function_from_supertype() {
+    // GIVEN
+    final ValueCustomer boris = new ValueCustomer(new Name("Boris", "Johnson"),
+      new Address("10, Downing Street",
+        "SW1A 2AA",
+        new Country("United Kingdom")),
+      12);
+    Function<Customer, Name> extractName = it -> it.name;
+    Condition<ValueCustomer> customerFirstName = nestable("customer name", extractName, first("Boris"));
+
+    // THEN
+    then(customerFirstName.matches(boris)).isTrue();
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
@@ -88,9 +88,9 @@ class NestableCondition_matches_Test {
                                                               "SW1A 2AA",
                                                               new Country("United Kingdom")),
                                                   12);
-    Condition<ValueCustomer> valueCustomer = nestable("value customer", name(
-                                                                         first("Boris")),
-                                                  value(12));
+    Condition<ValueCustomer> valueCustomer = nestable("value customer",
+                                                      name(first("Boris")),
+                                                      value(12));
 
     // THEN
     then(valueCustomer.matches(boris)).isTrue();
@@ -99,10 +99,11 @@ class NestableCondition_matches_Test {
   @Test
   void should_accept_extracting_function_from_supertype() {
     // GIVEN
-    final ValueCustomer boris = new ValueCustomer(new Name("Boris", "Johnson"),
-      new Address("10, Downing Street",
-        "SW1A 2AA",
-        new Country("United Kingdom")),
+    final ValueCustomer boris = new ValueCustomer(
+                                                  new Name("Boris", "Johnson"),
+                                                  new Address("10, Downing Street",
+                                                              "SW1A 2AA",
+                                                              new Country("United Kingdom")),
       12);
     Function<Customer, Name> extractName = it -> it.name;
     Condition<ValueCustomer> customerFirstName = nestable("customer name", extractName, first("Boris"));

--- a/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/condition/NestableCondition_matches_Test.java
@@ -104,7 +104,7 @@ class NestableCondition_matches_Test {
                                                   new Address("10, Downing Street",
                                                               "SW1A 2AA",
                                                               new Country("United Kingdom")),
-      12);
+                                                  12);
     Function<Customer, Name> extractName = it -> it.name;
     Condition<ValueCustomer> customerFirstName = nestable("customer name", extractName, first("Boris"));
 


### PR DESCRIPTION
#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Makes it possible to create a `NestableCondition<T>` by passing in a condition on a super type of `T`.