### PR TITLE
Change the way the properties are collected using the Class.getMethod…

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingProperties.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingProperties.java
@@ -59,8 +59,8 @@ public class ComparingProperties implements RecursiveComparisonIntrospectionStra
 
   private static String toPropertyName(String methodName) {
     String propertyWithCapitalLetter = methodName.startsWith(GET_PREFIX)
-      ? methodName.substring(GET_PREFIX.length())
-      : methodName.substring(IS_PREFIX.length());
+        ? methodName.substring(GET_PREFIX.length())
+        : methodName.substring(IS_PREFIX.length());
     return propertyWithCapitalLetter.toLowerCase().charAt(0) + propertyWithCapitalLetter.substring(1);
   }
 
@@ -69,11 +69,10 @@ public class ComparingProperties implements RecursiveComparisonIntrospectionStra
   }
 
   private static Set<Method> gettersOf(Class<?> clazz) {
-    return stream(clazz.getMethods())
-      .filter(method -> !belongsToFundamentalPackage(method))
-      .filter(method -> !isStatic(method))
-      .filter(ComparingProperties::isGetter)
-      .collect(toCollection(LinkedHashSet::new));
+    return stream(clazz.getMethods()).filter(method -> !belongsToFundamentalPackage(method))
+                                     .filter(method -> !isStatic(method))
+                                     .filter(ComparingProperties::isGetter)
+                                     .collect(toCollection(LinkedHashSet::new));
   }
 
   private static boolean belongsToFundamentalPackage(Method method) {

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/ComparingProperties_getChildrenNodeNamesOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/ComparingProperties_getChildrenNodeNamesOf_Test.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.core.api.recursive.comparison;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.recursive.comparison.ComparingFields.COMPARING_FIELDS;
-import static org.assertj.core.api.recursive.comparison.ComparingProperties.COMPARING_PROPERTIES;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.recursive.comparison.ComparingFields.COMPARING_FIELDS;
+import static org.assertj.core.api.recursive.comparison.ComparingProperties.COMPARING_PROPERTIES;
 
 @SuppressWarnings("unused")
 class ComparingProperties_getChildrenNodeNamesOf_Test {
@@ -36,13 +36,24 @@ class ComparingProperties_getChildrenNodeNamesOf_Test {
                              .doesNotContain("privateValue", "packagePrivateValue", "protectedValue", "publicStaticValue");
   }
 
+  @Test
+  void getChildrenNodeNamesOf_returns_inherited_default_properties_names() {
+    // GIVEN
+    PropertiesInterface actual = new PropertiesImpl();
+    // WHEN
+    Set<String> childrenNodeNames = COMPARING_PROPERTIES.getChildrenNodeNamesOf(actual);
+    // THEN
+    then(childrenNodeNames).containsExactlyInAnyOrder("string")
+                           .doesNotContain("staticValue", "invalidValue");
+  }
+
   static class Properties {
 
     // non readable
 
     public static Object getPublicStaticValue() {
       return "public Static value";
-    };
+    }
 
     protected Object getProtectedValue() {
       return "protectedValue value";
@@ -107,6 +118,28 @@ class ComparingProperties_getChildrenNodeNamesOf_Test {
     }
   }
 
+  interface PropertiesInterface {
+
+    // not readable
+
+    static String getStaticValue() {
+      return "static value";
+    }
+
+    default String invalidValue() {
+      return "";
+    }
+
+    // readable
+
+    default String getString() {
+      return "string value";
+    }
+  }
+
+  static class PropertiesImpl implements PropertiesInterface {
+  }
+
   @Test
   void getChildrenNodeNamesOf_ignores_synthetic_fields() {
     // GIVEN
@@ -139,6 +172,7 @@ class ComparingProperties_getChildrenNodeNamesOf_Test {
     private final String superClassField2 = "superClassField2 value";
 
   }
+
   static class SubClass extends SuperClass {
     private final String subClassField = "subClassField value";
   }


### PR DESCRIPTION
I change the way the properties are collected using the `Class.getMethods()` api instead iterating the class hierarchy using `Class.declaredMethods().` I think that collect the properties using the `getMethods` api should be  a better approach because:
-  it returns all public methods considering both super classes and interfaces
-  there's no need to filter public methods
-  there's no need to iterate through the class hierarchy 

Moreover, in this way the properties declared in the interfaces will not be ignored.  

#### Check List:
* Fixes #3125 (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
