### PR TITLE
Remove duplicate maven version

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -344,7 +344,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <excludes>


### PR DESCRIPTION
It's defined in the parent POM already via https://github.com/assertj/assertj/blob/55356a5254e9a50881301bbfaaa32f1a23d1dc2d/assertj-parent/pom.xml#L236-L238