### PR TITLE
#3159 Fix misleading subsequence failure messages in string assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -81,18 +81,25 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                              Map<CharSequence, Integer> notFoundRepeatedSubsequence,
                                                              ComparisonStrategy comparisonStrategy) {
 
-    String detailedErrorMessage = notFoundRepeatedSubsequence.entrySet().stream()
-                                                             .map(entry -> format("the %s occurrence of \"%s\" was not found",
-                                                                                  ordinal(entry.getValue() + 1),
-                                                                                  entry.getKey()))
-                                                             .collect(Collectors.joining("%n"));
+    String detailedErrorMessage;
+    if (notFoundRepeatedSubsequence.size() == 1) {
+      Map.Entry<CharSequence, Integer> singleEntry = notFoundRepeatedSubsequence.entrySet().iterator().next();
+      detailedErrorMessage = format("But the %s occurrence of \"%s\" was not found", ordinal(singleEntry.getValue() + 1),
+                                    singleEntry.getKey());
+    } else {
+      detailedErrorMessage = notFoundRepeatedSubsequence.entrySet().stream()
+                                                        .map(entry -> format("- the %s occurrence of \"%s\" was not found",
+                                                                             ordinal(entry.getValue() + 1), entry.getKey()))
+                                                        .collect(Collectors.joining("%n"));
+      detailedErrorMessage = "But:%n" + detailedErrorMessage;
+    }
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
                                                       "  %s%n" +
                                                       "to contain the following CharSequences in this order (possibly with other values between them):%n"
                                                       +
                                                       "  %s%n" +
-                                                      "But " + detailedErrorMessage + "%n%s",
+                                                      detailedErrorMessage + "%n%s",
                                                       actual, strings, comparisonStrategy);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -55,7 +55,7 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
                                                       "  %s%n" +
-                                                      "to contain the following CharSequences in this order:%n" +
+                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n" +
                                                       "  %s%n" +
                                                       "but %s was found before %s%n%s",
                                                       actual, strings, strings[badOrderIndex + 1],
@@ -86,7 +86,7 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
                                                       "  %s%n" +
