### PR TITLE
Add `isInThePast` and `isInTheFuture` to the missing java 8 date/time

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
@@ -335,7 +335,7 @@ public class AbstractInstantAssert<SELF extends AbstractInstantAssert<SELF>>
    * <p>
    * Example:
    * <pre><code class='java'> // assertion succeeds:
-   * assertThat(Instant.now().minusSeconds(1)).isInThePast();</code></pre>
+   * assertThat(Instant.now().minusSeconds(60)).isInThePast();</code></pre>
    *
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Instant} is {@code null}.
@@ -354,7 +354,7 @@ public class AbstractInstantAssert<SELF extends AbstractInstantAssert<SELF>>
    * <p>
    * Example:
    * <pre><code class='java'> // assertion succeeds:
-   * assertThat(Instant.now().plusSeconds(1)).isInTheFuture();</code></pre>
+   * assertThat(Instant.now().plusSeconds(60)).isInTheFuture();</code></pre>
    *
    * @return this assertion object.
    * @throws AssertionError if the actual {@code Instant} is {@code null}.

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInstantAssert.java
@@ -16,6 +16,8 @@ import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
 import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
 import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
 import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.time.Instant;
@@ -326,6 +328,44 @@ public class AbstractInstantAssert<SELF extends AbstractInstantAssert<SELF>>
   public SELF isNotIn(String... instantsAsString) {
     checkIsNotNullAndNotEmpty(instantsAsString);
     return isNotIn(convertToInstantArray(instantsAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code Instant} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(Instant.now().minusSeconds(1)).isInThePast();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Instant} is {@code null}.
+   * @throws AssertionError if the actual {@code Instant} is not in the past.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(Instant.now())) throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code Instant} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(Instant.now().plusSeconds(1)).isInTheFuture();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Instant} is {@code null}.
+   * @throws AssertionError if the actual {@code Instant} is not in the future.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(Instant.now())) throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
+    return myself;
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractLocalDateTimeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractLocalDateTimeAssert.java
@@ -18,6 +18,8 @@ import static org.assertj.core.error.ShouldBeEqualIgnoringHours.shouldBeEqualIgn
 import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualIgnoringMinutes;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
 import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
 import static org.assertj.core.util.Preconditions.checkArgument;
@@ -608,6 +610,44 @@ public abstract class AbstractLocalDateTimeAssert<SELF extends AbstractLocalDate
     if (!haveSameYearMonthAndDayOfMonth(actual, other)) {
       throw Failures.instance().failure(info, shouldBeEqualIgnoringHours(actual, other));
     }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code LocalDateTime} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(LocalDateTime.now().minusMinutes(1)).isInThePast();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code LocalDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code LocalDateTime} is not in the past.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(LocalDateTime.now())) throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code LocalDateTime} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(LocalDateTime.now().plusMinutes(1)).isInTheFuture();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code LocalDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code LocalDateTime} is not in the future.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(LocalDateTime.now())) throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOffsetDateTimeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOffsetDateTimeAssert.java
@@ -20,6 +20,8 @@ import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualI
 import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
 import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
 import static org.assertj.core.error.ShouldBeEqualIgnoringTimezone.shouldBeEqualIgnoringTimezone;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.time.OffsetDateTime;
@@ -446,7 +448,6 @@ public abstract class AbstractOffsetDateTimeAssert<SELF extends AbstractOffsetDa
     return isEqualTo(parse(dateTimeAsString));
   }
 
