### PR TITLE
Generate MANIFEST.MF build info

### DIFF
--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -205,6 +205,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${maven-jar-plugin.version}</version>
+          <configuration>
+            <archive>
+              <index>true</index>
+              <manifest>
+                <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -207,7 +207,6 @@
           <version>${maven-jar-plugin.version}</version>
           <configuration>
             <archive>
-              <index>true</index>
               <manifest>
                 <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
- Include build info and versioning info in the JAR manifest so that applications can inspect it  reflectively as needed without needing to check gradle, maven, or OSGi build metadata to find out the active version.
