### PR TITLE
Add `hasNullValue` and `doesNotHaveNullValue` to `AtomicReferenceAssert`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceAssert.java
@@ -178,10 +178,7 @@ public class AtomicReferenceAssert<V> extends AbstractAssert<AtomicReferenceAsse
    * @since 3.25.0
    */
   public AtomicReferenceAssert<V> hasNullValue() {
-    isNotNull();
-    V actualValue = actual.get();
-    objects.assertNull(info, actualValue);
-    return myself;
+    return hasValue(null);
   }
 
   /**
@@ -199,10 +196,7 @@ public class AtomicReferenceAssert<V> extends AbstractAssert<AtomicReferenceAsse
    * @since 3.25.0
    */
   public AtomicReferenceAssert<V> doesNotHaveNullValue() {
-    isNotNull();
-    V actualValue = actual.get();
-    objects.assertNotNull(info, actualValue);
-    return myself;
+    return doesNotHaveValue(null);
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceAssert.java
@@ -163,4 +163,46 @@ public class AtomicReferenceAssert<V> extends AbstractAssert<AtomicReferenceAsse
     return myself;
   }
 
+  /**
+   * Verifies that the atomic under test has the {@code null} value.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat(new AtomicReference(null)).hasNullValue();
+   *
+   * // assertion fails
+   * assertThat(new AtomicReference("foo")).hasNullValue();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the atomic under test does not have the null value.
+   * @since 3.25.0
+   */
+  public AtomicReferenceAssert<V> hasNullValue() {
+    isNotNull();
+    V actualValue = actual.get();
+    objects.assertNull(info, actualValue);
+    return myself;
+  }
+
+  /**
+   * Verifies that the atomic under test does not have the {@code null} value.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat(new AtomicReference("foo")).doesNotHaveNullValue();
+   *
+   * // assertion fails
+   * assertThat(new AtomicReference(null)).doesNotHaveNullValue();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the atomic under test has the null value.
+   * @since 3.25.0
+   */
+  public AtomicReferenceAssert<V> doesNotHaveNullValue() {
+    isNotNull();
+    V actualValue = actual.get();
+    objects.assertNotNull(info, actualValue);
+    return myself;
+  }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
@@ -1,0 +1,26 @@
+package org.assertj.core.api.atomic.reference;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+class AtomicReferenceAssert_doesNotHaveNullValue_Test {
+
+  @Test
+  void should_pass_when_actual_does_not_have_the_null_value() {
+    AtomicReference<String> actual = new AtomicReference<>("foo");
+    assertThat(actual).doesNotHaveNullValue();
+  }
+
+  @Test
+  void should_fail_when_actual_has_the_null_value() {
+    AtomicReference<String> actual = new AtomicReference<>(null);
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).doesNotHaveNullValue())
+                                                   .withMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
 
 class AtomicReferenceAssert_doesNotHaveNullValue_Test {
 
@@ -32,7 +32,7 @@ class AtomicReferenceAssert_doesNotHaveNullValue_Test {
   void should_fail_when_actual_has_the_null_value() {
     AtomicReference<String> actual = new AtomicReference<>(null);
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).doesNotHaveNullValue())
-                                                   .withMessage(actualIsNull());
+                                                   .withMessage(shouldNotContainValue(actual, null).create());
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
@@ -12,27 +12,33 @@
  */
 package org.assertj.core.api.atomic.reference;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
+import org.junit.jupiter.api.Test;
 
 class AtomicReferenceAssert_doesNotHaveNullValue_Test {
 
   @Test
   void should_pass_when_actual_does_not_have_the_null_value() {
+    // GIVEN
     AtomicReference<String> actual = new AtomicReference<>("foo");
+    // WHEN/THEN
     assertThat(actual).doesNotHaveNullValue();
   }
 
   @Test
   void should_fail_when_actual_has_the_null_value() {
+    // GIVEN
     AtomicReference<String> actual = new AtomicReference<>(null);
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).doesNotHaveNullValue())
-                                                   .withMessage(shouldNotContainValue(actual, null).create());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).doesNotHaveNullValue());
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainValue(actual, null).create());
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_doesNotHaveNullValue_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
 package org.assertj.core.api.atomic.reference;
 
 import org.junit.jupiter.api.Test;

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.atomic.reference;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class AtomicReferenceAssert_hasNullValue_Test {
+
+  @Test
+  void should_pass_when_actual_has_the_null_value() {
+    AtomicReference<String> actual = new AtomicReference<>(null);
+    assertThat(actual).hasNullValue();
+  }
+
+  @Test
+  void should_fail_when_actual_does_not_have_the_null_value() {
+    AtomicReference<String> actual = new AtomicReference<>("foo");
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).hasNullValue())
+                                                   .withMessage("\nexpected: null\n but was: \"foo\"");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
@@ -12,27 +12,33 @@
  */
 package org.assertj.core.api.atomic.reference;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveValue.shouldHaveValue;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.error.ShouldHaveValue.shouldHaveValue;
+import org.junit.jupiter.api.Test;
 
 class AtomicReferenceAssert_hasNullValue_Test {
 
   @Test
   void should_pass_when_actual_has_the_null_value() {
+    // GIVEN
     AtomicReference<String> actual = new AtomicReference<>(null);
+    // WHEN/THEN
     assertThat(actual).hasNullValue();
   }
 
   @Test
   void should_fail_when_actual_does_not_have_the_null_value() {
+    // GIVEN
     AtomicReference<String> actual = new AtomicReference<>("foo");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).hasNullValue())
-                                                   .withMessage(shouldHaveValue(actual, null).create());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasNullValue());
+    // THEN
+    then(assertionError).hasMessage(shouldHaveValue(actual, null).create());
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasNullValue_Test.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.error.ShouldHaveValue.shouldHaveValue;
 
 class AtomicReferenceAssert_hasNullValue_Test {
 
@@ -31,7 +32,7 @@ class AtomicReferenceAssert_hasNullValue_Test {
   void should_fail_when_actual_does_not_have_the_null_value() {
     AtomicReference<String> actual = new AtomicReference<>("foo");
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).hasNullValue())
-                                                   .withMessage("\nexpected: null\n but was: \"foo\"");
+                                                   .withMessage(shouldHaveValue(actual, null).create());
   }
 
 }


### PR DESCRIPTION
#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

`hasNullValue` and `doesNotHaveNullValue` will be useful for checking whether an `AtomicReference` has the null value or not. These are shortcuts of `hasVallue(null)` and `doesNotHaveValue(null)` and would be useful when using package which non-null is the default since IDE may warn that `hasVallue(null)` receives `null`.