-                                                      "to contain the following CharSequences in this order:%n" +
+                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n" +
                                                       "  %s%n" +
                                                       "But%n" +
                                                       detailedErrorMessage + "%n%s",

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -19,6 +19,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+
 /**
  * Creates an error message indicating that an assertion that verifies that a {@code CharSequence} contains a Subsequence of
  * several {@code CharSequence}s in order failed.
@@ -80,9 +82,9 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                              ComparisonStrategy comparisonStrategy) {
 
     String detailedErrorMessage = notFoundRepeatedSubsequence.entrySet().stream()
-                                                             .map(entry -> String.format("%s occurrence of \"%s\" was not found",
-                                                                                         ordinal(entry.getValue() + 1),
-                                                                                         entry.getKey()))
+                                                             .map(entry -> format("the %s occurrence of \"%s\" was not found",
+                                                                                  ordinal(entry.getValue() + 1),
+                                                                                  entry.getKey()))
                                                              .collect(Collectors.joining("%n"));
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
@@ -90,23 +92,30 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                       "to contain the following CharSequences in this order (possibly with other values between them):%n"
                                                       +
                                                       "  %s%n" +
-                                                      "But%n" +
-                                                      detailedErrorMessage + "%n%s",
+                                                      "But " + detailedErrorMessage + "%n%s",
                                                       actual, strings, comparisonStrategy);
   }
 
-  public static String ordinal(int i) {
+  /**
+   * Returns the ordinal representation of a given integer.
+   * <p>
+   * This method converts integers to their ordinal form (e.g., 1 to "1st", 2 to "2nd", etc.).
+   * Special cases for numbers ending in 11, 12, and 13 are handled to return "th" instead of
+   * "st", "nd", or "rd".
+   * </p>
+   *
+   * @param i the integer to convert
+   * @return the ordinal representation of {@code i}
+   */
+  private static String ordinal(int i) {
     int mod100 = i % 100;
     int mod10 = i % 10;
-    if (mod10 == 1 && mod100 != 11) {
-      return i + "st";
-    } else if (mod10 == 2 && mod100 != 12) {
-      return i + "nd";
-    } else if (mod10 == 3 && mod100 != 13) {
-      return i + "rd";
-    } else {
-      return i + "th";
-    }
+
+    if (mod10 == 1 && mod100 != 11) return i + "st";
+    if (mod10 == 2 && mod100 != 12) return i + "nd";
+    if (mod10 == 3 && mod100 != 13) return i + "rd";
+
+    return i + "th";
   }
 
   private ShouldContainSubsequenceOfCharSequence(String format, CharSequence actual, CharSequence[] strings,

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -55,7 +55,8 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
                                                       "  %s%n" +
-                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                                      +
                                                       "  %s%n" +
                                                       "but %s was found before %s%n%s",
                                                       actual, strings, strings[badOrderIndex + 1],
@@ -79,14 +80,15 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                              ComparisonStrategy comparisonStrategy) {
 
     String detailedErrorMessage = notFoundRepeatedSubsequence.entrySet().stream()
-                                                             .map(entry ->
-                                                               String.format("%s occurrence of \"%s\" was not found", ordinal(entry.getValue() + 1), entry.getKey())
-                                                             )
+                                                             .map(entry -> String.format("%s occurrence of \"%s\" was not found",
+                                                                                         ordinal(entry.getValue() + 1),
+                                                                                         entry.getKey()))
                                                              .collect(Collectors.joining("%n"));
 
     return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
                                                       "  %s%n" +
-                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                                      "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                                      +
                                                       "  %s%n" +
                                                       "But%n" +
                                                       detailedErrorMessage + "%n%s",

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -15,10 +15,14 @@ package org.assertj.core.error;
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
  * Creates an error message indicating that an assertion that verifies that a {@code CharSequence} contains a Subsequence of
  * several {@code CharSequence}s in order failed.
- * 
+ *
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  */
@@ -26,7 +30,7 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
 
   /**
    * Creates a new <code>{@link ShouldContainSubsequenceOfCharSequence}</code>.
-   * 
+   *
    * @param actual the actual value in the failed assertion.
    * @param strings the sequence of values expected to be in {@code actual}.
    * @param firstBadOrderIndex first index failing the subsequence.
@@ -39,7 +43,7 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
 
   /**
    * Creates a new <code>{@link ShouldContainSubsequenceOfCharSequence}</code>.
-   * 
+   *
    * @param actual the actual value in the failed assertion.
    * @param strings the sequence of values expected to be in {@code actual}.
    * @param badOrderIndex index failing the subsequence.
@@ -59,6 +63,50 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                       comparisonStrategy);
   }
 
+  /**
+   * Creates a new <code>{@link ShouldContainSubsequenceOfCharSequence}</code> with detailed error messages about missing subsequences.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param strings the sequence of values expected to be in {@code actual}.
+   * @param notFoundRepeatedSubsequence a map where each key is a subsequence of {@code strings}
+   *        that was expected to be found in {@code actual} and the corresponding value is
+   *        the number of times it was expected but not found.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldContainSubsequence(CharSequence actual, CharSequence[] strings,
+                                                             Map<CharSequence, Integer> notFoundRepeatedSubsequence,
+                                                             ComparisonStrategy comparisonStrategy) {
+
+    String detailedErrorMessage = notFoundRepeatedSubsequence.entrySet().stream()
+                                                             .map(entry ->
+                                                               String.format("%s occurrence of \"%s\" was not found", ordinal(entry.getValue() + 1), entry.getKey())
+                                                             )
+                                                             .collect(Collectors.joining("%n"));
+
+    return new ShouldContainSubsequenceOfCharSequence("%nExpecting actual:%n" +
+                                                      "  %s%n" +
+                                                      "to contain the following CharSequences in this order:%n" +
+                                                      "  %s%n" +
+                                                      "But%n" +
+                                                      detailedErrorMessage + "%n%s",
+                                                      actual, strings, comparisonStrategy);
+  }
+
+  public static String ordinal(int i) {
+    int mod100 = i % 100;
+    int mod10 = i % 10;
+    if (mod10 == 1 && mod100 != 11) {
+      return i + "st";
+    } else if (mod10 == 2 && mod100 != 12) {
+      return i + "nd";
+    } else if (mod10 == 3 && mod100 != 13) {
+      return i + "rd";
+    } else {
+      return i + "th";
+    }
+  }
+
   private ShouldContainSubsequenceOfCharSequence(String format, CharSequence actual, CharSequence[] strings,
                                                  CharSequence foundButBadOrder,
                                                  CharSequence foundButBadOrder2,
@@ -66,4 +114,8 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
     super(format, actual, strings, foundButBadOrder, foundButBadOrder2, comparisonStrategy);
   }
 
+  private ShouldContainSubsequenceOfCharSequence(String format, CharSequence actual, CharSequence[] strings,
+                                                 ComparisonStrategy comparisonStrategy) {
+    super(format, actual, strings, comparisonStrategy);
+  }
 }

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -79,12 +79,11 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.StringReader;
 import java.text.Normalizer;
-import java.util.Base64;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
@@ -190,7 +189,7 @@ public class Strings {
     assertNotNull(info, actual);
     LineNumberReader reader = new LineNumberReader(new StringReader(actual.toString()));
     try {
-      while (reader.readLine() != null);
+      while (reader.readLine() != null) ;
     } catch (IOException e) {
       throw new InputStreamsException(format("Unable to count lines in `%s`", actual), e);
     }
@@ -582,16 +581,8 @@ public class Strings {
   public void assertContainsSubsequence(AssertionInfo info, CharSequence actual, CharSequence[] subsequence) {
     doCommonCheckForCharSequence(info, actual, subsequence);
 
-    Set<CharSequence> notFound = stream(subsequence).filter(value -> !stringContains(actual, value))
-                                                    .collect(toCollection(LinkedHashSet::new));
-
-    if (!notFound.isEmpty()) {
-      // don't bother looking for a subsequence, some of the subsequence elements were not found !
-      if (notFound.size() == 1 && subsequence.length == 1) {
-        throw failures.failure(info, shouldContain(actual, subsequence[0], comparisonStrategy));
-      }
-      throw failures.failure(info, shouldContain(actual, subsequence, notFound, comparisonStrategy));
-    }
+    Map<CharSequence, Integer> notFound = getNotFoundSubsequence(actual, subsequence);
+    handleNotFound(info, actual, subsequence, notFound);
 
     // we have found all the given values but were they in the expected order ?
     if (subsequence.length == 1) return; // no order check needed for a one element subsequence
@@ -608,6 +599,88 @@ public class Strings {
       if (stringContains(actualRest, subsequence[i])) actualRest = removeUpTo(actualRest, subsequence[i]);
       else throw failures.failure(info, shouldContainSubsequence(actual, subsequence, i - 1, comparisonStrategy));
     }
+  }
+
+  /**
+   * Handles the scenario where certain subsequences were not found in the actual CharSequence.
+   * Depending on the exact mismatch details, it throws appropriate assertion failures.
+   *
+   * @param info Assertion metadata.
+   * @param actual The actual CharSequence being checked.
+   * @param subsequence The expected subsequence to be found in the actual CharSequence.
+   * @param notFound A map containing subsequences that were not found (or not found enough times) and their respective counts.
+   */
+  private void handleNotFound(AssertionInfo info, CharSequence actual,
+                              CharSequence[] subsequence, Map<CharSequence, Integer> notFound) {
+
+    // If there are no missing subsequences, there's nothing to handle, so return.
+    if (notFound.isEmpty()) return;
+
+    // Special case: If there's only one missing subsequence and we were only looking for one,
+    // throw a specific failure for that.
+    if (notFound.size() == 1 && subsequence.length == 1) {
+      throw failures.failure(info, shouldContain(actual, subsequence[0], comparisonStrategy));
+    }
+
+    // Check if all the missing subsequences are due to not finding duplicates.
+    // If every value in 'notFound' map is greater than 0, this indicates that the corresponding
+    // subsequences were found, but not as many times as expected.
+    boolean anyDuplicateSubsequenceFound = notFound.values().stream().allMatch(count -> count > 0);
+
+    // If the above is true, throw a failure specifying the subsequence mismatch details.
+    if (anyDuplicateSubsequenceFound) {
+      throw failures.failure(info, shouldContainSubsequence(actual, subsequence, notFound, comparisonStrategy));
+    }
+
+    // Otherwise, filter the 'notFound' map to get the keys (subsequences) that were not found at all (value is 0).
+    Set<CharSequence> notFoundKeysWithZeroValue = notFound.entrySet().stream()
+                                                          .filter(entry -> entry.getValue() == 0)
+                                                          .map(Map.Entry::getKey)
+                                                          .collect(Collectors.toSet());
+    // Throw a failure specifying the completely missing subsequences.
+    throw failures.failure(info, shouldContain(actual, subsequence, notFoundKeysWithZeroValue, comparisonStrategy));
+  }
+
+  /**
+   * Computes and returns a map of subsequences that were not found (or not found enough times) in the actual CharSequence.
+   *
+   * @param actual The actual CharSequence being checked.
+   * @param subsequence The expected subsequence to be found in the actual CharSequence.
+   * @return A map where the key represents the missing subsequence and the value represents the number of times it appears in 'actual'.
+   */
+  private Map<CharSequence, Integer> getNotFoundSubsequence(CharSequence actual, CharSequence[] subsequence) {
+    // Create a map to store how many times each element appears in the 'actual' sequence.
+    // We use a HashMap for efficient look-ups and modifications.
+    Map<CharSequence, Integer> actualCounts = new HashMap<>();
+
+    // Create a map to store how many times each element appears in the 'subsequence' array.
+    // We use the Java Streams API to group the elements by their identity and then count their occurrences.
+    Map<CharSequence, Long> subseqCounts = stream(subsequence)
+        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+    // For each element in the 'subsequence', compute its occurrences in the 'actual' sequence.
+    // If the element is not yet in the actualCounts map (v is null), then count its occurrences in 'actual'.
+    // If the element is already in the actualCounts map (v is not null), then keep its current count.
+    for (CharSequence value : subsequence) {
+      actualCounts.compute(value, (k, v) -> v == null ? countOccurrences(k, actual) : v);
+    }
+
+    // Return a map that contains only the elements from the 'subsequence'
+    // that appear more times in 'subsequence' than in 'actual'.
+    // The map's keys are the elements and the values are the number of times they appear in 'actual'.
+    return subseqCounts.entrySet().stream()
+                       .filter(entry -> entry.getValue() > actualCounts.getOrDefault(entry.getKey(), 0))
+                       .collect(Collectors.toMap(
+                           // The key of the output map entry is the same as the subsequence entry key.
+                           Map.Entry::getKey,
+                           // The value of the output map entry is the number of times the key appears in 'actual'.
+                           entry -> actualCounts.get(entry.getKey()),
+                           // If there are duplicate keys when collecting (which shouldn't happen in this case),
+                           // prefer the existing key.
+                           (existing, replacement) -> existing,
+                           // Use a LinkedHashMap to maintain the insertion order.
+                           LinkedHashMap::new
+                       ));
   }
 
   private String removeUpTo(String string, CharSequence toRemove) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -189,7 +189,7 @@ public class Strings {
     assertNotNull(info, actual);
     LineNumberReader reader = new LineNumberReader(new StringReader(actual.toString()));
     try {
-      while (reader.readLine() != null) ;
+      while (reader.readLine() != null);
     } catch (IOException e) {
       throw new InputStreamsException(format("Unable to count lines in `%s`", actual), e);
     }
@@ -254,7 +254,8 @@ public class Strings {
   public void assertContainsIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence sequence) {
     checkCharSequenceIsNotNull(sequence);
     assertNotNull(info, actual);
-    if (!containsIgnoreCase(actual, sequence)) throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
+    if (!containsIgnoreCase(actual, sequence))
+      throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
   }
 
   private boolean containsIgnoreCase(CharSequence actual, CharSequence sequence) {
@@ -298,11 +299,13 @@ public class Strings {
   }
 
   public void assertEqualsIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (!areEqualIgnoringCase(actual, expected)) throw failures.failure(info, shouldBeEqual(actual, expected), actual, expected);
+    if (!areEqualIgnoringCase(actual, expected))
+      throw failures.failure(info, shouldBeEqual(actual, expected), actual, expected);
   }
 
   public void assertNotEqualsIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (areEqualIgnoringCase(actual, expected)) throw failures.failure(info, shouldNotBeEqualIgnoringCase(actual, expected));
+    if (areEqualIgnoringCase(actual, expected))
+      throw failures.failure(info, shouldNotBeEqualIgnoringCase(actual, expected));
   }
 
   private static boolean areEqualIgnoringCase(CharSequence actual, CharSequence expected) {
@@ -605,10 +608,10 @@ public class Strings {
    * Handles the scenario where certain subsequences were not found in the actual CharSequence.
    * Depending on the exact mismatch details, it throws appropriate assertion failures.
    *
-   * @param info Assertion metadata.
-   * @param actual The actual CharSequence being checked.
+   * @param info        Assertion metadata.
+   * @param actual      The actual CharSequence being checked.
    * @param subsequence The expected subsequence to be found in the actual CharSequence.
-   * @param notFound A map containing subsequences that were not found (or not found enough times) and their respective counts.
+   * @param notFound    A map containing subsequences that were not found (or not found enough times) and their respective counts.
    */
   private void handleNotFound(AssertionInfo info, CharSequence actual,
                               CharSequence[] subsequence, Map<CharSequence, Integer> notFound) {
@@ -644,7 +647,7 @@ public class Strings {
   /**
    * Computes and returns a map of subsequences that were not found (or not found enough times) in the actual CharSequence.
    *
-   * @param actual The actual CharSequence being checked.
+   * @param actual      The actual CharSequence being checked.
    * @param subsequence The expected subsequence to be found in the actual CharSequence.
    * @return A map where the key represents the missing subsequence and the value represents the number of times it appears in 'actual'.
    */
@@ -656,7 +659,8 @@ public class Strings {
     // Create a map to store how many times each element appears in the 'subsequence' array.
     // We use the Java Streams API to group the elements by their identity and then count their occurrences.
     Map<CharSequence, Long> subseqCounts = stream(subsequence)
-        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+                                                              .collect(Collectors.groupingBy(Function.identity(),
+                                                                                             Collectors.counting()));
 
     // For each element in the 'subsequence', compute its occurrences in the 'actual' sequence.
     // If the element is not yet in the actualCounts map (v is null), then count its occurrences in 'actual'.
@@ -671,16 +675,17 @@ public class Strings {
     return subseqCounts.entrySet().stream()
                        .filter(entry -> entry.getValue() > actualCounts.getOrDefault(entry.getKey(), 0))
                        .collect(Collectors.toMap(
-                           // The key of the output map entry is the same as the subsequence entry key.
-                           Map.Entry::getKey,
-                           // The value of the output map entry is the number of times the key appears in 'actual'.
-                           entry -> actualCounts.get(entry.getKey()),
-                           // If there are duplicate keys when collecting (which shouldn't happen in this case),
-                           // prefer the existing key.
-                           (existing, replacement) -> existing,
-                           // Use a LinkedHashMap to maintain the insertion order.
-                           LinkedHashMap::new
-                       ));
+                                                 // The key of the output map entry is the same as the subsequence entry key.
+                                                 Map.Entry::getKey,
+                                                 // The value of the output map entry is the number of times the key appears in
+                                                 // 'actual'.
+                                                 entry -> actualCounts.get(entry.getKey()),
+                                                 // If there are duplicate keys when collecting (which shouldn't happen in this
+                                                 // case),
+                                                 // prefer the existing key.
+                                                 (existing, replacement) -> existing,
+                                                 // Use a LinkedHashMap to maintain the insertion order.
+                                                 LinkedHashMap::new));
   }
 
   private String removeUpTo(String string, CharSequence toRemove) {

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
@@ -24,7 +24,6 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.test.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
 
-
 /**
  * Tests for <code>{@link ShouldContainSubsequenceOfCharSequence#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
  *
@@ -43,7 +42,8 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
                                    "  \"" + actual + "\"%n" +
-                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                   +
                                    "  [\"{\", \"author\", \"title\", \"}\"]%n" +
                                    "but \"title\" was found before \"author\"%n"));
   }
@@ -60,7 +60,8 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
                                    "  \"" + actual + "\"%n" +
-                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                   +
                                    "  [\"{\", \"author\", \"title\", \"}\"]%n" +
                                    "but \"title\" was found before \"author\"%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
@@ -78,7 +79,8 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
                                    "  \"" + actual + "\"%n" +
-                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                   +
                                    "  [\"{\", \"title\", \"author\", \"title\", \"}\"]%n" +
                                    "But%n" +
                                    "2nd occurrence of \"title\" was not found%n" +

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
@@ -13,8 +13,10 @@
 package org.assertj.core.error;
 
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainSubsequenceOfCharSequence.shouldContainSubsequence;
+import static org.assertj.core.test.Maps.mapOf;
 
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
@@ -22,7 +24,6 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.test.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 
 /**
  * Tests for <code>{@link ShouldContainSubsequenceOfCharSequence#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
@@ -70,7 +71,7 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // GIVEN
     String[] sequenceValues = { "{", "title", "author", "title", "}" };
     String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
-    ErrorMessageFactory factory = shouldContainSubsequence(actual, sequenceValues, Map.of("title", 1),
+    ErrorMessageFactory factory = shouldContainSubsequence(actual, sequenceValues, mapOf(entry("title", 1)),
                                                            new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.INSTANCE));
     // WHEN
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
@@ -22,6 +22,8 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.test.CaseInsensitiveStringComparator;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 /**
  * Tests for <code>{@link ShouldContainSubsequenceOfCharSequence#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
  *
@@ -40,7 +42,7 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
                                    "  \"" + actual + "\"%n" +
-                                   "to contain the following CharSequences in this order:%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
                                    "  [\"{\", \"author\", \"title\", \"}\"]%n" +
                                    "but \"title\" was found before \"author\"%n"));
   }
@@ -57,10 +59,28 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
                                    "  \"" + actual + "\"%n" +
-                                   "to contain the following CharSequences in this order:%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
                                    "  [\"{\", \"author\", \"title\", \"}\"]%n" +
                                    "but \"title\" was found before \"author\"%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
 
+  @Test
+  void should_create_error_message_indicating_duplicate_subsequence() {
+    // GIVEN
+    String[] sequenceValues = { "{", "title", "author", "title", "}" };
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
+    ErrorMessageFactory factory = shouldContainSubsequence(actual, sequenceValues, Map.of("title", 1),
+                                                           new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.INSTANCE));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %nExpecting actual:%n" +
+                                   "  \"" + actual + "\"%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n" +
+                                   "  [\"{\", \"title\", \"author\", \"title\", \"}\"]%n" +
+                                   "But%n" +
+                                   "2nd occurrence of \"title\" was not found%n" +
+                                   "when comparing values using CaseInsensitiveStringComparator"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
@@ -142,9 +142,10 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
                                    "  \"" + actual + "\"%n" +
                                    "to contain the following CharSequences in this order (possibly with other values between them):%n"
                                    +
-                                   "  [\"{\", \"title\", \"author\", \"title\", \"title\", \"}\"]%n" +
-                                   "But the 3rd occurrence of \"title\" was not found%n" +
-                                   "the 2nd occurrence of \"George\" was not found%n" +
+                                   "  [\"{\", \"title\", \"George\", \"title\", \"title\", \"George\", \"}\"]%n" +
+                                   "But:%n" +
+                                   "- the 3rd occurrence of \"title\" was not found%n" +
+                                   "- the 2nd occurrence of \"George\" was not found%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
@@ -155,7 +155,7 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
   void should_fail_when_actual_does_not_contain_non_existing_elements_and_missing_subsequence_duplicates() {
     // GIVEN
     String actual = "v1 : v2 : v3 : v2";
-    String[] subsequence = { "v2", "v2", "v2", "v3", "v4", "v5"};
+    String[] subsequence = { "v2", "v2", "v2", "v3", "v4", "v5" };
     // WHEN
     expectAssertionError(() -> strings.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
@@ -177,7 +177,7 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
   void should_fail_if_actual_does_not_contain_repeated_occurrences_of_subsequence_values_in_text_with_multiple_values() {
     // GIVEN
     String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
-    String[] subsequence = new String[]{"George", "George"};
+    String[] subsequence = new String[] { "George", "George" };
     // WHEN
     expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
@@ -12,14 +12,13 @@
  */
 package org.assertj.core.internal.strings;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldContainSubsequenceOfCharSequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
@@ -29,10 +28,7 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.internal.StringsBaseTest;
-import org.assertj.core.test.jdk11.Jdk11;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
 
@@ -152,7 +148,7 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
     // WHEN
     expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("v2", 1), comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, mapOf(entry("v2", 1)), comparisonStrategy));
   }
 
   @Test
@@ -174,7 +170,7 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
     // WHEN
     expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("da", 1), comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, mapOf(entry("da", 1)), comparisonStrategy));
   }
 
   @Test
