### PR TITLE
Add `hasPrecisionOf(int)` assertion for `BigDecimal`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalPrecisionAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalPrecisionAssert.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api;
+
+/**
+ * Base class for {@code BigDecimal} precision assertions.
+ */
+public abstract class AbstractBigDecimalPrecisionAssert<SELF extends AbstractBigDecimalAssert<SELF>>
+    extends AbstractIntegerAssert<AbstractBigDecimalPrecisionAssert<SELF>> {
+
+  protected AbstractBigDecimalPrecisionAssert(Integer actualPrecision, Class<?> selfType) {
+    super(actualPrecision, selfType);
+  }
+
+  /**
+   * Returns to the {@code BigDecimal} on which we ran precision assertions on.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThat(new BigDecimal(&quot;2.313&quot;)).precision()
+   *                                        .isGreaterThan(1)
+   *                                        .isLessThan(5)
+   *                                      .returnToBigDecimal()
+   *                                        .isPositive();</code></pre>
+   *
+   * @return BigDecimal assertions.
+   */
+  public abstract AbstractBigDecimalAssert<SELF> returnToBigDecimal();
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/BigDecimalPrecisionAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BigDecimalPrecisionAssert.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api;
+
+public class BigDecimalPrecisionAssert<T> extends AbstractBigDecimalPrecisionAssert<BigDecimalAssert> {
+
+  private final AbstractBigDecimalAssert<BigDecimalAssert> bigDecimalAssert;
+
+  public BigDecimalPrecisionAssert(AbstractBigDecimalAssert<BigDecimalAssert> bigDecimalAssert) {
+    super(bigDecimalAssert.actual.precision(), BigDecimalPrecisionAssert.class);
+    this.bigDecimalAssert = bigDecimalAssert;
+  }
+
+  @Override
+  public AbstractBigDecimalAssert<BigDecimalAssert> returnToBigDecimal() {
+    return bigDecimalAssert;
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldHavePrecision.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldHavePrecision.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.math.BigDecimal;
+
+public class ShouldHavePrecision extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHavePrecision(BigDecimal actual, int expectedPrecision) {
+    return new ShouldHavePrecision(actual, expectedPrecision);
+  }
+
+  private ShouldHavePrecision(BigDecimal actual, int expectedPrecision) {
+    super("%nExpecting %s to have a precision of:%n" +
+          "  %s%n" +
+          "but had a precision of:%n" +
+          "  %s",
+          actual, expectedPrecision, actual.precision());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalsAssert_assertHasPrecisionOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalsAssert_assertHasPrecisionOf_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.bigdecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHavePrecision.shouldHavePrecision;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+class BigDecimalsAssert_assertHasPrecisionOf_Test {
+
+  @ParameterizedTest
+  @ValueSource(strings = { "0", "-1.01", "1234", "999.00000009" })
+  void should_pass_when_actual_has_expected_precision(String value) {
+    BigDecimal actual = new BigDecimal(value);
+
+    assertThat(actual).hasPrecisionOf(actual.precision());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "1", "0.1234", "123456" })
+  void should_fail_when_actual_does_not_have_expected_precision(String value) {
+    // GIVEN
+    BigDecimal actual = new BigDecimal(value);
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasPrecisionOf(123));
+    // THEN
+    then(assertionError).hasMessage(shouldHavePrecision(actual, 123).create());
+  }
+
+  @Test
+  void should_fail_when_actual_is_null() {
+    // GIVEN
+    BigDecimal actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasPrecisionOf(1));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldHavePrecision_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldHavePrecision_create_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.description.TextDescription;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHavePrecision.shouldHavePrecision;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+class ShouldHavePrecision_create_Test {
+
+  @Test
+  void should_create_error_message_for_big_decimal() {
+    // GIVEN
+    BigDecimal actual = BigDecimal.TEN;
+    // WHEN
+    String message = shouldHavePrecision(actual, 5).create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %nExpecting %s to have a precision of:%n" +
+                                   "  5%n" +
+                                   "but had a precision of:%n" +
+                                   "  %s", actual, actual.precision()));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimalAssert_precision_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/bigdecimals/BigDecimalAssert_precision_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal.bigdecimals;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.BigDecimalAssert;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+class BigDecimalAssert_precision_Test implements NavigationMethodBaseTest<BigDecimalAssert> {
+
+  @Test
+  void should_fail_if_big_decimal_is_null() {
+    // GIVEN
+    BigDecimal bigDecimal = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(bigDecimal).precision());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_big_decimal_does_not_have_expected_precision() {
+    // GIVEN
+    BigDecimal bigDecimal = BigDecimal.TEN;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(bigDecimal).precision().isEqualTo(123));
+    // THEN
+    then(assertionError).hasMessage(format("%nexpected: 123%n but was: 2"));
+  }
+
+  @Test
+  void should_pass_if_big_decimal_has_expected_precision() {
+    // GIVEN
+    BigDecimal bigDecimal = BigDecimal.TEN;
+    // THEN
+    then(bigDecimal).precision()
+                    .isEqualTo(2)
+                    .returnToBigDecimal()
+                    .hasPrecisionOf(2);
+  }
+
+  @Override
+  public BigDecimalAssert getAssertion() {
+    return new BigDecimalAssert(BigDecimal.TEN);
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(BigDecimalAssert assertion) {
+    return assertion.precision();
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes N/A
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

AssertJ provides a `hasScaleOf()` assertion for the `BigDecimal` type.  This PR adds a companion assertion `hasPrecisionOf` for verifying the `BigDecimal.precision()` method. I followed the `hasScaleOf()` implementation and tests in this PR.