### PR TITLE
Add isRecord() and isNotRecord() Class assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -19,7 +19,6 @@ import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.util.Arrays.array;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
@@ -230,6 +229,8 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * @return {@code this} assertions object
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is not a record.
+   *
+   * @since 3.25.0
    */
   public SELF isRecord() {
     isNotNull();
@@ -252,6 +253,8 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * @return {@code this} assertions object
    * @throws AssertionError if {@code actual} is {@code null}.
    * @throws AssertionError if the actual {@code Class} is a record.
+   *
+   * @since 3.25.0
    */
   public SELF isNotRecord() {
     isNotNull();
@@ -259,14 +262,14 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
     return myself;
   }
 
-  private boolean isRecord(Class<?> actual) {
+  private static boolean isRecord(Class<?> actual) {
     try {
-      Method isRecordMethod = Class.class.getMethod("isRecord");
-      return (boolean) isRecordMethod.invoke(actual);
+      Method isRecord = Class.class.getMethod("isRecord");
+      return (boolean) isRecord.invoke(actual);
     } catch (NoSuchMethodException e) {
       // Definitely not a record if we're running on a JVM that doesn't support records
       return false;
-    } catch (InvocationTargetException | IllegalAccessException e) {
+    } catch (ReflectiveOperationException e) {
       throw new IllegalStateException(e);
     }
   }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeRecord.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeRecord.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class is (or not) a record.
+ *
+ * @author Louis Morgan
+ */
+public class ShouldBeRecord extends BasicErrorMessageFactory {
+  /**
+   * Creates a new <code>{@link ShouldBeRecord}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeRecord(Class<?> actual) {
+    return new ShouldBeRecord(actual, true);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeRecord}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotBeRecord(Class<?> actual) {
+    return new ShouldBeRecord(actual, false);
+  }
+
+  private ShouldBeRecord(Class<?> actual, boolean toBeOrNotToBe) {
+    super("%nExpecting%n  %s%n" + (toBeOrNotToBe ? "" : " not ") + "to be a record", actual);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isNotRecord_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isNotRecord_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ClassAssert#isNotRecord()}</code>.
+ *
+ * @author Louis Morgan
+ */
+class ClassAssert_isNotRecord_Test {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    Class<?> actual = null;
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotRecord());
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {
+    String.class,
+    ArrayList.class,
+    ValueSource.class
+  })
+  void should_pass_if_actual_is_not_a_record(Class<?> actual) {
+    assertThat(actual).isNotRecord();
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isNotRecord_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isNotRecord_Test.java
@@ -24,26 +24,28 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link org.assertj.core.api.ClassAssert#isNotRecord()}</code>.
- *
  * @author Louis Morgan
  */
 class ClassAssert_isNotRecord_Test {
 
   @Test
   void should_fail_if_actual_is_null() {
+    // GIVEN
     Class<?> actual = null;
+    // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotRecord());
+    // THEN
     then(assertionError).hasMessage(shouldNotBeNull().create());
   }
 
   @ParameterizedTest
   @ValueSource(classes = {
-    String.class,
-    ArrayList.class,
-    ValueSource.class
+      String.class,
+      ArrayList.class,
+      ValueSource.class
   })
   void should_pass_if_actual_is_not_a_record(Class<?> actual) {
+    // WHEN/THEN
     assertThat(actual).isNotRecord();
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isRecord_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isRecord_Test.java
@@ -25,27 +25,30 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link org.assertj.core.api.ClassAssert#isRecord()}</code>.
- *
  * @author Louis Morgan
  */
-public class ClassAssert_isRecord_Test {
+class ClassAssert_isRecord_Test {
 
   @Test
   void should_fail_if_actual_is_null() {
+    // GIVEN
     Class<?> actual = null;
+    // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isRecord());
+    // THEN
     then(assertionError).hasMessage(shouldNotBeNull().create());
   }
 
   @ParameterizedTest
   @ValueSource(classes = {
-    String.class,
-    ArrayList.class,
-    ValueSource.class
+      String.class,
+      ArrayList.class,
+      ValueSource.class
   })
   void should_fail_if_actual_is_not_a_record(Class<?> actual) {
+    // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isRecord());
+    // THEN
     then(assertionError).hasMessage(shouldBeRecord(actual).create());
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isRecord_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/classes/ClassAssert_isRecord_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.classes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeRecord.shouldBeRecord;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ClassAssert#isRecord()}</code>.
+ *
+ * @author Louis Morgan
+ */
+public class ClassAssert_isRecord_Test {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    Class<?> actual = null;
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isRecord());
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {
+    String.class,
+    ArrayList.class,
+    ValueSource.class
+  })
+  void should_fail_if_actual_is_not_a_record(Class<?> actual) {
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isRecord());
+    then(assertionError).hasMessage(shouldBeRecord(actual).create());
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-groovy/src/test/groovy/org/assertj/core/tests/groovy/StandardRepresentation_using_GString_Test.groovy
+++ b/assertj-tests/assertj-integration-tests/assertj-core-groovy/src/test/groovy/org/assertj/core/tests/groovy/StandardRepresentation_using_GString_Test.groovy
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.tests.groovy
 
-
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-java-17/pom.xml
+++ b/assertj-tests/assertj-integration-tests/assertj-core-java-17/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.assertj</groupId>
+    <artifactId>assertj-integration-tests</artifactId>
+    <version>3.25.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>assertj-core-java-17</artifactId>
+
+  <name>AssertJ Core Integration Tests - Java 17</name>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/assertj-tests/assertj-integration-tests/assertj-core-java-17/src/test/java/org/assertj/core/tests/java17/Assertions_assertThat_with_Record_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-java-17/src/test/java/org/assertj/core/tests/java17/Assertions_assertThat_with_Record_Test.java
@@ -13,28 +13,33 @@
 package org.assertj.core.tests.java17;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldBeRecord.shouldNotBeRecord;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Java 17 specific tests for assertions on records.
- *
  * @author Louis Morgan
  */
-class RecordTest {
-  record MyRecord(String name) {}
+class Assertions_assertThat_with_Record_Test {
 
   @Test
   void is_record_should_pass_if_actual_is_a_record() {
+    // WHEN/THEN
     assertThat(MyRecord.class).isRecord();
   }
 
   @Test
   void is_not_record_should_fail_if_actual_is_a_record() {
-    assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> assertThat(MyRecord.class).isNotRecord())
-      .withMessage(shouldNotBeRecord(MyRecord.class).create());
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(MyRecord.class).isNotRecord());
+    // THEN
+    then(thrown).isInstanceOf(AssertionError.class)
+                .hasMessage(shouldNotBeRecord(MyRecord.class).create());
   }
+
+  record MyRecord(String value) {
+  }
+
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-java-17/src/test/java/org/assertj/core/tests/java17/RecordTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-java-17/src/test/java/org/assertj/core/tests/java17/RecordTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.tests.java17;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.error.ShouldBeRecord.shouldNotBeRecord;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java 17 specific tests for assertions on records.
+ *
+ * @author Louis Morgan
+ */
+class RecordTest {
+  record MyRecord(String name) {}
+
+  @Test
+  void is_record_should_pass_if_actual_is_a_record() {
+    assertThat(MyRecord.class).isRecord();
+  }
+
+  @Test
+  void is_not_record_should_fail_if_actual_is_a_record() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(MyRecord.class).isNotRecord())
+      .withMessage(shouldNotBeRecord(MyRecord.class).create());
+  }
+}

--- a/assertj-tests/assertj-integration-tests/pom.xml
+++ b/assertj-tests/assertj-integration-tests/pom.xml
@@ -14,6 +14,7 @@
   <name>AssertJ Integration Tests</name>
 
   <modules>
+    <module>assertj-core-java-17</module>
     <module>assertj-core-junit4-with-opentest4j</module>
     <module>assertj-core-kotlin</module>
     <module>assertj-core-osgi</module>


### PR DESCRIPTION
#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Add `isRecord()` and `isNotRecord()` Class assertions.

As `record` only landed in Java 16 I'm having to use reflection to check whether the class is a record or not. I'm also only able to add unit tests for the negative cases, because I can't compile code that uses `record`.

If this is accepted I thought I'd also open a PR that adds a `hasRecordComponents` assertion.