### PR TITLE
Deprecate `asList` in favor of `asInstanceOf`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -591,12 +591,11 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   }
 
   /** {@inheritDoc} */
-  @SuppressWarnings("unchecked")
+  @Deprecated
   @Override
   @CheckReturnValue
   public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> asList() {
-    objects.assertIsInstanceOf(info, actual, List.class);
-    return newListAssertInstance((List<Object>) actual).as(info.description());
+    return asInstanceOf(InstanceOfAssertFactories.LIST);
   }
 
   /** {@inheritDoc} */

--- a/assertj-core/src/main/java/org/assertj/core/api/Assert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assert.java
@@ -650,7 +650,9 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * assertThat(unsortedListAsObject).asList().isSorted();</code></pre>
    *
    * @return a list assertion object
+   * @deprecated use {@link #asInstanceOf(InstanceOfAssertFactory) asInstanceOf(InstanceOfAssertFactories.LIST)} instead
    */
+  @Deprecated
   AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> asList();
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -50,7 +50,6 @@ class SoftProxies {
                                                                                                                                    "asFloat",
                                                                                                                                    "asInstanceOf",
                                                                                                                                    "asInt",
-                                                                                                                                   "asList",
                                                                                                                                    "asLong",
                                                                                                                                    "asShort",
                                                                                                                                    "asString",

--- a/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThat_asList_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThat_asList_Test.java
@@ -22,9 +22,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for Assert.asList() methods
- */
+@SuppressWarnings("deprecation")
 class Assertions_assertThat_asList_Test {
 
   @Test
@@ -57,4 +55,5 @@ class Assertions_assertThat_asList_Test {
     // THEN
     assertThat(error).hasMessageContaining("oops");
   }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1608,6 +1608,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught
+  @SuppressWarnings("deprecation")
   @Test
   void object_soft_assertions_should_report_errors_on_final_methods_and_methods_that_switch_the_object_under_test() {
     // GIVEN

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1954,6 +1954,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught
+  @SuppressWarnings("deprecation")
   @Test
   void object_soft_assertions_should_report_errors_on_final_methods_and_methods_that_switch_the_object_under_test() {
     // GIVEN

--- a/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_Object_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/assumptions/Assumptions_assumeThat_Object_Test.java
@@ -33,6 +33,7 @@ class Assumptions_assumeThat_Object_Test {
     assertThatCode(() -> assumeThat(STRING_OBJECT).isNotNull().asString().startsWith("te")).doesNotThrowAnyException();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void should_run_test_when_assumption_for_internally_created_list_passes() {
     Object listObject = asList(1, 2, 3);
@@ -52,6 +53,7 @@ class Assumptions_assumeThat_Object_Test {
                                                                    .isEqualTo("other"));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void should_ignore_test_when_assumption_for_internally_created_list_assertion_fails() {
     Object listObject = asList(1, 2, 3);

--- a/assertj-core/src/test/java/org/assertj/core/internal/IterableDiff_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/IterableDiff_Test.java
@@ -149,6 +149,7 @@ class IterableDiff_Test {
   }
 
   // issue #2147
+  @SuppressWarnings("deprecation")
   @Test
   void should_work_when_comparison_strategy_is_not_symmetrical() {
     // GIVEN


### PR DESCRIPTION
Triggered by https://github.com/assertj/assertj/issues/3105#issuecomment-1633150460.