### PR TITLE
Speed up for BinaryDiff used by hasSameBinaryContentAs for example. Fixes #3193.

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/internal/BinaryDiff.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/BinaryDiff.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class BinaryDiff {
 
   @VisibleForTesting
   public BinaryDiffResult diff(Path actual, byte[] expected) throws IOException {
-    try (InputStream actualStream = Files.newInputStream(actual)) {
+    try(InputStream actualStream = new BufferedInputStream(Files.newInputStream(actual))) {
       return diff(actualStream, expected);
     }
   }


### PR DESCRIPTION
#### Check List:
* Fixes #3193
* Unit tests : NA (not added methods, hoping there are unit tests in place already)
* Javadoc with a code example (on API only) : NA (not added a method)
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
