### PR TITLE
Disable tests failing on Windows

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
@@ -26,6 +26,8 @@ import java.nio.file.Paths;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
 
@@ -71,6 +73,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
@@ -29,6 +29,8 @@ import java.nio.file.Paths;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertEndsWith_Test extends PathsBaseTest {
 
@@ -88,6 +90,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
 
@@ -54,6 +56,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_a_symbolic_link_and_target_exists() throws IOException {
     // GIVEN
     Path target = createFile(tempDir.resolve("target"));
@@ -63,6 +66,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertExists_Test extends PathsBaseTest {
 
@@ -54,6 +56,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_a_symbolic_link_and_target_exists() throws IOException {
     // GIVEN
     Path target = createFile(tempDir.resolve("target"));
@@ -63,6 +66,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
@@ -25,6 +25,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertHasFileName_Test extends PathsBaseTest {
 
@@ -90,6 +92,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_with_existing_symbolic_link() throws IOException {
     // GIVEN
     Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
 
@@ -54,6 +56,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path root = tempDir.getRoot();

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
@@ -28,6 +28,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertHasNoParent_Test extends PathsBaseTest {
 
@@ -71,6 +73,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path root = tempDir.getRoot();

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertHasParentRaw_Test extends PathsBaseTest {
 
@@ -82,6 +84,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path expected = createDirectory(tempDir.resolve("expected"));
@@ -94,6 +97,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_expected_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
@@ -29,6 +29,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertHasParent_Test extends PathsBaseTest {
 
@@ -113,6 +115,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path expected = createDirectory(tempDir.resolve("expected"));
@@ -123,6 +126,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_expected_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
@@ -28,6 +28,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertIsCanonical_Test extends PathsBaseTest {
 
@@ -53,6 +55,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
@@ -25,6 +25,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
 
@@ -57,6 +59,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_succeed_if_actual_is_a_symbolic_link() throws IOException {
     // GIVEN
     Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir.resolve("target"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
@@ -24,6 +24,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertNotExists_Test extends PathsBaseTest {
 
@@ -54,6 +56,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
 
@@ -71,6 +73,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path other = createDirectory(tempDir.resolve("other"));
@@ -83,6 +86,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_fail_if_other_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
@@ -29,6 +29,8 @@ import java.nio.file.Path;
 
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class Paths_assertStartsWith_Test extends PathsBaseTest {
 
@@ -102,6 +104,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path other = createDirectory(tempDir.resolve("other"));
@@ -112,6 +115,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
   }
 
   @Test
+  @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows due to missing privileges")
   void should_pass_if_other_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));

--- a/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit5_Assertions_To_Assertj_Test.java
+++ b/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit5_Assertions_To_Assertj_Test.java
@@ -18,6 +18,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -27,6 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author XiaoMingZHM, Eveneko
  */
 @DisplayName("Convert JUnit5 assertions to AssertJ")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Executes Linux shell scripts")
 public class Convert_Junit5_Assertions_To_Assertj_Test {
   private ShellScriptInvoker tester;
 

--- a/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit_Assertions_To_Assertj_Test.java
+++ b/assertj-core/src/test/java/org/assertj/scripts/Convert_Junit_Assertions_To_Assertj_Test.java
@@ -18,6 +18,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 
 @DisplayName("Convert JUnit assertions to AssertJ")
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Executes Linux shell scripts")
 public class Convert_Junit_Assertions_To_Assertj_Test {
   private ShellScriptInvoker conversionScriptInvoker;
 


### PR DESCRIPTION
* The conversion shell scripts cannot be executed on Windows.
* Path related tests trying to create symbolic links fail with an exception on Windows, as documented in
java.nio.file.Files.createSymbolicLink(Path, Path, FileAttribute<?>...)

#### Check List:
* Fixes #3183 
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

With this change I can build the complete Maven reactor. Without it, there are around 50 test failures, exactly on the disabled test classes and methods.
