### PR TITLE
Add getters for field path in ComparisonDifference

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
@@ -92,6 +92,10 @@ public class ComparisonDifference implements Comparable<ComparisonDifference> {
     return additionalInformation;
   }
 
+  public List<String> getDecomposedPath() {
+    return decomposedPath;
+  }
+
   @Override
   public String toString() {
     return additionalInformation.isPresent()


### PR DESCRIPTION
Check List:
Fixes absense of getters for field path in ComparisonDifference
Unit tests : NA
Javadoc with a code example (on API only) : NA
PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

org.assertj.core.api.recursive.comparison.ComparisonDifference unnecessery closes access to both decomposedPath and concatenatedPath.
org.assertj.core.api.recursive.comparison.RecursiveComparisonDifferenceCalculator#determineDifferences is a public method but you cannot get a field path from its result. It would be nice to have getters on it to use in an application code.