### PR TITLE
Fix NPE when expected and actual field values are null

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -160,10 +160,18 @@ public class RecursiveComparisonDifferenceCalculator {
       if (recursiveComparisonConfiguration.hasCustomMessageForField(fieldName)) {
         return recursiveComparisonConfiguration.getMessageForField(fieldName);
       }
-      Class<?> fieldType = dualValue.actual != null ? dualValue.actual.getClass() : dualValue.expected.getClass();
-      if (recursiveComparisonConfiguration.hasCustomMessageForType(fieldType)) {
+
+      Class<?> fieldType = null;
+      if (dualValue.actual != null) {
+        fieldType = dualValue.actual.getClass();
+      } else if (dualValue.expected != null) {
+        fieldType = dualValue.expected.getClass();
+      }
+
+      if (fieldType != null && recursiveComparisonConfiguration.hasCustomMessageForType(fieldType)) {
         return recursiveComparisonConfiguration.getMessageForType(fieldType);
       }
+
       return null;
     }
   }


### PR DESCRIPTION
When both the expected and actual field values are null, fall back to the default message instead of throwing a NPE when trying to find a custom message for the value type.

see: https://github.com/assertj/assertj/issues/3034

#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES / NO / NA
* Javadoc with a code example (on API only) : YES / NO / NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
