### PR TITLE
Add fail(Throwable) and fail() variants

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -64,6 +64,17 @@ public abstract class AbstractSoftAssertions extends DefaultAssertionErrorCollec
   }
 
   /**
+   * Fails without a message.
+   *
+   * @param <T> dummy return value type
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail()));}.
+   */
+  @CanIgnoreReturnValue
+  public <T> T fail() {
+    return fail((String) null);
+  }
+
+  /**
    * Fails with the given message built like {@link String#format(String, Object...)}.
    *
    * @param <T> dummy return value type
@@ -92,6 +103,18 @@ public abstract class AbstractSoftAssertions extends DefaultAssertionErrorCollec
     error.initCause(realCause);
     collectAssertionError(error);
     return null;
+  }
+
+  /**
+   * Fails with the {@link Throwable} that caused the failure.
+   *
+   * @param <T> dummy return value type
+   * @param realCause cause of the error.
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail(cause)));}.
+   */
+  @CanIgnoreReturnValue
+  public <T> T fail(Throwable realCause) {
+    return fail(null, realCause);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -1819,6 +1819,18 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
+   * Throws an {@link AssertionError} without a message.
+   *
+   * @param <T> dummy return value type
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail()));}.
+   * @throws AssertionError without a message.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail() {
+    return fail((String) null);
+  }
+
+  /**
    * Throws an {@link AssertionError} with the given message built as {@link String#format(String, Object...)}.
    *
    * @param <T> dummy return value type
@@ -1843,6 +1855,18 @@ public class Assertions implements InstanceOfAssertFactories {
   @CanIgnoreReturnValue
   public static <T> T fail(String failureMessage, Throwable realCause) {
     return Fail.fail(failureMessage, realCause);
+  }
+
+  /**
+   * Throws an {@link AssertionError} with the {@link Throwable} that caused the failure.
+   * @param <T> dummy return value type
+   * @param realCause cause of the error.
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail(cause)));}.
+   * @throws AssertionError with the {@link Throwable} that caused the failure.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail(Throwable realCause) {
+    return fail(null, realCause);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -960,6 +960,16 @@ public class AssertionsForClassTypes {
   }
 
   /**
+   * Only delegate to {@link Fail#fail()} so that Assertions offers a full feature entry point to all Assertj
+   * Assert features (but you can use Fail if you prefer).
+   *
+   * @throws AssertionError without a message.
+   */
+  public static void fail() {
+    Fail.fail();
+  }
+
+  /**
    * Only delegate to {@link Fail#fail(String, Throwable)} so that Assertions offers a full feature entry point to all
    * AssertJ features (but you can use Fail if you prefer).
    *
@@ -969,6 +979,17 @@ public class AssertionsForClassTypes {
    */
   public static void fail(String failureMessage, Throwable realCause) {
     Fail.fail(failureMessage, realCause);
+  }
+
+  /**
+   * Only delegate to {@link Fail#fail(Throwable)} so that Assertions offers a full feature entry point to all
+   * AssertJ features (but you can use Fail if you prefer).
+   *
+   * @param realCause cause of the error.
+   * @throws AssertionError with the {@link Throwable} that caused the failure.
+   */
+  public static void fail(Throwable realCause) {
+    Fail.fail(realCause);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -2316,6 +2316,18 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Throws an {@link AssertionError} without a message.
+   *
+   * @param <T> dummy return value type
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail()));}.
+   * @throws AssertionError without a message.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail() {
+    return fail((String) null);
+  }
+
+  /**
    * Throws an {@link AssertionError} with the given message built as {@link String#format(String, Object...)}.
    *
    * @param <T> dummy return value type
@@ -2344,6 +2356,18 @@ public class BDDAssertions extends Assertions {
   @CanIgnoreReturnValue
   public static <T> T fail(String failureMessage, Throwable realCause) {
     return Assertions.fail(failureMessage, realCause);
+  }
+
+  /**
+   * Throws an {@link AssertionError} with the {@link Throwable} that caused the failure.
+   * @param <T> dummy return value type
+   * @param realCause cause of the error.
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail(cause)));}.
+   * @throws AssertionError with the {@link Throwable} that caused the failure.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail(Throwable realCause) {
+    return fail(null, realCause);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/Fail.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Fail.java
@@ -47,6 +47,18 @@ public final class Fail {
   }
 
   /**
+   * Throws an {@link AssertionError} without a message.
+   *
+   * @param <T> dummy return value type
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail()));}.
+   * @throws AssertionError without a message.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail() {
+    return fail((String) null);
+  }
+
+  /**
    * Throws an {@link AssertionError} with the given message built as {@link String#format(String, Object...)}.
    *
    * @param <T> dummy return value type
@@ -74,6 +86,19 @@ public final class Fail {
     AssertionError error = Failures.instance().failure(failureMessage);
     error.initCause(realCause);
     throw error;
+  }
+
+  /**
+   * Throws an {@link AssertionError} with the {@link Throwable} that caused the failure.
+   *
+   * @param <T> dummy return value type
+   * @param realCause cause of the error.
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail(cause)));}.
+   * @throws AssertionError with the {@link Throwable} that caused the failure.
+   */
+  @CanIgnoreReturnValue
+  public static <T> T fail(Throwable realCause) {
+    return fail(null, realCause);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -172,6 +172,18 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
+   * Throws an {@link AssertionError} without a message.
+   *
+   * @param <T> dummy return value type
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail()));}.
+   * @throws AssertionError without a message.
+   */
+  @CanIgnoreReturnValue
+  default <T> T fail() {
+    return fail((String) null);
+  }
+
+  /**
    * Throws an {@link AssertionError} with the given message built as {@link String#format(String, Object...)}.
    *
    * @param <T> dummy return value type
@@ -198,6 +210,19 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   @CanIgnoreReturnValue
   default <T> T fail(final String failureMessage, final Throwable realCause) {
     return Assertions.fail(failureMessage, realCause);
+  }
+
+  /**
+   * Throws an {@link AssertionError} with the {@link Throwable} that caused the failure.
+   *
+   * @param <T> dummy return value type
+   * @param realCause cause of the error.
+   * @return nothing, it's just to be used in {@code doSomething(optional.orElseGet(() -> fail(cause)));}.
+   * @throws AssertionError with the {@link Throwable} that caused the failure.
+   */
+  @CanIgnoreReturnValue
+  default <T> T fail(final Throwable realCause) {
+    return fail(null, realCause);
   }
 
   /**


### PR DESCRIPTION
#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES / NO / NA
* Javadoc with a code example (on API only) : YES / NO / NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

This PR adds `fail(Throwable)` and `fail()` variants similar to JUnit Jupiter's [`Assertions.fail(Throwable)`](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java#L160) and [`Assertions.fail()`](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/main/java/org/junit/jupiter/api/Assertions.java#L118).