@@ -185,6 +181,6 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
     // WHEN
     expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("George", 1), comparisonStrategy));
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, mapOf(entry("George", 1)), comparisonStrategy));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal.strings;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldContainSubsequenceOfCharSequence.shouldContainSubsequence;
@@ -28,7 +29,10 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.internal.StringsBaseTest;
+import org.assertj.core.test.jdk11.Jdk11;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
 
@@ -140,4 +144,47 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
     verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, 1, comparisonStrategy));
   }
 
+  @Test
+  void should_fail_if_actual_does_not_contain_all_occurrences_of_subsequence_values() {
+    // GIVEN
+    String actual = "v1 : v2 : v3";
+    String[] subsequence = { "v2", "v2", "v3" };
+    // WHEN
+    expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
+    // THEN
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("v2", 1), comparisonStrategy));
+  }
+
+  @Test
+  void should_fail_when_actual_does_not_contain_non_existing_elements_and_missing_subsequence_duplicates() {
+    // GIVEN
+    String actual = "v1 : v2 : v3 : v2";
+    String[] subsequence = { "v2", "v2", "v2", "v3", "v4", "v5"};
+    // WHEN
+    expectAssertionError(() -> strings.assertContainsSubsequence(INFO, actual, subsequence));
+    // THEN
+    verify(failures).failure(INFO, shouldContain(actual, subsequence, newLinkedHashSet("v4", "v5")));
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_repeated_occurrences_of_subsequence_values() {
+    // GIVEN
+    String actual = "Yoda";
+    String[] subsequence = { "Yo", "da", "da" };
+    // WHEN
+    expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
+    // THEN
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("da", 1), comparisonStrategy));
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_repeated_occurrences_of_subsequence_values_in_text_with_multiple_values() {
+    // GIVEN
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
+    String[] subsequence = new String[]{"George", "George"};
+    // WHEN
+    expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
+    // THEN
+    verify(failures).failure(INFO, shouldContainSubsequence(actual, subsequence, Map.of("George", 1), comparisonStrategy));
+  }
 }


