### PR TITLE
Remove default goal

### DIFF
--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -80,7 +80,6 @@
   </dependencyManagement>
 
   <build>
-    <defaultGoal>clean install</defaultGoal>
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
This makes it possible to invoke maven without arguments in the root module.

#### Check List:
* Fixes #3181
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
