### PR TITLE
Fix NPE thrown by `anyMatch(Objects::isNull)` given an iterable containing a null element

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1352,9 +1352,9 @@ public class Iterables {
                                  PredicateDescription predicateDescription) {
     assertNotNull(info, actual);
     predicates.assertIsNotNull(predicate);
-    stream(actual).filter(predicate)
-                  .findFirst()
-                  .orElseThrow(() -> failures.failure(info, anyElementShouldMatch(actual, predicateDescription)));
+    if (stream(actual).noneMatch(predicate)) {
+      throw failures.failure(info, anyElementShouldMatch(actual, predicateDescription));
+    }
   }
 
   public <E> void assertNoneMatch(AssertionInfo info, Iterable<? extends E> actual, Predicate<? super E> predicate,

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnyMatch_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAnyMatch_Test.java
@@ -23,6 +23,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.assertj.core.internal.IterablesBaseTest;
@@ -35,6 +36,12 @@ class Iterables_assertAnyMatch_Test extends IterablesBaseTest {
   void should_pass_if_an_element_satisfies_predicate() {
     List<String> actual = newArrayList("123", "1234", "12345");
     iterables.assertAnyMatch(someInfo(), actual, s -> s.length() >= 5, PredicateDescription.GIVEN);
+  }
+
+  @Test
+  void should_pass_if_an_element_is_null() {
+    List<String> actual = newArrayList("123", null, "12345");
+    iterables.assertAnyMatch(someInfo(), actual, Objects::isNull, PredicateDescription.GIVEN);
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a null pointer exception produced by the following usage:

```java
assertThat(Arrays.asList("foo", null)).anyMatch(Objects::isNull);
```

I came across the exception while trying to assert that a collection contains both, null and non-null values:

```java
assertThat(Arrays.asList("foo", null))
   .anyMatch(Objects::isNull)
   .anyMatch(Objects::nonNull);
```

The alternative is to use `containsNull()`:

```java
assertThat(Arrays.asList("foo", null)
    .containsNull()
    .anyMatch(Objects::nonNull);
```


#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