### PR DESCRIPTION
      - Resolved ambiguity in error messages when a subsequence element is repeated in the expectation but not in the actual string.
      - Refactored `assertContainsSubsequence` to handle different subsequence scenarios.
      - Improved error handling by introducing `handleNotFound` to distinctly report missing elements and discrepancies in expected duplicates.
      - Enhanced `getNotFoundSubsequence` to correctly compute and return missing or inadequately represented subsequences.

      This change ensures clearer and more accurate failure messages when asserting string subsequences.

#### Check List:
* Fixes #3159 
* Unit tests : YES
* Javadoc with a code example (on API only) : NO 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

**Description**:

The core assertContainsSubsequence method has undergone a significant overhaul to better cater to a broader range of subsequence scenarios. The driving force behind this refactoring is twofold:

- Enhanced Subsequence Handling:

    The refactoring ensures that the method can adeptly handle cases where there might be duplicate subsequences present. The essence of this handling lies in distinguishing between two different situations:
        Where the actual string contains the subsequence but not as many times as the subsequence array dictates.
        Where the actual string doesn't contain a particular subsequence at all.

- Introduction of handleNotFound Method:

    A fresh method, handleNotFound, has been extracted to specifically address the nuances of missing subsequences. A core task of this new method is:
        To scrutinize whether missing subsequences arise because the actual string didn't cater to the repeated instances as specified by the subsequence array.

- Behavioural Precedence:

In instances where at least one subsequence is completely absent from the actual string, this missing subsequence takes precedence over any discrepancies in the count of other subsequences. As illustrated in the example:
```
String actual = "Yoda";
String[] subsequence = { "Yo", "da", "Han", "Foo" };
```

This will yield the same output as:
```
String actual = "Yoda";
String[] subsequence = { "Yo", "da", "Han", "Foo" , "da"};
```
Even though "da" appears twice in the latter example, the predominant error message would be about the absence of the strings "Han" and "Foo" in the actual string. This decision was made to ensure that the most pertinent errors (complete absence) are flagged prior to counting discrepancies.