-
   /**
    * Verifies that the actual {@code OffsetDateTime} is not equal to the given value according to the comparator in use.
    * <p>
@@ -744,6 +745,46 @@ public abstract class AbstractOffsetDateTimeAssert<SELF extends AbstractOffsetDa
     if (!haveSameYearMonthAndDayOfMonth(actual, other)) {
       throw Failures.instance().failure(info, shouldBeEqualIgnoringHours(actual, other));
     }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code OffsetDateTime} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(OffsetDateTime.now().minusMinutes(1)).isInThePast();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code OffsetDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code OffsetDateTime} is not in the past.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(OffsetDateTime.now(actual.getOffset())))
+      throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code OffsetDateTime} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(OffsetDateTime.now().plusMinutes(1)).isInTheFuture();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code OffsetDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code OffsetDateTime} is not in the future.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(OffsetDateTime.now(actual.getOffset())))
+      throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractZonedDateTimeAssert.java
@@ -16,6 +16,8 @@ import static org.assertj.core.error.ShouldBeEqualIgnoringHours.shouldBeEqualIgn
 import static org.assertj.core.error.ShouldBeEqualIgnoringMinutes.shouldBeEqualIgnoringMinutes;
 import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
 import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.time.ZonedDateTime;
@@ -697,6 +699,46 @@ public abstract class AbstractZonedDateTimeAssert<SELF extends AbstractZonedDate
   public SELF isNotIn(String... dateTimesAsString) {
     checkIsNotNullAndNotEmpty(dateTimesAsString);
     return isNotIn(convertToDateTimeArray(dateTimesAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code ZonedDateTime} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(ZonedDateTime.now().minusMinutes(1)).isInThePast();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is not in the past.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(ZonedDateTime.now(actual.getZone())))
+      throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code ZonedDateTime} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(ZonedDateTime.now().plusMinutes(1)).isInTheFuture();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is {@code null}.
+   * @throws AssertionError if the actual {@code ZonedDateTime} is not in the future.
+   *
+   * @since 3.25.0
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(ZonedDateTime.now(actual.getZone())))
+      throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
+    return myself;
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractOffsetDateTimeAssertBaseTest extends TemporalAsser
   protected static final OffsetDateTime BEFORE = REFERENCE.minusHours(1);
   protected static final OffsetDateTime AFTER = REFERENCE.plusHours(1);
 
-  protected static final OffsetDateTime REFERENCE_WITH_DIFFERENT_OFFSET = OffsetDateTime.now(OFFSET);
+  protected static final OffsetDateTime REFERENCE_WITH_DIFFERENT_OFFSET = REFERENCE.withOffsetSameInstant(OFFSET);
   protected static final OffsetDateTime BEFORE_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.minusHours(1);
   protected static final OffsetDateTime AFTER_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.plusHours(1);
 

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
@@ -26,12 +26,12 @@ public abstract class AbstractOffsetDateTimeAssertBaseTest extends TemporalAsser
   private static final ZoneOffset OFFSET = ZoneOffset.ofHours(3);
 
   protected static final OffsetDateTime REFERENCE = OffsetDateTime.now(ZoneOffset.UTC);
-  protected static final OffsetDateTime BEFORE = REFERENCE.minusMinutes(1);
-  protected static final OffsetDateTime AFTER = REFERENCE.plusMinutes(1);
+  protected static final OffsetDateTime BEFORE = REFERENCE.minusHours(1);
+  protected static final OffsetDateTime AFTER = REFERENCE.plusHours(1);
 
   protected static final OffsetDateTime REFERENCE_WITH_DIFFERENT_OFFSET = OffsetDateTime.now(OFFSET);
-  protected static final OffsetDateTime BEFORE_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.minusMinutes(1);
-  protected static final OffsetDateTime AFTER_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.plusMinutes(1);
+  protected static final OffsetDateTime BEFORE_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.minusHours(1);
+  protected static final OffsetDateTime AFTER_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.plusHours(1);
 
   protected static final ComparatorBasedComparisonStrategy COMPARISON_STRATEGY = comparisonStrategy();
 

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractOffsetDateTimeAssertBaseTest.java
@@ -24,12 +24,15 @@ import org.assertj.core.internal.OffsetDateTimeByInstantComparator;
 public abstract class AbstractOffsetDateTimeAssertBaseTest extends TemporalAssertBaseTest<OffsetDateTimeAssert, OffsetDateTime> {
 
   private static final ZoneOffset OFFSET = ZoneOffset.ofHours(3);
-  protected static final OffsetDateTime REFERENCE = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 0, ZoneOffset.UTC);
-  protected static final OffsetDateTime BEFORE = OffsetDateTime.of(2000, 12, 13, 23, 59, 59, 999, ZoneOffset.UTC);
-  protected static final OffsetDateTime AFTER = OffsetDateTime.of(2000, 12, 14, 0, 0, 0, 1, ZoneOffset.UTC);
-  protected static final OffsetDateTime REFERENCE_WITH_DIFFERENT_OFFSET = OffsetDateTime.of(2000, 12, 14, 3, 0, 0, 0, OFFSET);
-  protected static final OffsetDateTime BEFORE_WITH_DIFFERENT_OFFSET = OffsetDateTime.of(2000, 12, 14, 2, 59, 59, 999, OFFSET);
-  protected static final OffsetDateTime AFTER_WITH_DIFFERENT_OFFSET = OffsetDateTime.of(2000, 12, 14, 3, 0, 0, 1, OFFSET);
+
+  protected static final OffsetDateTime REFERENCE = OffsetDateTime.now(ZoneOffset.UTC);
+  protected static final OffsetDateTime BEFORE = REFERENCE.minusMinutes(1);
+  protected static final OffsetDateTime AFTER = REFERENCE.plusMinutes(1);
+
+  protected static final OffsetDateTime REFERENCE_WITH_DIFFERENT_OFFSET = OffsetDateTime.now(OFFSET);
+  protected static final OffsetDateTime BEFORE_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.minusMinutes(1);
+  protected static final OffsetDateTime AFTER_WITH_DIFFERENT_OFFSET = REFERENCE_WITH_DIFFERENT_OFFSET.plusMinutes(1);
+
   protected static final ComparatorBasedComparisonStrategy COMPARISON_STRATEGY = comparisonStrategy();
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractZonedDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractZonedDateTimeAssertBaseTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractZonedDateTimeAssertBaseTest extends TemporalAssert
   protected static final ZonedDateTime YESTERDAY = NOW.minusDays(1);
   protected static final ZonedDateTime TOMORROW = NOW.plusDays(1);
 
-  protected static final ZonedDateTime NOW_WITH_DIFFERENT_ZONE = ZonedDateTime.now(TOKYO_ZONE_ID);
+  protected static final ZonedDateTime NOW_WITH_DIFFERENT_ZONE = NOW.withZoneSameInstant(TOKYO_ZONE_ID);
   protected static final ZonedDateTime YESTERDAY_WITH_DIFFERENT_ZONE = NOW_WITH_DIFFERENT_ZONE.minusDays(1);
   protected static final ZonedDateTime TOMORROW_WITH_DIFFERENT_ZONE = NOW_WITH_DIFFERENT_ZONE.plusDays(1);
 

--- a/assertj-core/src/test/java/org/assertj/core/api/AbstractZonedDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AbstractZonedDateTimeAssertBaseTest.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import static org.mockito.Mockito.mock;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import org.assertj.core.internal.ChronoZonedDateTimeByInstantComparator;
@@ -22,9 +23,16 @@ import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
 
 public abstract class AbstractZonedDateTimeAssertBaseTest extends TemporalAssertBaseTest<ZonedDateTimeAssert, ZonedDateTime> {
 
+  private static final ZoneId TOKYO_ZONE_ID = ZoneId.of("Asia/Tokyo");
+
   protected static final ZonedDateTime NOW = ZonedDateTime.now();
   protected static final ZonedDateTime YESTERDAY = NOW.minusDays(1);
   protected static final ZonedDateTime TOMORROW = NOW.plusDays(1);
+
+  protected static final ZonedDateTime NOW_WITH_DIFFERENT_ZONE = ZonedDateTime.now(TOKYO_ZONE_ID);
+  protected static final ZonedDateTime YESTERDAY_WITH_DIFFERENT_ZONE = NOW_WITH_DIFFERENT_ZONE.minusDays(1);
+  protected static final ZonedDateTime TOMORROW_WITH_DIFFERENT_ZONE = NOW_WITH_DIFFERENT_ZONE.plusDays(1);
+
   protected static final ComparatorBasedComparisonStrategy COMPARISON_STRATEGY = comparisonStrategy();
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
@@ -15,7 +15,9 @@ package org.assertj.core.api.instant;
 import java.time.Instant;
 
 public class InstantAssertBaseTest {
-  public static final Instant BEFORE = Instant.now().minusSeconds(1);
+
   public static final Instant REFERENCE = Instant.now();
-  public static final Instant AFTER = Instant.now().plusSeconds(1);
+  public static final Instant BEFORE = REFERENCE.minusSeconds(1);
+  public static final Instant AFTER = REFERENCE.plusSeconds(1);
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssertBaseTest.java
@@ -13,11 +13,12 @@
 package org.assertj.core.api.instant;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 public class InstantAssertBaseTest {
 
   public static final Instant REFERENCE = Instant.now();
-  public static final Instant BEFORE = REFERENCE.minusSeconds(1);
-  public static final Instant AFTER = REFERENCE.plusSeconds(1);
+  public static final Instant BEFORE = REFERENCE.minus(1, ChronoUnit.HOURS);
+  public static final Instant AFTER = REFERENCE.plus(1, ChronoUnit.HOURS);
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssert_isInTheFuture_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class InstantAssert_isInTheFuture_Test extends InstantAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(AFTER).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Instant actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/instant/InstantAssert_isInThePast_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+class InstantAssert_isInThePast_Test extends InstantAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Instant actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
@@ -27,7 +27,7 @@ import org.assertj.core.api.AbstractLocalDateTimeAssert;
 public class LocalDateTimeAssertBaseTest {
 
   public static final LocalDateTime REFERENCE = LocalDateTime.now();
-  public static final LocalDateTime BEFORE = REFERENCE.minusMinutes(1);
-  public static final LocalDateTime AFTER = REFERENCE.plusMinutes(1);
+  public static final LocalDateTime BEFORE = REFERENCE.minusHours(1);
+  public static final LocalDateTime AFTER = REFERENCE.plusHours(1);
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssertBaseTest.java
@@ -16,18 +16,18 @@ import java.time.LocalDateTime;
 
 import org.assertj.core.api.AbstractLocalDateTimeAssert;
 
-
 /**
  * 
  * Base test class for {@link AbstractLocalDateTimeAssert} tests.
  * 
  * @author Joel Costigliola
  * @author Marcin Zajączkowski
+ * @author Stefan Bratanov
  */
 public class LocalDateTimeAssertBaseTest {
 
-  public static final LocalDateTime REFERENCE = LocalDateTime.of(2000, 12, 14, 0, 0);
-  public static final LocalDateTime BEFORE = LocalDateTime.of(2000, 12, 13, 23, 59, 59, 999);
-  public static final LocalDateTime AFTER = LocalDateTime.of(2000, 12, 14, 0, 0, 0, 1);
+  public static final LocalDateTime REFERENCE = LocalDateTime.now();
+  public static final LocalDateTime BEFORE = REFERENCE.minusMinutes(1);
+  public static final LocalDateTime AFTER = REFERENCE.plusMinutes(1);
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isInTheFuture_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.localdatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+class LocalDateTimeAssert_isInTheFuture_Test extends LocalDateTimeAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(AFTER).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDate actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/localdatetime/LocalDateTimeAssert_isInThePast_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.localdatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+class LocalDateTimeAssert_isInThePast_Test extends LocalDateTimeAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDateTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isInTheFuture_Test.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.OffsetDateTime;
+
+import org.assertj.core.api.AbstractOffsetDateTimeAssertBaseTest;
+import org.assertj.core.api.OffsetDateTimeAssert;
+import org.junit.jupiter.api.Test;
+
+class OffsetDateTimeAssert_isInTheFuture_Test extends AbstractOffsetDateTimeAssertBaseTest {
+
+  @Override
+  protected OffsetDateTimeAssert invoke_api_method() {
+    return assertions;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // NO-OP
+  }
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(AFTER).isInTheFuture();
+  }
+
+  @Test
+  void should_pass_if_actual__with_different_offset_is_in_the_future() {
+    assertThat(AFTER_WITH_DIFFERENT_OFFSET).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_offset_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE_WITH_DIFFERENT_OFFSET).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE_WITH_DIFFERENT_OFFSET).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_offset_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE_WITH_DIFFERENT_OFFSET).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE_WITH_DIFFERENT_OFFSET).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    OffsetDateTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/offsetdatetime/OffsetDateTimeAssert_isInThePast_Test.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.offsetdatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.AbstractOffsetDateTimeAssertBaseTest;
+import org.assertj.core.api.OffsetDateTimeAssert;
+import org.junit.jupiter.api.Test;
+
+class OffsetDateTimeAssert_isInThePast_Test extends AbstractOffsetDateTimeAssertBaseTest {
+
+  @Override
+  protected OffsetDateTimeAssert invoke_api_method() {
+    return assertions;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // NO-OP
+  }
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isInThePast();
+  }
+
+  @Test
+  void should_pass_if_actual_with_different_offset_is_in_the_past() {
+    assertThat(BEFORE_WITH_DIFFERENT_OFFSET).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_offset_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER_WITH_DIFFERENT_OFFSET).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER_WITH_DIFFERENT_OFFSET).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDateTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isInTheFuture_Test.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.zoneddatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.ZonedDateTime;
+
+import org.assertj.core.api.AbstractZonedDateTimeAssertBaseTest;
+import org.assertj.core.api.ZonedDateTimeAssert;
+import org.junit.jupiter.api.Test;
+
+class ZonedDateTimeAssert_isInTheFuture_Test extends AbstractZonedDateTimeAssertBaseTest {
+
+  @Override
+  protected ZonedDateTimeAssert invoke_api_method() {
+    return assertions;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // NO-OP
+  }
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(TOMORROW).isInTheFuture();
+  }
+
+  @Test
+  void should_pass_if_actual__with_different_zone_is_in_the_future() {
+    assertThat(TOMORROW_WITH_DIFFERENT_ZONE).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(NOW).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(NOW).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_zone_is_now() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(NOW_WITH_DIFFERENT_ZONE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(NOW_WITH_DIFFERENT_ZONE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(YESTERDAY).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(YESTERDAY).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_zone_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(YESTERDAY_WITH_DIFFERENT_ZONE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(YESTERDAY_WITH_DIFFERENT_ZONE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    ZonedDateTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/zoneddatetime/ZonedDateTimeAssert_isInThePast_Test.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.zoneddatetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.AbstractZonedDateTimeAssertBaseTest;
+import org.assertj.core.api.ZonedDateTimeAssert;
+import org.junit.jupiter.api.Test;
+
+class ZonedDateTimeAssert_isInThePast_Test extends AbstractZonedDateTimeAssertBaseTest {
+
+  @Override
+  protected ZonedDateTimeAssert invoke_api_method() {
+    return assertions;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    // NO-OP
+  }
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(YESTERDAY).isInThePast();
+  }
+
+  @Test
+  void should_pass_if_actual_with_different_zone_is_in_the_past() {
+    assertThat(YESTERDAY_WITH_DIFFERENT_ZONE).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(TOMORROW).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(TOMORROW).create());
+  }
+
+  @Test
+  void should_fail_if_actual_with_different_zone_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(TOMORROW_WITH_DIFFERENT_ZONE).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(TOMORROW_WITH_DIFFERENT_ZONE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalDateTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2932 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

- Add the missing assertions for `Instant` `LocalDateTime` `OffsetDateTime` `ZonedDateTime` since they follow the same patterns. Decided it makes sense to make them one PR.
- Not sure if is necessary to implement `invoke_api_method` and `verify_internal_effects` for the `ZonedDateTimeAssert` and the `OffsetDateTimeAssert` tests. I implemented them as no-op.
