### PR TITLE
Add assertions for JDK YearMonth type

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
@@ -1,0 +1,617 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.Month;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.Objects;
+
+import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
+import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
+import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
+import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
+import static org.assertj.core.error.ShouldBeCurrentYearMonth.shouldBeCurrentYearMonth;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+/**
+ * Base class for all implementations of assertions for {@link YearMonth} type
+ * from new Date &amp; Time API introduced in Java 8.
+ *
+ * @param <SELF> the "self" type of this assertion class.
+ * @since 3.26.0
+ */
+public abstract class AbstractYearMonthAssert<SELF extends AbstractYearMonthAssert<SELF>>
+    extends AbstractTemporalAssert<SELF, YearMonth> {
+
+  /**
+   * Creates a new <code>{@link AbstractYearMonthAssert}</code>.
+   *
+   * @param selfType the "self type".
+   * @param actual the actual value to verify.
+   */
+  protected AbstractYearMonthAssert(YearMonth actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly before the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThat(parse("2000-01")).isBefore(parse("2000-02"));</code></pre>
+   *
+   * @param other the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if other {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not strictly before the given one.
+   */
+  public SELF isBefore(YearMonth other) {
+    Objects.instance().assertNotNull(info, actual);
+    assertYearMonthParameterIsNotNull(other);
+    if (!actual.isBefore(other)) throw Failures.instance().failure(info, shouldBeBefore(actual, other));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly before the given one.
+   * <p>
+   * Same assertion as {@link #isBefore(YearMonth)} but the {@code YearMonth} is built from the given string,
+   * which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isBefore("2000-02");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not strictly before the {@code YearMonth} built
+   *           from given string.
+   */
+  public SELF isBefore(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isBefore(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is before or equal to the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThat(parse("2000-01")).isBeforeOrEqualTo(parse("2000-01"))
+   *                             .isBeforeOrEqualTo(parse("2000-02"));</code></pre>
+   *
+   * @param other the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if other {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not before or equals to the given one.
+   */
+  public SELF isBeforeOrEqualTo(YearMonth other) {
+    Objects.instance().assertNotNull(info, actual);
+    assertYearMonthParameterIsNotNull(other);
+    if (actual.isAfter(other)) {
+      throw Failures.instance().failure(info, shouldBeBeforeOrEqualTo(actual, other));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is before or equal to the given one.
+   * <p>
+   * Same assertion as {@link #isBeforeOrEqualTo(YearMonth)} but the {@code YearMonth} is built from given
+   * string, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isBeforeOrEqualTo("2000-01")
+   *                             .isBeforeOrEqualTo("2000-02");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not before or equals to the {@code YearMonth} built from
+   *           given string.
+   */
+  public SELF isBeforeOrEqualTo(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isBeforeOrEqualTo(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is after or equal to the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThat(parse("2000-01")).isAfterOrEqualTo(parse("2000-01"))
+   *                             .isAfterOrEqualTo(parse("1999-12"));</code></pre>
+   *
+   * @param other the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if other {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not after or equals to the given one.
+   */
+  public SELF isAfterOrEqualTo(YearMonth other) {
+    Objects.instance().assertNotNull(info, actual);
+    assertYearMonthParameterIsNotNull(other);
+    if (actual.isBefore(other)) {
+      throw Failures.instance().failure(info, shouldBeAfterOrEqualTo(actual, other));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is after or equal to the given one.
+   * <p>
+   * Same assertion as {@link #isAfterOrEqualTo(YearMonth)} but the {@code YearMonth} is built from given
+   * string, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isAfterOrEqualTo("2000-01")
+   *                             .isAfterOrEqualTo("1999-12");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not after or equals to the {@code YearMonth} built from
+   *           given string.
+   */
+  public SELF isAfterOrEqualTo(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isAfterOrEqualTo(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly after the given one.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThat(parse("2000-01")).isAfter(parse("1999-12"));</code></pre>
+   *
+   * @param other the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if other {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not strictly after the given one.
+   */
+  public SELF isAfter(YearMonth other) {
+    Objects.instance().assertNotNull(info, actual);
+    assertYearMonthParameterIsNotNull(other);
+    if (!actual.isAfter(other)) {
+      throw Failures.instance().failure(info, shouldBeAfter(actual, other));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly after the given one.
+   * <p>
+   * Same assertion as {@link #isAfter(YearMonth)} but the {@code YearMonth} is built from given
+   * string, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isAfter("1999-12");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not strictly after the {@code YearMonth} built
+   *           from given string.
+   */
+  public SELF isAfter(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isAfter(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is equal to the given one.
+   * <p>
+   * Same assertion as {@link #isEqualTo(Object)} but the {@code YearMonth} is built from given
+   * string, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isEqualTo("2000-01");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not equal to the {@code YearMonth} built from
+   *           given string.
+   */
+  public SELF isEqualTo(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isEqualTo(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is not equal to the given one.
+   * <p>
+   * Same assertion as {@link #isNotEqualTo(Object)} but the {@code YearMonth} is built from given
+   * string, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isNotEqualTo("2000-02");</code></pre>
+   *
+   * @param otherYearMonthAsString string representation of the other {@code YearMonth} to compare to, not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if the given string is {@code null}.
+   * @throws DateTimeParseException if the given string cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is equal to the {@code YearMonth} built from given
+   *           string.
+   */
+  public SELF isNotEqualTo(String otherYearMonthAsString) {
+    assertYearMonthAsStringParameterIsNotNull(otherYearMonthAsString);
+    return isNotEqualTo(parse(otherYearMonthAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is present in the given array of values.
+   * <p>
+   * Same assertion as {@link #isIn(Object...)} but the {@code YearMonth}s are built from given
+   * strings, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isIn("1999-12", "2000-01");</code></pre>
+   *
+   * @param otherYearMonthsAsString string array representing {@code YearMonth}s.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if any of the given strings is {@code null}.
+   * @throws DateTimeParseException if any of the given strings cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the {@code YearMonth}s built from given strings.
+   */
+  public SELF isIn(String... otherYearMonthsAsString) {
+    checkIsNotNullAndNotEmpty(otherYearMonthsAsString);
+    return isIn(convertToYearMonthArray(otherYearMonthsAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is not present in the given array of values.
+   * <p>
+   * Same assertion as {@link #isNotIn(Object...)} but the {@code YearMonth}s are built from given
+   * strings, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // use string representation of YearMonth
+   * assertThat(parse("2000-01")).isNotIn("1999-12", "2000-02");</code></pre>
+   *
+   * @param otherYearMonthsAsString Array of string representing a {@code YearMonth}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws IllegalArgumentException if any of the given strings is {@code null}.
+   * @throws DateTimeParseException if any of the given strings cannot be parsed to a {@code YearMonth}.
+   * @throws AssertionError if the actual {@code YearMonth} is in the {@code YearMonth}s built from given strings.
+   */
+  public SELF isNotIn(String... otherYearMonthsAsString) {
+    checkIsNotNullAndNotEmpty(otherYearMonthsAsString);
+    return isNotIn(convertToYearMonthArray(otherYearMonthsAsString));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly in the past.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.now().minusMonths(1)).isInThePast();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the past.
+   */
+  public SELF isInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isBefore(YearMonth.now())) throw Failures.instance().failure(info, shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is the current {@code YearMonth}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.now()).isCurrentYearMonth();
+   *
+   * // assertion fails:
+   * assertThat(theFellowshipOfTheRing.getReleaseDate()).isCurrentYearMonth();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not the current {@code YearMonth}.
+   */
+  public SELF isCurrentYearMonth() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.equals(YearMonth.now())) throw Failures.instance().failure(info, shouldBeCurrentYearMonth(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.now().plusMonths(1)).isInTheFuture();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the future.
+   */
+  public SELF isInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.isAfter(YearMonth.now())) throw Failures.instance().failure(info, shouldBeInTheFuture(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the [start, end] period (start and end included).
+   * <p>
+   * Example:
+   * <pre><code class='java'> YearMonth yearMonth = YearMonth.now();
+   *
+   * // assertions succeed:
+   * assertThat(yearMonth).isBetween(yearMonth.minusMonths(1), yearMonth.plusMonths(1))
+   *                      .isBetween(yearMonth, yearMonth.plusMonths(1))
+   *                      .isBetween(yearMonth.minusMonths(1), yearMonth)
+   *                      .isBetween(yearMonth, yearMonth);
+   *
+   * // assertions fail:
+   * assertThat(yearMonth).isBetween(yearMonth.minusMonths(10), yearMonth.minusMonths(1));
+   * assertThat(yearMonth).isBetween(yearMonth.plusMonths(1), yearMonth.plusMonths(10));</code></pre>
+   *
+   * @param startInclusive the start value (inclusive), not null.
+   * @param endInclusive the end value (inclusive), not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws NullPointerException if start value is {@code null}.
+   * @throws NullPointerException if end value is {@code null}.
+   * @throws AssertionError if the actual value is not in [start, end] period.
+   */
+  public SELF isBetween(YearMonth startInclusive, YearMonth endInclusive) {
+    comparables.assertIsBetween(info, actual, startInclusive, endInclusive, true, true);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the [start, end] period (start and end included).
+   * <p>
+   * Same assertion as {@link #isBetween(YearMonth, YearMonth)} but the {@code YearMonth}s are built from given
+   * strings, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> YearMonth january2000 = YearMonth.parse("2000-01");
+   *
+   * // assertions succeed:
+   * assertThat(january2000).isBetween("1999-01", "2001-01")
+   *                        .isBetween("2000-01", "2001-01")
+   *                        .isBetween("1999-01", "2000-01")
+   *                        .isBetween("2000-01", "2000-01");
+   *
+   * // assertion fails:
+   * assertThat(january2000).isBetween("1999-01", "1999-12");</code></pre>
+   *
+   * @param startInclusive the start value (inclusive), not null.
+   * @param endInclusive the end value (inclusive), not null.
+   * @return {@code this} assertion object.
+   *
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws NullPointerException if start value is {@code null}.
+   * @throws NullPointerException if end value is {@code null}.
+   * @throws DateTimeParseException if any of the given string can't be converted to a {@code YearMonth}.
+   * @throws AssertionError if the actual value is not in [start, end] period.
+   */
+  public SELF isBetween(String startInclusive, String endInclusive) {
+    return isBetween(parse(startInclusive), parse(endInclusive));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the ]start, end[ period (start and end excluded).
+   * <p>
+   * Example:
+   * <pre><code class='java'> YearMonth yearMonth = YearMonth.now();
+   *
+   * // assertion succeeds:
+   * assertThat(yearMonth).isStrictlyBetween(yearMonth.minusMonths(1), yearMonth.plusMonths(1));
+   *
+   * // assertions fail:
+   * assertThat(yearMonth).isStrictlyBetween(yearMonth.minusMonths(10), yearMonth.minusMonths(1));
+   * assertThat(yearMonth).isStrictlyBetween(yearMonth.plusMonths(1), yearMonth.plusMonths(10));
+   * assertThat(yearMonth).isStrictlyBetween(yearMonth, yearMonth.plusMonths(1));
+   * assertThat(yearMonth).isStrictlyBetween(yearMonth.minusMonths(1), yearMonth);</code></pre>
+   *
+   * @param startExclusive the start value (exclusive), not null.
+   * @param endExclusive the end value (exclusive), not null.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws NullPointerException if start value is {@code null}.
+   * @throws NullPointerException if end value is {@code null}.
+   * @throws AssertionError if the actual value is not in ]start, end[ period.
+   */
+  public SELF isStrictlyBetween(YearMonth startExclusive, YearMonth endExclusive) {
+    comparables.assertIsBetween(info, actual, startExclusive, endExclusive, false, false);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the ]start, end[ period (start and end excluded).
+   * <p>
+   * Same assertion as {@link #isStrictlyBetween(YearMonth, YearMonth)} but the {@code YearMonth}s are built from given
+   * strings, which must follow the {@link DateTimeFormatter} pattern <code>uuuu-MM</code>
+   * to allow calling {@link YearMonth#parse(CharSequence)} method.
+   * <p>
+   * Example:
+   * <pre><code class='java'> YearMonth january2000 = YearMonth.parse("2000-01");
+   *
+   * // assertion succeeds:
+   * assertThat(january2000).isStrictlyBetween("1999-01", "2001-01");
+   *
+   * // assertions fail:
+   * assertThat(january2000).isStrictlyBetween("1999-01", "1999-12");
+   * assertThat(january2000).isStrictlyBetween("2000-01", "2001-01");
+   * assertThat(january2000).isStrictlyBetween("1999-01", "2000-01");</code></pre>
+   *
+   * @param startExclusive the start value (exclusive), not null.
+   * @param endExclusive the end value (exclusive), not null.
+   * @return {@code this} assertion object.
+   *
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws NullPointerException if start value is {@code null}.
+   * @throws NullPointerException if end value is {@code null}.
+   * @throws DateTimeParseException if any of the given string can't be converted to a {@code YearMonth}.
+   * @throws AssertionError if the actual value is not in ]start, end[ period.
+   */
+  public SELF isStrictlyBetween(String startExclusive, String endExclusive) {
+    return isStrictlyBetween(parse(startExclusive), parse(endExclusive));
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the given year.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.of(2000, 12)).hasYear(2000);
+   *
+   * // assertion fails:
+   * assertThat(YearMonth.of(2000, 12)).hasYear(2001);</code></pre>
+   *
+   * @param year the given year.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the given year.
+   */
+  public SELF hasYear(int year) {
+    Objects.instance().assertNotNull(info, actual);
+    if (actual.getYear() != year) {
+      throw Failures.instance().failure(info, shouldHaveDateField(actual, "year", year));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the given month.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.of(2000, 12)).hasMonth(Month.DECEMBER);
+   *
+   * // assertion fails:
+   * assertThat(YearMonth.of(2000, 12)).hasMonth(Month.JANUARY);</code></pre>
+   *
+   * @param month the given {@link Month}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the given month.
+   */
+  public SELF hasMonth(Month month) {
+    Objects.instance().assertNotNull(info, actual);
+    if (!actual.getMonth().equals(month)) {
+      throw Failures.instance().failure(info, shouldHaveMonth(actual, month));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is in the given month.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.of(2000, 12)).hasMonthValue(12);
+   *
+   * // assertion fails:
+   * assertThat(YearMonth.of(2000, 12)).hasMonthValue(11);</code></pre>
+   *
+   * @param month the given month's value between 1 and 12 inclusive.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the given month.
+   */
+  public SELF hasMonthValue(int month) {
+    Objects.instance().assertNotNull(info, actual);
+    if (actual.getMonthValue() != month) {
+      throw Failures.instance().failure(info, shouldHaveDateField(actual, "month", month));
+    }
+    return myself;
+  }
+
+  /**
+   * Obtains an instance of {@link YearMonth} from a text string such as 2007-12.
+   *
+   * @see YearMonth#parse(CharSequence)
+   */
+  @Override
+  protected YearMonth parse(String yearMonthAsString) {
+    return YearMonth.parse(yearMonthAsString);
+  }
+
+  /**
+   * Check that the {@code YearMonth} to compare actual {@code YearMonth} to is not null, in that case throws a
+   * {@link IllegalArgumentException} with an explicit message.
+   *
+   * @param other the {@code YearMonth} to check.
+   * @throws IllegalArgumentException with an explicit message if the given {@code YearMonth} is null.
+   */
+  private static void assertYearMonthParameterIsNotNull(YearMonth other) {
+    checkArgument(other != null, "The YearMonth to compare actual with should not be null");
+  }
+
+  /**
+   * Check that the {@code YearMonth} string representation to compare actual {@code YearMonth} to is not null,
+   * otherwise throws a {@link IllegalArgumentException} with an explicit message.
+   *
+   * @param otherYearMonthAsString string representing the {@code YearMonth} to compare actual with.
+   * @throws IllegalArgumentException with an explicit message if the given {@code String} is null.
+   */
+  private static void assertYearMonthAsStringParameterIsNotNull(String otherYearMonthAsString) {
+    checkArgument(otherYearMonthAsString != null,
+                  "The String representing the YearMonth to compare actual with should not be null");
+  }
+
+  private static void checkIsNotNullAndNotEmpty(Object[] values) {
+    checkArgument(values != null, "The given YearMonth array should not be null");
+    checkArgument(values.length > 0, "The given YearMonth array should not be empty");
+  }
+
+  private static Object[] convertToYearMonthArray(String... yearMonthsAsString) {
+    return Arrays.stream(yearMonthsAsString).map(YearMonth::parse).toArray();
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -34,6 +34,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalUnit;
 import java.util.Collection;
@@ -978,6 +979,17 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    */
   public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  public static AbstractYearMonthAssert<?> assertThat(YearMonth actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -31,6 +31,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
@@ -667,6 +668,17 @@ public class AssertionsForClassTypes {
    */
   public static AbstractLocalDateAssert<?> assertThat(LocalDate localDate) {
     return new LocalDateAssert(localDate);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code>.
+   *
+   * @param yearMonth the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  public static AbstractYearMonthAssert<?> assertThat(YearMonth yearMonth) {
+    return new YearMonthAssert(yearMonth);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assumptions.java
@@ -38,6 +38,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
@@ -1394,6 +1395,17 @@ public class Assumptions {
    */
   public static AbstractLocalDateAssert<?> assumeThat(LocalDate actual) {
     return asAssumption(LocalDateAssert.class, LocalDate.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link YearMonthAssert} assumption.
+   *
+   * @param actual the YearMonth to test
+   * @return the created assumption for assertion object.
+   * @since 3.26.0
+   */
+  public static AbstractYearMonthAssert<?> assumeThat(YearMonth actual) {
+    return asAssumption(YearMonthAssert.class, YearMonth.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -31,6 +31,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalUnit;
 import java.util.Collection;
@@ -1467,6 +1468,17 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
   public static AbstractLocalDateAssert<?> then(LocalDate actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.YearMonthAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  public static AbstractYearMonthAssert<?> then(YearMonth actual) {
     return assertThat(actual);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -136,6 +137,17 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   */
   default LocalDateAssert then(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  default YearMonthAssert then(YearMonth actual) {
+    return proxy(YearMonthAssert.class, YearMonth.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
@@ -534,6 +535,14 @@ public interface InstanceOfAssertFactories {
    * {@link InstanceOfAssertFactory} for a {@link LocalDate}.
    */
   InstanceOfAssertFactory<LocalDate, AbstractLocalDateAssert<?>> LOCAL_DATE = new InstanceOfAssertFactory<>(LocalDate.class,
+                                                                                                            Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@link LocalDate}.
+   *
+   * @since 3.26.0
+   */
+  InstanceOfAssertFactory<YearMonth, AbstractYearMonthAssert<?>> YEAR_MONTH = new InstanceOfAssertFactory<>(YearMonth.class,
                                                                                                             Assertions::assertThat);
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -21,6 +21,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +41,6 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-
 import org.assertj.core.util.CheckReturnValue;
 
 @CheckReturnValue
@@ -135,6 +135,17 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    */
   default LocalDateAssert assertThat(LocalDate actual) {
     return proxy(LocalDateAssert.class, LocalDate.class, actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  default YearMonthAssert assertThat(YearMonth actual) {
+    return proxy(YearMonthAssert.class, YearMonth.class, actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -31,6 +31,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalUnit;
 import java.util.Collection;
@@ -2597,6 +2598,17 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    */
   default AbstractLocalDateAssert<?> assertThat(final LocalDate localDate) {
     return Assertions.assertThat(localDate);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code>.
+   *
+   * @param yearMonth the actual value.
+   * @return the created assertion object.
+   * @since 3.26.0
+   */
+  default AbstractYearMonthAssert<?> assertThat(final YearMonth yearMonth) {
+    return Assertions.assertThat(yearMonth);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -29,6 +29,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Iterator;
@@ -984,6 +985,17 @@ public interface WithAssumptions {
    */
   default AbstractLocalDateAssert<?> assumeThat(final LocalDate localDate) {
     return Assumptions.assumeThat(localDate);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link YearMonthAssert}</code> assumption.
+   *
+   * @param yearMonth the actual value.
+   * @return the created assumption for assertion object.
+   * @since 3.26.0
+   */
+  default AbstractYearMonthAssert<?> assumeThat(final YearMonth yearMonth) {
+    return Assumptions.assumeThat(yearMonth);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/YearMonthAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/YearMonthAssert.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.YearMonth;
+
+/**
+ * Assertions for {@link YearMonth} type from new Date &amp; Time API introduced in Java 8.
+ * 
+ * @since 3.26.0
+ */
+public class YearMonthAssert extends AbstractYearMonthAssert<YearMonthAssert> {
+
+  /**
+   * Creates a new <code>{@link YearMonthAssert}</code>.
+   *
+   * @param actual the actual value to verify
+   */
+  protected YearMonthAssert(YearMonth actual) {
+    super(actual, YearMonthAssert.class);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeCurrentYearMonth.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeCurrentYearMonth.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.time.YearMonth;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@link java.time.YearMonth}
+ * is the current one (matching year and month).
+ *
+ * @since 3.26.0
+ */
+public class ShouldBeCurrentYearMonth extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeCurrentYearMonth}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeCurrentYearMonth(YearMonth actual) {
+    return new ShouldBeCurrentYearMonth(actual);
+  }
+
+  private ShouldBeCurrentYearMonth(YearMonth actual) {
+    super("%nExpecting actual:%n  %s%nto be the current YearMonth but was not.", actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Collection;
@@ -216,6 +217,7 @@ public class StandardRepresentation implements Representation {
     if (object instanceof Date) return toStringOf((Date) object);
     if (object instanceof Duration) return toStringOf((Duration) object);
     if (object instanceof LocalDate) return toStringOf((LocalDate) object);
+    if (object instanceof YearMonth) return toStringOf((YearMonth) object);
     if (object instanceof LocalDateTime) return toStringOf((LocalDateTime) object);
     if (object instanceof OffsetDateTime) return toStringOf((OffsetDateTime) object);
     if (object instanceof ZonedDateTime) return toStringOf((ZonedDateTime) object);
@@ -429,6 +431,10 @@ public class StandardRepresentation implements Representation {
 
   protected String toStringOf(LocalDate localDate) {
     return defaultToStringWithClassNameDisambiguation(localDate);
+  }
+
+  protected String toStringOf(YearMonth yearMonth) {
+    return defaultToStringWithClassNameDisambiguation(yearMonth);
   }
 
   protected String classNameDisambiguation(Object o) {

--- a/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThat_with_YearMonth_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThat_with_YearMonth_Test.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(YearMonth)}</code>.
+ */
+class Assertions_assertThat_with_YearMonth_Test {
+
+  @Test
+  void should_create_Assert() {
+    AbstractYearMonthAssert<?> assertions = Assertions.assertThat(YearMonth.now());
+    assertThat(assertions).isNotNull();
+  }
+
+  @Test
+  void should_pass_actual() {
+    YearMonth yearMonth = YearMonth.now();
+    AbstractYearMonthAssert<?> assertions = Assertions.assertThat(yearMonth);
+    assertThat(assertions.getActual()).isSameAs(yearMonth);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -98,6 +98,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUILDER;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URI_TYPE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URL_TYPE;
+import static org.assertj.core.api.InstanceOfAssertFactories.YEAR_MONTH;
 import static org.assertj.core.api.InstanceOfAssertFactories.ZONED_DATE_TIME;
 import static org.assertj.core.api.InstanceOfAssertFactories.array;
 import static org.assertj.core.api.InstanceOfAssertFactories.array2D;
@@ -141,6 +142,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
@@ -782,6 +784,16 @@ class InstanceOfAssertFactoriesTest {
     AbstractLocalDateAssert<?> result = assertThat(value).asInstanceOf(LOCAL_DATE);
     // THEN
     result.isBeforeOrEqualTo(LocalDate.now());
+  }
+
+  @Test
+  void year_month_factory_should_allow_year_month_assertions() {
+    // GIVEN
+    Object value = YearMonth.now();
+    // WHEN
+    AbstractYearMonthAssert<?> result = assertThat(value).asInstanceOf(YEAR_MONTH);
+    // THEN
+    result.isBeforeOrEqualTo(YearMonth.now());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/YearMonthAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/YearMonthAssertBaseTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.mockito.Mockito.mock;
+
+import java.time.YearMonth;
+import org.assertj.core.internal.Comparables;
+
+public abstract class YearMonthAssertBaseTest extends BaseTestTemplate<YearMonthAssert, YearMonth> {
+
+  protected Comparables comparables;
+  protected YearMonth now = YearMonth.now();
+
+  @Override
+  protected void inject_internal_objects() {
+    super.inject_internal_objects();
+    comparables = mock(Comparables.class);
+    assertions.comparables = comparables;
+  }
+
+  @Override
+  protected YearMonthAssert create_assertions() {
+    return new YearMonthAssert(now);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssertBaseTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.AbstractYearMonthAssert;
+
+/**
+ * Base test class for {@link AbstractYearMonthAssert} tests.
+ */
+public class YearMonthAssertBaseTest {
+
+  public static final YearMonth BEFORE = YearMonth.now().minusMonths(1);
+  public static final YearMonth REFERENCE = YearMonth.now();
+  public static final YearMonth AFTER = YearMonth.now().plusMonths(1);
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasMonthValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasMonthValue_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert hasMonthValue")
+class YearMonthAssert_hasMonthValue_Test {
+
+  @Test
+  void should_pass_if_actual_is_in_given_month() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2021, 2);
+    // WHEN/THEN
+    then(actual).hasMonthValue(2);
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_in_given_month() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2022, 1);
+    int wrongMonth = 12;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasMonthValue(wrongMonth));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveDateField(actual, "month", wrongMonth).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasMonthValue(5));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasMonth_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasMonth_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import java.time.Month;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert hasMonth")
+class YearMonthAssert_hasMonth_Test {
+
+  @Test
+  void should_pass_if_actual_is_in_given_month() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2021, 2);
+    // WHEN/THEN
+    then(actual).hasMonth(Month.FEBRUARY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_in_given_month() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2022, 1);
+    Month wrongMonth = Month.DECEMBER;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasMonth(wrongMonth));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveMonth(actual, wrongMonth).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasMonth(YearMonth.now().getMonth()));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasYear_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_hasYear_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert hasYear")
+class YearMonthAssert_hasYear_Test {
+
+  @Test
+  void should_pass_if_actual_is_in_given_year() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2022, 1);
+    // WHEN/THEN
+    then(actual).hasYear(2022);
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_in_given_year() {
+    // GIVEN
+    YearMonth actual = YearMonth.of(2022, 1);
+    int expectedYear = 2021;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasYear(expectedYear));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveDateField(actual, "year", expectedYear).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasYear(YearMonth.now().getYear()));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isAfterOrEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isAfterOrEqualTo_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isAfterOrEqualTo")
+class YearMonthAssert_isAfterOrEqualTo_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_after_year_month_parameter() {
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_after_year_month_as_string_parameter() {
+    assertThat(AFTER).isAfterOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  void should_pass_if_actual_is_equal_to_year_month_parameter() {
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_equal_to_year_month_as_string_parameter() {
+    assertThat(REFERENCE).isAfterOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_before_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfterOrEqualTo(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfterOrEqualTo(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_before_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfterOrEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfterOrEqualTo(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth yearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(yearMonth).isAfterOrEqualTo(YearMonth.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_year_month_parameter_is_null() {
+    // GIVEN
+    YearMonth otherYearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isAfterOrEqualTo(otherYearMonth);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The YearMonth to compare actual with should not be null");
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isAfterOrEqualTo(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isAfter_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isAfter_Test.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldBeAfter.shouldBeAfter;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isAfter")
+class YearMonthAssert_isAfter_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_after_year_month_parameter() {
+    assertThat(AFTER).isAfter(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_after_year_month_as_string_parameter() {
+    assertThat(AFTER).isAfter(REFERENCE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_equal_to_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isAfter(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_equal_to_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isAfter(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_before_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfter(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_before_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isAfter(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeAfter(BEFORE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth yearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(yearMonth).isAfter(YearMonth.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_year_month_parameter_is_null() {
+    // GIVEN
+    YearMonth otherYearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isAfter(otherYearMonth);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The YearMonth to compare actual with should not be null");
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isAfter(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBeforeOrEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBeforeOrEqualTo_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqualTo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isBeforeOrEqualTo")
+class YearMonthAssert_isBeforeOrEqualTo_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_before_year_month_parameter() {
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_before_year_month_as_string_parameter() {
+    assertThat(BEFORE).isBeforeOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  void should_pass_if_actual_is_equal_to_year_month_parameter() {
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_equal_to_year_month_as_string_parameter() {
+    assertThat(REFERENCE).isBeforeOrEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_after_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBeforeOrEqualTo(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBeforeOrEqualTo(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_after_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBeforeOrEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBeforeOrEqualTo(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth yearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(yearMonth).isBeforeOrEqualTo(YearMonth.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_year_month_parameter_is_null() {
+    // GIVEN
+    YearMonth otherYearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isBeforeOrEqualTo(otherYearMonth);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The YearMonth to compare actual with should not be null");
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isBeforeOrEqualTo(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBefore_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBefore_Test.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldBeBefore.shouldBeBefore;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isBefore")
+class YearMonthAssert_isBefore_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_before_year_month_parameter() {
+    assertThat(BEFORE).isBefore(REFERENCE);
+  }
+
+  @Test
+  void should_pass_if_actual_is_before_year_month_as_string_parameter() {
+    assertThat(BEFORE).isBefore(REFERENCE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_after_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBefore(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_after_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isBefore(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(AFTER, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_equal_to_year_month_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isBefore(REFERENCE);
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_equal_to_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isBefore(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeBefore(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth yearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(yearMonth).isBefore(YearMonth.now());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_year_month_parameter_is_null() {
+    // GIVEN
+    YearMonth otherYearMonth = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isBefore(otherYearMonth);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The YearMonth to compare actual with should not be null");
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isBefore(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBetween_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBetween_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.YearMonthAssert;
+import org.assertj.core.api.YearMonthAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("YearMonthAssert isBetween")
+class YearMonthAssert_isBetween_Test extends YearMonthAssertBaseTest {
+
+  private YearMonth before = now.minusMonths(1);
+  private YearMonth after = now.plusMonths(1);
+
+  @Override
+  protected YearMonthAssert invoke_api_method() {
+    return assertions.isBetween(before, after);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), before, after, true, true);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBetween_with_String_parameters_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isBetween_with_String_parameters_Test.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import org.assertj.core.api.YearMonthAssert;
+import org.assertj.core.api.YearMonthAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("YearMonthAssert isBetweenWithStringParameters")
+class YearMonthAssert_isBetween_with_String_parameters_Test extends YearMonthAssertBaseTest {
+
+  private YearMonth before = now.minusMonths(1);
+  private YearMonth after = now.plusMonths(1);
+
+  @Override
+  protected YearMonthAssert invoke_api_method() {
+    return assertions.isBetween(before.toString(), after.toString());
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), before, after, true, true);
+  }
+
+  @Test
+  void should_throw_a_DateTimeParseException_if_start_String_parameter_cannot_be_converted() {
+    // GIVEN
+    String abc = "abc";
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.isBetween(abc, after.toString()));
+    // THEN
+    assertThat(thrown).isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  void should_throw_a_DateTimeParseException_if_end_String_parameter_cannot_be_converted() {
+    // GIVEN
+    String abc = "abc";
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.isBetween(before.toString(), abc));
+    // THEN
+    assertThat(thrown).isInstanceOf(DateTimeParseException.class);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isEqualTo_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.test.ErrorMessagesForTest.shouldBeEqualMessage;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+/**
+ * Only test String based assertion (tests with {@link YearMonth} are already defined in assertj-core)
+ */
+@DisplayName("YearMonthAssert isEqualTo")
+class YearMonthAssert_isEqualTo_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_equal_to_year_month_as_string_parameter() {
+    assertThat(REFERENCE).isEqualTo(REFERENCE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_equal_to_year_month_as_string_parameter() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isEqualTo(REFERENCE.toString()));
+    // THEN
+    then(assertionError).hasMessage(shouldBeEqualMessage(AFTER + " (java.time.YearMonth)", REFERENCE + " (java.time.YearMonth)"));
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isEqualTo(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isInTheFuture_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isInTheFuture")
+class YearMonthAssert_isInTheFuture_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_future() {
+    assertThat(AFTER).isInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_today() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(BEFORE).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInTheFuture(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isInThePast_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isInThePast")
+class YearMonthAssert_isInThePast_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_today() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(REFERENCE).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(AFTER).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeInThePast(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isIn_Test.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldBeIn.shouldBeIn;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+
+/**
+ * Only test String based assertion (tests with {@link YearMonth} are already defined in assertj-core)
+ */
+@DisplayName("YearMonthAssert isIn")
+class YearMonthAssert_isIn_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_in_dates_as_string_array_parameter() {
+    assertThat(REFERENCE).isIn(REFERENCE.toString(), AFTER.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_in_dates_as_string_array_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isIn(AFTER.toString(), BEFORE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeIn(REFERENCE, asList(AFTER, BEFORE)).create());
+  }
+
+  @Test
+  void should_fail_if_dates_as_string_array_parameter_is_null() {
+    // GIVEN
+    String[] otherYearMonthsAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isIn(otherYearMonthsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The given YearMonth array should not be null");
+  }
+
+  @Test
+  void should_fail_if_dates_as_string_array_parameter_is_empty() {
+    // GIVEN
+    String[] otherYearMonthsAsString = new String[0];
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isIn(otherYearMonthsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The given YearMonth array should not be empty");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotEqualTo_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldNotBeEqual.shouldNotBeEqual;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+
+/**
+ * Only test String based assertion (tests with {@link YearMonth} are already defined in assertj-core)
+ */
+@DisplayName("YearMonthAssert isNotEqualTo")
+class YearMonthAssert_isNotEqualTo_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_not_equal_to_year_month_as_string_parameter() {
+    assertThat(REFERENCE).isNotEqualTo(AFTER.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_equal_to_year_month_as_string_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isNotEqualTo(REFERENCE.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeEqual(REFERENCE, REFERENCE).create());
+  }
+
+  @Test
+  void should_fail_if_year_month_as_string_parameter_is_null() {
+    // GIVEN
+    String otherYearMonthAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isNotEqualTo(otherYearMonthAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The String representing the YearMonth to compare actual with should not be null");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotIn_Test.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.error.ShouldNotBeIn.shouldNotBeIn;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+
+/**
+ * Only test String based assertion (tests with {@link YearMonth} are already defined in assertj-core)
+ */
+@DisplayName("YearMonthAssert isNotIn")
+class YearMonthAssert_isNotIn_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_not_in_dates_as_string_array_parameter() {
+    assertThat(REFERENCE).isNotIn(AFTER.toString(), BEFORE.toString());
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_dates_as_string_array_parameter() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(REFERENCE).isNotIn(REFERENCE.toString(), AFTER.toString());
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldNotBeIn(REFERENCE, asList(REFERENCE, AFTER)).create());
+  }
+
+  @Test
+  void should_fail_if_dates_as_string_array_parameter_is_null() {
+    // GIVEN
+    String[] otherYearMonthsAsString = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isNotIn(otherYearMonthsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The given YearMonth array should not be null");
+  }
+
+  @Test
+  void should_fail_if_dates_as_string_array_parameter_is_empty() {
+    // GIVEN
+    String[] otherYearMonthsAsString = new String[0];
+    // WHEN
+    ThrowingCallable code = () -> assertThat(YearMonth.now()).isNotIn(otherYearMonthsAsString);
+    // THEN
+    assertThatIllegalArgumentException().isThrownBy(code)
+                                        .withMessage("The given YearMonth array should not be empty");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isStrictlyBetween_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isStrictlyBetween_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.YearMonthAssert;
+import org.assertj.core.api.YearMonthAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+@DisplayName("YearMonthAssert isStrictlyBetween")
+class YearMonthAssert_isStrictlyBetween_Test extends YearMonthAssertBaseTest {
+
+  private YearMonth before = now.minusMonths(1);
+  private YearMonth after = now.plusMonths(1);
+
+  @Override
+  protected YearMonthAssert invoke_api_method() {
+    return assertions.isStrictlyBetween(before, after);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), before, after, false, false);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isStrictlyBetween_with_String_parameters_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isStrictlyBetween_with_String_parameters_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import org.assertj.core.api.YearMonthAssert;
+import org.assertj.core.api.YearMonthAssert;
+import org.assertj.core.api.YearMonthAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("YearMonthAssert isStrictlyBetweenWithStringParameters")
+class YearMonthAssert_isStrictlyBetween_with_String_parameters_Test extends YearMonthAssertBaseTest {
+
+  private final YearMonth before = now.minusMonths(1);
+  private YearMonth after = now.plusMonths(1);
+
+  @Override
+  protected YearMonthAssert invoke_api_method() {
+    return assertions.isStrictlyBetween(before.toString(), after.toString());
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(comparables).assertIsBetween(getInfo(assertions), getActual(assertions), before, after, false, false);
+  }
+
+  @Test
+  void should_throw_a_DateTimeParseException_if_start_String_parameter_cannot_be_converted() {
+    // GIVEN
+    String abc = "abc";
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.isStrictlyBetween(abc, after.toString()));
+    // THEN
+    assertThat(thrown).isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  void should_throw_a_DateTimeParseException_if_end_String_parameter_cannot_be_converted() {
+    // GIVEN
+    String abc = "abc";
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.isStrictlyBetween(before.toString(), abc));
+    // THEN
+    assertThat(thrown).isInstanceOf(DateTimeParseException.class);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isToday_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isToday_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import java.time.YearMonth;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldBeCurrentYearMonth.shouldBeCurrentYearMonth;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+@DisplayName("YearMonthAssert isCurrentYearMonth")
+class YearMonthAssert_isCurrentYearMonth_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_current_year_month() {
+    assertThat(REFERENCE).isCurrentYearMonth();
+  }
+
+  @Test
+  void should_fail_if_actual_is_before_current_year_month() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(BEFORE).isCurrentYearMonth();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeCurrentYearMonth(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_after_current_year_month() {
+    // WHEN
+    ThrowingCallable code = () -> assertThat(AFTER).isCurrentYearMonth();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(shouldBeCurrentYearMonth(AFTER).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    ThrowingCallable code = () -> assertThat(actual).isCurrentYearMonth();
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_Test.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -244,6 +245,16 @@ class StandardRepresentation_toStringOf_Test extends AbstractBaseRepresentationT
     String localDateRepresentation = STANDARD_REPRESENTATION.toStringOf(localDate);
     // THEN
     then(localDateRepresentation).isEqualTo("2011-06-18 (java.time.LocalDate)");
+  }
+
+  @Test
+  void should_return_unambiguous_toString_of_YearMonth() {
+    // GIVEN use Object to call toStringOf(Object) and not toStringOf(YearMonth)
+    Object yearMonth = YearMonth.of(2011, 6);
+    // WHEN
+    String localDateRepresentation = STANDARD_REPRESENTATION.toStringOf(yearMonth);
+    // THEN
+    then(localDateRepresentation).isEqualTo("2011-06 (java.time.YearMonth)");
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes  #3141
* Unit tests : YES
* Javadoc with a code example (on API only) : YES

This PR adds assertions for the `java.time.YearMonth` type. I have based the new assertions on the existing `LocalDate` assertions. Therefore they should contain similar/matching assertions except for the following differences:

- no `hasDayOfMonth` assertion
- no `isToday` assertion
- an `isCurrentYearMonth` assertion

I hope I found and extended all the right entry points.
