### PR TITLE
Fix/3129 recursive comparison fails if comparing only fileds has non existing fields

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -152,6 +152,30 @@ public class RecursiveComparisonDifferenceCalculator {
       }
     }
 
+    private static Set<String> getAllChildFieldsSpecifiedForCompare(RecursiveComparisonConfiguration recursiveComparisonConfiguration,
+                                                                    DualValue dualValue) {
+      return recursiveComparisonConfiguration.getComparedFields().stream()
+                                             // Remove all specified fields that are not children of this DualValue
+                                             .filter(field -> isChildOfSpecifiedComparatorField(dualValue, field))
+                                             // Map the next FieldLocation to the fieldName
+                                             .map(field -> getChildFieldForValidation(field, dualValue.fieldLocation))
+                                             .collect(Collectors.toSet());
+    }
+
+    private static boolean isChildOfSpecifiedComparatorField(DualValue dualValue, FieldLocation field) {
+
+      return field.getPathToUseInRules()
+                  // Check if the comparator field is relevant by checking if the path validated so far matches
+                  // &&
+                  // Check if it has a child field still waiting to be validated.
+                  .startsWith(dualValue.fieldLocation.getPathToUseInRules())
+             && field.getDecomposedPath().size() > dualValue.fieldLocation.getDecomposedPath().size();
+    }
+
+    private static String getChildFieldForValidation(FieldLocation field, FieldLocation fieldValue) {
+      return field.getDecomposedPath().get(fieldValue.getDecomposedPath().size());
+    }
+
     private boolean mustCompareNodesRecursively(DualValue dualValue) {
       return !recursiveComparisonConfiguration.hasCustomComparator(dualValue)
              && !shouldHonorEquals(dualValue, recursiveComparisonConfiguration)

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -871,7 +871,7 @@ public class RecursiveComparisonDifferenceCalculator {
   private static List<?> actualToList(Object actual) {
 
     if(actual ==null){
-      return List.of();
+      return Collections.emptyList();
     }
 
     if(actual instanceof Map ){

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -152,30 +152,6 @@ public class RecursiveComparisonDifferenceCalculator {
       }
     }
 
-    private static Set<String> getAllChildFieldsSpecifiedForCompare(RecursiveComparisonConfiguration recursiveComparisonConfiguration,
-                                                                    DualValue dualValue) {
-      return recursiveComparisonConfiguration.getComparedFields().stream()
-                                             // Remove all specified fields that are not children of this DualValue
-                                             .filter(field -> isChildOfSpecifiedComparatorField(dualValue, field))
-                                             // Map the next FieldLocation to the fieldName
-                                             .map(field -> getChildFieldForValidation(field, dualValue.fieldLocation))
-                                             .collect(Collectors.toSet());
-    }
-
-    private static boolean isChildOfSpecifiedComparatorField(DualValue dualValue, FieldLocation field) {
-
-      return field.getPathToUseInRules()
-                  // Check if the comparator field is relevant by checking if the path validated so far matches
-                  // &&
-                  // Check if it has a child field still waiting to be validated.
-                  .startsWith(dualValue.fieldLocation.getPathToUseInRules())
-             && field.getDecomposedPath().size() > dualValue.fieldLocation.getDecomposedPath().size();
-    }
-
-    private static String getChildFieldForValidation(FieldLocation field, FieldLocation fieldValue) {
-      return field.getDecomposedPath().get(fieldValue.getDecomposedPath().size());
-    }
-
     private boolean mustCompareNodesRecursively(DualValue dualValue) {
       return !recursiveComparisonConfiguration.hasCustomComparator(dualValue)
              && !shouldHonorEquals(dualValue, recursiveComparisonConfiguration)

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
@@ -277,15 +277,7 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     ComparisonDifference difference = diff("[1].name", "Rohit", "Rohyt");
     return Stream.of(arguments(list(john1, rohit), list(john2, rohyt), difference),
                      arguments(array(john1, rohit), array(john2, rohyt), difference),
-                     arguments(set(john1, rohit), set(john2, rohyt), difference),
-                     //Ensure nested containers are also checked
-                     arguments(list(toMap(john1, rohit)), list(toMap(john2,
-                                                                     rohyt)), difference),
-                     arguments(set(set(john1, rohit)), set(set(john2,
-                                                               rohyt)), difference),
-                     arguments(toMap(toMap(john1, rohit)), toMap(toMap(john2,
-                                                                       rohyt)), difference));
-
+                     arguments(set(john1, rohit), set(john2, rohyt), difference));
   }
 
   // #3129


### PR DESCRIPTION
#### Check List:
* Fixes # 3129 Partially
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

This PR fixes
This PR checks when using recursive comparison if all fields specified in "comparingOnlyFields" exist on the actual object being compared. This prevents misnaming of the fields and silent failures.

This PR does not fix
Items specified in containers (lists/arrays/etc) these items are currently compared using "Deeply compare two Collections that must be same length and in same order." checking all field entries and ignoring the specified fields.
