### PR TITLE
Fixes a bug when failing assertions on DirectoryStream types

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -112,6 +113,15 @@ public class StandardRepresentation implements Representation {
   private static final Map<Class<?>, Function<?, ? extends CharSequence>> customFormatterByType = new HashMap<>();
   private static final Class<?>[] TYPE_WITH_UNAMBIGUOUS_REPRESENTATION = { Date.class, LocalDateTime.class, ZonedDateTime.class,
       OffsetDateTime.class, Calendar.class };
+
+  // Iterable types that should be considered to be unsafe to dereference and iterate across (e.g. they may have
+  // visible side effects).
+  private static final Class<?>[] BLACKLISTED_ITERABLE_CLASSES = {
+    // DirectoryStream implementations can choose to only provide a single-use iterator once across their contents.
+    // This means we should not try to iterate across them in their representation as this can cause unwanted
+    // side effects in test cases.
+    DirectoryStream.class,
+  };
 
   protected enum GroupType {
     ITERABLE("iterable"), ARRAY("array");
@@ -242,7 +252,7 @@ public class StandardRepresentation implements Representation {
     if (object instanceof DeleteDelta<?>) return toStringOf((DeleteDelta<?>) object);
     // Only format Iterables that are not collections and have not overridden toString
     // ex: JsonNode is an Iterable that is best formatted with its own String
-    // Path is another example but we can deal with it specifically as it is part of the JDK.
+    // Path is another example, but we can deal with it specifically as it is part of the JDK.
     if (object instanceof Iterable<?> && !hasOverriddenToString(object.getClass())) return smartFormat((Iterable<?>) object);
     if (object instanceof AtomicInteger) return toStringOf((AtomicInteger) object);
     if (object instanceof AtomicBoolean) return toStringOf((AtomicBoolean) object);
@@ -549,13 +559,19 @@ public class StandardRepresentation implements Representation {
    * Returns the {@code String} representation of the given {@code Iterable}, or {@code null} if the given
    * {@code Iterable} is {@code null}.
    * <p>
-   * The {@code Iterable} will be formatted to a single line if it does not exceed 100 char, otherwise each elements
+   * The {@code Iterable} will be formatted to a single line if it does not exceed 100 char, otherwise each element
    * will be formatted on a new line with 4 space indentation.
    *
    * @param iterable the {@code Iterable} to format.
    * @return the {@code String} representation of the given {@code Iterable}.
    */
   protected String smartFormat(Iterable<?> iterable) {
+    for (Class<?> blacklistedClass : BLACKLISTED_ITERABLE_CLASSES) {
+      if (blacklistedClass.isInstance(iterable)) {
+        return fallbackToStringOf(iterable);
+      }
+    }
+
     String singleLineDescription = singleLineFormat(iterable, DEFAULT_START, DEFAULT_END);
     return doesDescriptionFitOnSingleLine(singleLineDescription) ? singleLineDescription : multiLineFormat(iterable);
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_doNotBreakOnFailingTestsForDirectoryStreams.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_doNotBreakOnFailingTestsForDirectoryStreams.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import org.assertj.core.api.IterableAssert;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SecureDirectoryStream;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;;
+
+/**
+ * Checks that we can fail an assertion on DirectoryStream types without accidentally
+ * dereferencing the items in the iterable. This is important for this class as the
+ * iterators provided by directory streams can only be used once. API contracts
+ * allow this class to throw exceptions if {@code #iterator()} is called multiple times.
+ *
+ * @author Ashley Scopes
+ */
+public class IterableAssert_doNotBreakOnFailingTestsForDirectoryStreams {
+
+  @Test
+  void canPerformAssertionsOnDirectoryStream() {
+    // Given
+    OneShotDirectoryStream stream = new OneShotDirectoryStream();
+    IterableAssert<Path> assertions = new IterableAssert<>(stream);
+
+    // Then
+    thenNoException().isThrownBy(assertions::isNotNull);
+    then(stream.iteratorCount).hasValue(0);
+    then(stream.closed).isFalse();
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void canFailAssertionsOnIterableWithoutRecallingCallingIterator() {
+    // Given
+    OneShotDirectoryStream stream = new OneShotDirectoryStream();
+    IterableAssert<Path> assertions = new IterableAssert<>(stream);
+
+    // When
+    // Some code that makes use of the iterator() method prior to running the assertions
+    stream.iterator();
+
+    // Then
+    expectAssertionError(() -> assertions.isInstanceOf(SecureDirectoryStream.class));
+    then(stream.iteratorCount).hasValue(1);
+    then(stream.closed).isFalse();
+  }
+
+  static class OneShotDirectoryStream implements DirectoryStream<Path> {
+    final AtomicInteger iteratorCount = new AtomicInteger(0);
+    final AtomicBoolean closed = new AtomicBoolean(false);
+
+    @Override
+    public Iterator<Path> iterator() {
+      if (closed.get()) {
+        throw new IllegalStateException("Stream is already closed");
+      }
+
+      if (iteratorCount.getAndIncrement() >= 1) {
+        throw new IllegalStateException("You cant call #iterator() multiple times");
+      }
+
+      List<Path> paths = Arrays.asList(
+        Paths.get(  "foo", "bar"),
+        Paths.get(  "baz", "bork"),
+        Paths.get(  "qux", "quxx")
+      );
+
+      return paths.iterator();
+    }
+
+    @Override
+    public void close() throws IOException {
+      closed.set(true);
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -18,8 +18,15 @@ import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 
+import java.nio.file.DirectoryStream;
+import java.nio.file.SecureDirectoryStream;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -30,6 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StandardRepresentation_iterable_format_Test extends AbstractBaseRepresentationTest {
 
@@ -96,6 +104,23 @@ class StandardRepresentation_iterable_format_Test extends AbstractBaseRepresenta
     // formattedAfterNewLine is built to show we align values on the first element.
     String formattedAfterNewLine = "  <" + formatted + ">";
     then(formattedAfterNewLine).isEqualTo(format(expectedDescription));
+  }
+
+  @ParameterizedTest(name = "Iterables derived from {0} should not be iterated across")
+  @ValueSource(classes = {DirectoryStream.class, SecureDirectoryStream.class})
+  <T extends Iterable<?>> void should_use_fallback_toString_if_iterable_is_blacklisted(Class<T> type) {
+    // GIVEN
+    String expectedToString = "defaultToString-" + UUID.randomUUID();
+    T iterable = mock(type, withSettings().name(expectedToString).defaultAnswer(RETURNS_SMART_NULLS));
+
+    // WHEN
+    String formatted = STANDARD_REPRESENTATION.smartFormat(iterable);
+
+    // THEN
+    then(formatted).isEqualTo(expectedToString);
+    // Mockito will not verify the toString call due to internal implementation details, but just
+    // pretend we are verifying that here. The test logic verifies this implicitly anyway.
+    verifyNoMoreInteractions(iterable);
   }
 
   private static Stream<Arguments> should_format_iterable_source() {


### PR DESCRIPTION
The DirectoryStream class is somewhat special because the API allows it to only support .iterator() being called at most once on any implementations. Due to the nature of how the StandardRepresentation currently works for iterable types, any assertion error that is thrown as a result of assertions failing on a DirectoryStream object can result in IllegalStateExceptions being propagated to the caller if .iterator() has already been called on the class. This can break further if using soft assertions, as the state of the class could change unexpectedly resulting in different exceptions being raised depending on the execution order.

I've added a mechanism to deal with allowing the definition of so-called 'blacklisted' iterable types, just in case other cases like this appear in the JRE standard library anywhere in the future. This will prevent unexpected errors occuring when dealing with the NIO FileSystem APIs.

This was discovered as a result of https://github.com/ascopes/java-compiler-testing/pull/450, where @marschall pointed out that the `#iterator()` on a `DirectoryStream` should only be called once in some implementations. 