### PR TITLE
Add `isInThePast` and `isInTheFuture` to LocalDate assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
@@ -16,6 +16,8 @@ import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
 import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
 import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
 import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.error.ShouldBeToday.shouldBeToday;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
@@ -312,6 +314,25 @@ public abstract class AbstractLocalDateAssert<SELF extends AbstractLocalDateAsse
   }
 
   /**
+   * Verifies that the actual {@code LocalDate} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(theTwoTowers.getReleaseDate()).isInThePast();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code LocalDate} is {@code null}.
+   * @throws AssertionError if the actual {@code LocalDate} is not in the past.
+   *
+   * @since 3.24.3
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(LocalDate.now())) throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code LocalDate} is today, that is matching current year, month and day.
    * <p>
    * Example:
@@ -328,6 +349,25 @@ public abstract class AbstractLocalDateAssert<SELF extends AbstractLocalDateAsse
   public SELF isToday() {
     Objects.instance().assertNotNull(info, actual);
     if (!actual.isEqual(LocalDate.now())) throw Failures.instance().failure(info, shouldBeToday(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code LocalDate} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will fail
+   * assertThat(theTwoTowers.getReleaseDate()).isInTheFuture();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code LocalDate} is {@code null}.
+   * @throws AssertionError if the actual {@code LocalDate} is not in the future.
+   *
+   * @since 3.24.3
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(LocalDate.now())) throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
     return myself;
   }
 
@@ -481,7 +521,6 @@ public abstract class AbstractLocalDateAssert<SELF extends AbstractLocalDateAsse
     }
     return myself;
   }
-
 
   /**
    * Verifies that actual {@code LocalDate} is in the given month.

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeInTheFuture.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeInTheFuture.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.error;
 
+import java.time.temporal.Temporal;
 import java.util.Date;
 
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 
-
 /**
- * Creates an error message indicating that an assertion that verifies that a {@link Date} is in the future failed.
+ * Creates an error message indicating that an assertion that verifies that a {@link Date} or a {@link Temporal} is in the future failed.
  * 
  * @author Joel Costigliola
+ * @author Stefan Bratanov
  */
 public class ShouldBeInTheFuture extends BasicErrorMessageFactory {
 
@@ -44,7 +45,20 @@ public class ShouldBeInTheFuture extends BasicErrorMessageFactory {
     return new ShouldBeInTheFuture(actual, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new <code>{@link ShouldBeInTheFuture}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeInTheFuture(Temporal actual) {
+    return new ShouldBeInTheFuture(actual);
+  }
+
   private ShouldBeInTheFuture(Date actual, ComparisonStrategy comparisonStrategy) {
     super("%nExpecting actual:%n  %s%nto be in the future %s but was not.", actual, comparisonStrategy);
+  }
+
+  private ShouldBeInTheFuture(Temporal actual) {
+    super("%nExpecting actual:%n  %s%nto be in the future but was not.", actual);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeInThePast.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeInThePast.java
@@ -12,16 +12,17 @@
  */
 package org.assertj.core.error;
 
+import java.time.temporal.Temporal;
 import java.util.Date;
 
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 
-
 /**
- * Creates an error message indicating that an assertion that verifies that a {@link Date} is in the past failed.
+ * Creates an error message indicating that an assertion that verifies that a {@link Date} or a {@link Temporal} is in the past failed.
  * 
  * @author Joel Costigliola
+ * @author Stefan Bratanov
  */
 public class ShouldBeInThePast extends BasicErrorMessageFactory {
 
@@ -44,7 +45,20 @@ public class ShouldBeInThePast extends BasicErrorMessageFactory {
     return new ShouldBeInThePast(actual, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new <code>{@link ShouldBeInThePast}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeInThePast(Temporal actual) {
+    return new ShouldBeInThePast(actual);
+  }
+
   private ShouldBeInThePast(Date actual, ComparisonStrategy comparisonStrategy) {
     super("%nExpecting actual:%n  %s%nto be in the past %s but was not.", actual, comparisonStrategy);
+  }
+
+  private ShouldBeInThePast(Temporal actual) {
+    super("%nExpecting actual:%n  %s%nto be in the past but was not.", actual);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isInTheFuture_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.localdate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LocalDateAssert isInTheFuture")
+class LocalDateAssert_isInTheFuture_Test extends LocalDateAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(AFTER).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_today() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDate actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdate/LocalDateAssert_isInThePast_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.localdate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LocalDateAssert isInThePast")
+class LocalDateAssert_isInThePast_Test extends LocalDateAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_today() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDate actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInTheFutureTest_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInTheFutureTest_create_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
 package org.assertj.core.error;
 
 import static java.lang.String.format;

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInTheFutureTest_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInTheFutureTest_create_Test.java
@@ -1,0 +1,32 @@
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+
+import java.time.LocalDate;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Stefan Bratanov
+ */
+class ShouldBeInTheFutureTest_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    LocalDate pastDate = LocalDate.of(1993, 7, 28);
+    ErrorMessageFactory factory = shouldBeInTheFuture(pastDate);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  1993-07-28 (java.time.LocalDate)%n" +
+                                   "to be in the future but was not."));
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInThePastTest_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInThePastTest_create_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
 package org.assertj.core.error;
 
 import static java.lang.String.format;

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInThePastTest_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeInThePastTest_create_Test.java
@@ -1,0 +1,32 @@
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+
+import java.time.LocalDate;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Stefan Bratanov
+ */
+class ShouldBeInThePastTest_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    LocalDate futureDate = LocalDate.of(2999, 7, 28);
+    ErrorMessageFactory factory = shouldBeInThePast(futureDate);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  2999-07-28 (java.time.LocalDate)%n" +
+                                   "to be in the past but was not."));
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes one of the tasks in #2932 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Two things I am unsure about:
- The correctness of the `@since` version
- `ShouldBeInTheFuture/ThePast` error message contains the class name (java.time.LocalDate). This seems to be the behaviour of the `MessageFormatter` handling dates classes. Is the error message ok like this?
