### PR TITLE
Fix ignoringFields with different map size

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.core.api.recursive.comparison;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.collect.ImmutableSortedMap.of;import static java.lang.String.format;
+import static java.util.Collections.singletonMap;import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.entry;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.recursive.comparison.Color.BLUE;
@@ -37,11 +37,11 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
+import java.util.SortedMap;import java.util.stream.Stream;
 
 import javax.xml.datatype.DatatypeFactory;
 
-import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
+import com.google.common.collect.Maps;import org.assertj.core.api.Assertions;import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
 import org.assertj.core.internal.objects.data.AlwaysEqualPerson;
 import org.assertj.core.internal.objects.data.FriendlyPerson;
 import org.assertj.core.internal.objects.data.Giant;
@@ -564,8 +564,8 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
 
   private static Stream<Arguments> should_not_introspect_java_base_classes() throws Exception {
 
-    return Stream.of(arguments(DatatypeFactory.newInstance().newXMLGregorianCalendar(), 
-                               DatatypeFactory.newInstance().newXMLGregorianCalendar(), 
+    return Stream.of(arguments(DatatypeFactory.newInstance().newXMLGregorianCalendar(),
+                               DatatypeFactory.newInstance().newXMLGregorianCalendar(),
                                "com.sun.org.apache.xerces.internal.jaxp.datatype.XMLGregorianCalendarImpl"),
                      arguments(InetAddress.getByName("127.0.0.1"),
                                InetAddress.getByName("127.0.0.1"),

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
@@ -13,20 +13,20 @@
 package org.assertj.core.api.recursive.comparison;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.api.AssertionsForClassTypes.entry;import static org.assertj.core.test.Maps.mapOf;import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Lists.list;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
-import org.assertj.core.internal.objects.data.Address;
+import org.assertj.core.data.MapEntry;import org.assertj.core.internal.objects.data.Address;
 import org.assertj.core.internal.objects.data.Giant;
 import org.assertj.core.internal.objects.data.Human;
 import org.assertj.core.internal.objects.data.Person;
@@ -279,6 +279,56 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
                                list("home")),
                      arguments(person7, person8, "same data except for one subfield of an ignored field",
                                list("neighbour.neighbour.home.address.number", "neighbour.name")));
+  }
+
+  @SuppressWarnings("unused")
+  @ParameterizedTest(name = "{2}: actual={0} / expected={1} / ignored fields={3}")
+  @MethodSource("recursivelyEqualMapsWithVariousSizesIgnoringGivenFields")
+  void should_pass_for_maps_with_the_various_sizes_when_given_fields_are_ignored(Object actual,
+                                                                                Object expected,
+                                                                                String testDescription,
+                                                                                List<String> ignoredFields) {
+    assertThat(actual).usingRecursiveComparison()
+      .ignoringFields(arrayOf(ignoredFields))
+      .isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> recursivelyEqualMapsWithVariousSizesIgnoringGivenFields() {
+    return Stream.of(
+      arguments(mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Doe")
+      ), mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Wick")), "maps with same size, one common field ignored", list("lastName")),
+
+      arguments(mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Doe")
+      ), mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Doe"),
+        entry("age", "25")
+      ), "maps without same size, one ignored field 'age' added", list("age")),
+
+      arguments(mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Doe")
+      ), mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Wick"),
+        entry("age", "25")
+      ), "maps without same size, two ignored fields 'age', 'lastName' added", list("age", "lastName")),
+
+      arguments(mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Doe")
+      ), mapOf(
+        entry("firstName", "John"),
+        entry("lastName", "Wick"),
+        entry("age", "25")
+      ), "maps without same size, all field ignored", list("age", "lastName", "firstName"))
+    );
   }
 
   @Test


### PR DESCRIPTION
Fix ignoringFields behavior that doesn't work properly when using maps of different sizes with usingRecursiveComparison and isEqualTo for example.

Fix #2988