### PR TITLE
Add varargs overload to Assert#hasString and Assert#doesNotHaveString

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -526,9 +526,23 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  public SELF hasToString(String expectedStringTemplate, Object... args) {
+    requireNonNull(expectedStringTemplate, "The expectedStringTemplate must not be null");
+    return hasToString(String.format(expectedStringTemplate, args));
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public SELF doesNotHaveToString(String otherToString) {
     objects.assertDoesNotHaveToString(info, actual, otherToString);
     return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF doesNotHaveToString(String expectedStringTemplate, Object... args) {
+    requireNonNull(expectedStringTemplate, "The expectedStringTemplate must not be null");
+    return doesNotHaveToString(String.format(expectedStringTemplate, args));
   }
 
   /** {@inheritDoc} */

--- a/assertj-core/src/main/java/org/assertj/core/api/Assert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assert.java
@@ -473,6 +473,25 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
   SELF hasToString(String expectedToString);
 
   /**
+   * Verifies that actual {@code actual.toString()} is equal to the given {@code String} when
+   * {@link String#format formatted} with the given arguments.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Foo foo = new Foo();
+   * FooWrapper wrapper = new FooWrapper(foo);
+   *
+   * assertThat(wrapper).hasToString("FooWrapper[foo=%s]", foo);
+   * </code></pre>
+   *
+   * @param expectedStringTemplate the format string to use.
+   * @param args the arguments to interpolate into the format string.
+   * @return this assertion object.
+   * @throws AssertionError if {@code actual.toString()} result is not equal to the given {@code String}.
+   * @throws AssertionError if actual is {@code null}.
+   */
+  SELF hasToString(String expectedStringTemplate, Object... args);
+
+  /**
    * Verifies that actual {@code actual.toString()} is not equal to the given {@code String}.
    * <p>
    * Example :
@@ -489,6 +508,25 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * @throws AssertionError if actual is {@code null}.
    */
   SELF doesNotHaveToString(String otherToString);
+
+  /**
+   * Verifies that actual {@code actual.toString()} is not equal to the given {@code String}.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Foo foo = new Foo();
+   * Bar bar = new Bar();
+   * FooBarWrapper wrapper = new FooBarWrapper(bar);
+   *
+   * assertThat(wrapper).doesNotHaveToString("FooBarWrapper[%s]", foo);
+   * </code></pre>
+   *
+   * @param expectedStringTemplate the format string to use.
+   * @param args the arguments to interpolate into the format string.
+   * @return this assertion object.
+   * @throws AssertionError if {@code actual.toString()} result is equal to the given {@code String}.
+   * @throws AssertionError if actual is {@code null}.
+   */
+  SELF doesNotHaveToString(String expectedStringTemplate, Object... args);
 
   /**
    * Verifies that the actual value does not have the same class as the given object.

--- a/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveToString_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveToString_format_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractAssertBaseTest;
+import org.assertj.core.api.ConcreteAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ashley Scopes
+ */
+class AbstractAssert_doesNotHaveToString_format_Test extends AbstractAssertBaseTest {
+
+  @Override
+  protected ConcreteAssert invoke_api_method() {
+    return assertions.doesNotHaveToString("%s %s", "some", "description");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertDoesNotHaveToString(getInfo(assertions), getActual(assertions), "some description");
+  }
+
+  @Test
+  void nullStringArgumentsThrowAnException() {
+    assertThatThrownBy(() -> assertions.doesNotHaveToString(null, "foo", "bar"))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("The expectedStringTemplate must not be null");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_hasToString_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_hasToString_format_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractAssertBaseTest;
+import org.assertj.core.api.ConcreteAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ashley Scopes
+ */
+class AbstractAssert_hasToString_format_Test extends AbstractAssertBaseTest {
+
+  @Override
+  protected ConcreteAssert invoke_api_method() {
+    return assertions.hasToString("%s %s", "some", "description");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertHasToString(getInfo(assertions), getActual(assertions), "some description");
+  }
+
+  @Test
+  void nullStringArgumentsThrowAnException() {
+    assertThatThrownBy(() -> assertions.hasToString(null, "foo", "bar"))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("The expectedStringTemplate must not be null");
+  }
+}


### PR DESCRIPTION
This overload will delegate to String#format internally, similar to how StringAssert#isEqualTo allows for string templating expansion. This removes the need to write manual formatting in tests that need to consume a fixture placeholder.

Example:

```java
@Test
void toStringReturnsTheExpectedValue() {
  // Given
  var fileRepository = someFileRepository();
  var fileManager = new FileManager(fileRepository);

  // Then
  assertThat(fileManager)
      .hasToString("FileManager{repository=%s}", repository);
}
```

...rather than the current solution:

```java
@Test
void toStringReturnsTheExpectedValue() {
  // Given
  var fileRepository = someFileRepository();
  var fileManager = new FileManager(fileRepository);

  // Then
  assertThat(fileManager)
      .extracting(FileManager::toString, STRING)
      .isEqualTo("FileManager{repository=%s}", repository);
  // or
  assertThat(fileManager.toString())
      .isEqualTo("FileManager{repository=%s}", repository);
}
```