### PR TITLE
Make test for long iterable smaller

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_iterable_format_Test.java
@@ -25,11 +25,16 @@ import static org.mockito.Mockito.withSettings;
 
 import java.nio.file.DirectoryStream;
 import java.nio.file.SecureDirectoryStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.configuration.Configuration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -258,6 +263,23 @@ class StandardRepresentation_iterable_format_Test extends AbstractBaseRepresenta
     String formatted = STANDARD_REPRESENTATION.toStringOf(a);
     // THEN
     then(formatted).isEqualTo("[{\"a\":1}]");
+  }
+
+  @Test
+  @Timeout(value = 1, unit = TimeUnit.SECONDS)
+  void should_format_big_list() {
+    // GIVEN
+    int elementsPerArray = 200;
+    List<int[]> numbers = new ArrayList<>();
+    for (int i = 0; i < 1 << 18; i++) {
+      numbers.add(new int[elementsPerArray]);
+    }
+    // WHEN
+    String formatted = STANDARD_REPRESENTATION.toStringOf(numbers);
+    // THEN
+    then(formatted).contains("...");
+    then(StringUtils.countMatches(formatted, "0")).isEqualTo(
+      Configuration.MAX_ELEMENTS_FOR_PRINTING * elementsPerArray);
   }
 
   private static String stringOfLength(int length) {


### PR DESCRIPTION
Creating the test data for the long iterable causes an out of memory error in the GitHub automated build system. This change uses a much smaller example, with fewer things to iterate through and smaller items. It adds a timeout, however, so the test still should fail without the related change that makes this more efficient.

#### Check List:
* Fixes https://github.com/assertj/assertj/issues/3123
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
