### PR TITLE
Handle null values in map entry sets when formatting

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -498,7 +498,14 @@ public class StandardRepresentation implements Representation {
         builder.append(DEFAULT_MAX_ELEMENTS_EXCEEDED);
         return builder.append("}").toString();
       }
-      builder.append(format(map, entry.getKey())).append('=').append(format(map, entry.getValue()));
+
+      // the entry shouldn't be null in a valid map, but if it is, print it out gracefully instead of throwing a NPE
+      if (entry == null) {
+        builder.append("null");
+      } else {
+        builder.append(format(map, entry.getKey())).append('=').append(format(map, entry.getValue()));
+      }
+
       printedElements++;
       if (!entriesIterator.hasNext()) return builder.append("}").toString();
       builder.append(", ");

--- a/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_map_format_Test.java
@@ -15,10 +15,14 @@ package org.assertj.core.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.AbstractMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -85,5 +89,19 @@ class StandardRepresentation_map_format_Test extends AbstractBaseRepresentationT
     map.put('A', 1);
 
     assertThat(STANDARD_REPRESENTATION.toStringOf(map)).isEqualTo("{\"foo\"=3, false=2, 'A'=1}");
+  }
+
+  @Test
+  void should_formal_null_in_the_entry_set() {
+    Map<Integer, Integer> map = new AbstractMap<Integer, Integer>() {
+      @Override
+      public Set<Entry<Integer, Integer>> entrySet() {
+        Set <Entry<Integer, Integer>> entries = new HashSet<>();
+        entries.add(null);
+        return entries;
+      }
+    };
+
+    assertThat(STANDARD_REPRESENTATION.toStringOf(map)).isEqualTo("{null}");
   }
 }


### PR DESCRIPTION
If the map entry set contains a null value, print "null" instead of throwing a NPE.

see: https://github.com/assertj/assertj/issues/3087

#### Check List:
* Fixes[ #??? (ignore if not applicable)](https://github.com/assertj/assertj/issues/3087)
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
