### PR TITLE
Format large arrays as strings

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/presentation/PrimitiveArrayList.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/PrimitiveArrayList.java
@@ -1,0 +1,44 @@
+package org.assertj.core.presentation;
+
+import org.assertj.core.util.Arrays;
+import org.assertj.core.util.Preconditions;
+
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+import java.lang.reflect.Array;
+import java.util.AbstractList;
+import java.util.Objects;
+
+/**
+ * Provides a read-only view of an array as a list.
+ *
+ * <p>This is different from {@link java.util.ArrayList} because the array may be an array of primitives. Arrays of non-primitives
+ * also work, but {@link java.util.ArrayList} would probably be a better choice for these arrays.
+ */
+final class PrimitiveArrayList extends AbstractList<Object> {
+  /** The array to provide a view of. */
+  private final Object array;
+
+  /**
+   * Creates a new {@link PrimitiveArrayList}.
+   *
+   * @param array primitive or object array
+   */
+  PrimitiveArrayList(final Object array) {
+    Objects.requireNonNull(array, "array must not be null");
+    Preconditions.checkArgument(Arrays.isObjectArray(array) || Arrays.isArrayTypePrimitive(array),
+                                "input data must be an array type");
+
+    this.array = array;
+  }
+
+  @Override
+  public Object get(final int index) {
+    return Array.get(array, index);
+  }
+
+  @Override
+  public int size() {
+    return Array.getLength(array);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/presentation/TransformingList.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/TransformingList.java
@@ -1,0 +1,43 @@
+package org.assertj.core.presentation;
+
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Converts elements of one list to a different type on demand.
+ *
+ * @param <F> the type to convert from
+ * @param <T> the type to convert to
+ */
+final class TransformingList<F, T> extends AbstractList<T> {
+  /** The list to transform. */
+  private final List<? extends F> source;
+
+  /** Converts elements to the new type. */
+  private final Function<? super F, ? extends T> transform;
+
+  /**
+   * Creates a new {@code TransformingList}.
+   *
+   * @param source the list to transform
+   * @param transform transforms elements to the output type
+   */
+  TransformingList(final List<? extends F> source, final Function<? super F, ? extends T> transform) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.transform = Objects.requireNonNull(transform, "transform");
+  }
+
+  @Override
+  public T get(final int index) {
+    return transform.apply(source.get(index));
+  }
+
+  @Override
+  public int size() {
+    return source.size();
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/presentation/PrimitiveArrayListTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/PrimitiveArrayListTest.java
@@ -1,0 +1,50 @@
+package org.assertj.core.presentation;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.BDDAssertions.then;
+
+class PrimitiveArrayListTest {
+  @Test
+  void should_not_be_able_to_create_for_non_array() {
+    // WHEN
+    IllegalArgumentException exception = catchThrowableOfType(
+      () -> new PrimitiveArrayList("not an array"), IllegalArgumentException.class);
+    // THEN
+    then(exception).hasMessageContaining("array");
+  }
+
+  @Test
+  void should_handle_empty() {
+    // GIVEN
+    int[] array = new int[0];
+    // WHEN
+    List<Object> view = new PrimitiveArrayList(array);
+    // THEN
+    then(view).isEmpty();
+  }
+
+  @Test
+  void should_handle_non_empty_primitive() {
+    // GIVEN
+    int[] array = new int[] {1, 2, 3};
+    // WHEN
+    List<Object> view = new PrimitiveArrayList(array);
+    // THEN
+    then(view).isEqualTo(ImmutableList.of(1, 2, 3));
+  }
+
+  @Test
+  void should_handle_non_empty_objects() {
+    // GIVEN
+    Integer[] array = new Integer[] {1, 2, 3};
+    // WHEN
+    List<Object> view = new PrimitiveArrayList(array);
+    // THEN
+    then(view).isEqualTo(ImmutableList.of(1, 2, 3));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_array_format_Test.java
@@ -20,6 +20,8 @@ import static org.assertj.core.util.Strings.quote;
 
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.configuration.Configuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -179,6 +181,28 @@ class StandardRepresentation_array_format_Test extends AbstractBaseRepresentatio
     String formatted = STANDARD_REPRESENTATION.formatArray(array);
     // THEN
     then(formatted).isEqualTo("[\"Hello\", null]");
+  }
+
+  @Test
+  void should_format_big_primitive_array() {
+    // GIVEN
+    int[] array = new int[1 << 30];
+    // WHEN
+    String formatted = STANDARD_REPRESENTATION.formatArray(array);
+    // THEN
+    then(formatted).contains("...");
+    then(StringUtils.countMatches(formatted, "0")).isEqualTo(Configuration.MAX_ELEMENTS_FOR_PRINTING);
+  }
+
+  @Test
+  void should_format_big_object_array() {
+    // GIVEN
+    Object[] array = new Object[1 << 30];
+    // WHEN
+    String formatted = STANDARD_REPRESENTATION.formatArray(array);
+    // THEN
+    then(formatted).contains("...");
+    then(StringUtils.countMatches(formatted, "null")).isEqualTo(Configuration.MAX_ELEMENTS_FOR_PRINTING);
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/presentation/TransformingListTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/TransformingListTest.java
@@ -1,0 +1,27 @@
+package org.assertj.core.presentation;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransformingListTest {
+  @Test
+  void should_handle_empty() {
+    // GIVEN
+    List<Integer> source = ImmutableList.of();
+    List<String> transformed = new TransformingList<>(source, Object::toString);
+    // WHEN/THEN
+    then(transformed).isEmpty();
+  }
+
+  @Test
+  void should_handle_non_empty() {
+    // GIVEN
+    List<Integer> source = ImmutableList.of(1, 2, 3);
+    List<String> transformed = new TransformingList<>(source, Object::toString);
+    // WHEN/THEN
+    then(transformed).isEqualTo(ImmutableList.of("1", "2", "3"));
+  }
+}


### PR DESCRIPTION
The process for converting an array of primitives to a string was:
1. convert the array to an array of objects
2. convert the objects to strings
3. select up to 1000 elements to print

This is fine if there aren't too many elements, but if there are 2^30 elements, all the copying may result in an OOM exception.

With this change, instead of copying the arrays, create a collection that proxies the original collection as a list of Strings. The strings aren't created unless they're actually needed.

Testing:

Originally, on my computer, trying to turn big arrays into strings resulted in OOM error after about 10 seconds of computation. Now, this completes in a fraction of a second.

#### Check List:
* Fixes https://github.com/assertj/assertj/issues/3065
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) I hope so :^)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
