### PR TITLE
Embed module version into module descriptor

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -319,6 +319,9 @@
             </goals>
             <configuration>
               <release>9</release>
+              <compilerArgs>
+                <compilerArg>--module-version=${project.version}</compilerArg>
+              </compilerArgs>
               <compileSourceRoots>
                 <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
               </compileSourceRoots>


### PR DESCRIPTION
This makes the module descriptor aware of the module version.

By doing this, stacktraces in Java 9+ will contain the specific version of AssertJ next to the module name, allowing bug reports to contain the AssertJ version in use automatically when a stacktrace is present.
