### PR TITLE
Add default constructor for `RecursiveComparator`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparator.java
@@ -20,11 +20,8 @@ import java.util.List;
 /**
  * {@code Comparator} comparing objects recursively as in {@link org.assertj.core.api.RecursiveComparisonAssert}.
  * <p>
- * This comparator does not enforce any ordering, it just returns zero if
- * the compared objects are equals according the recursive comparison,
- * or a non-zero value otherwise.
- * <p>
- * This comparator honors the {@link RecursiveComparisonConfiguration} passed at construction time.
+ * This comparator does not enforce any ordering and returns zero if the compared objects are equals,
+ * according to the recursive comparison, or a non-zero value otherwise.
  *
  * @since 3.24.0
  */
@@ -34,10 +31,21 @@ public class RecursiveComparator implements Comparator<Object> {
   private final RecursiveComparisonDifferenceCalculator recursiveComparisonDifferenceCalculator;
 
   /**
-   * Returns a new {@code RecursiveComparator} that uses the given {@link RecursiveComparisonConfiguration} when comparing
-   * objects with the recursive comparison.
+   * Returns a new {@code RecursiveComparator} that uses the default {@link RecursiveComparisonConfiguration}
+   * when comparing objects with the recursive comparison.
    *
-   * @param recursiveComparisonConfiguration the used {@code RecursiveComparisonConfiguration}
+   * @since 3.25.0
+   */
+  public RecursiveComparator() {
+    this.recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
+    this.recursiveComparisonDifferenceCalculator = new RecursiveComparisonDifferenceCalculator();
+  }
+
+  /**
+   * Returns a new {@code RecursiveComparator} that uses the given {@link RecursiveComparisonConfiguration}
+   * when comparing objects with the recursive comparison.
+   *
+   * @param recursiveComparisonConfiguration the {@code RecursiveComparisonConfiguration} instance to be used
    */
   public RecursiveComparator(RecursiveComparisonConfiguration recursiveComparisonConfiguration) {
     this.recursiveComparisonConfiguration = recursiveComparisonConfiguration;
@@ -46,6 +54,11 @@ public class RecursiveComparator implements Comparator<Object> {
 
   private List<ComparisonDifference> determineDifferencesWith(Object actual, Object expected) {
     return recursiveComparisonDifferenceCalculator.determineDifferences(actual, expected, recursiveComparisonConfiguration);
+  }
+
+  public String getDescription() {
+    return format("RecursiveComparator a comparator based on the recursive comparison with the following configuration:%n%s",
+                  recursiveComparisonConfiguration);
   }
 
   /**
@@ -61,11 +74,6 @@ public class RecursiveComparator implements Comparator<Object> {
     if (actual != null && other != null) return determineDifferencesWith(actual, other).size();
     // either actual or other is null but not both => can't be equal
     return -1;
-  }
-
-  public String getDescription() {
-    return format("RecursiveComparator a comparator based on the recursive comparison with the following configuration:%n%s",
-                  recursiveComparisonConfiguration);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparator_constructor_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparator_constructor_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparator_constructor_Test {
+
+  @Test
+  void default_constructor_should_use_default_configuration() {
+    // WHEN
+    RecursiveComparator recursiveComparator = new RecursiveComparator();
+    // THEN
+    then(recursiveComparator).extracting("recursiveComparisonConfiguration")
+                             .isEqualTo(new RecursiveComparisonConfiguration());
+  }
+
+  @Test
+  void constructor_with_configuration_should_use_given_configuration() {
+    // GIVEN
+    RecursiveComparisonConfiguration configuration = new RecursiveComparisonConfiguration();
+    // WHEN
+    RecursiveComparator recursiveComparator = new RecursiveComparator(configuration);
+    // THEN
+    then(recursiveComparator).extracting("recursiveComparisonConfiguration")
+                             .isSameAs(configuration);
+  }
+
+}


### PR DESCRIPTION
This allows a simpler creation of a `RecursiveComparator` instance for cases where a custom `RecursiveComparisonConfiguration` is not required.

Originally inspired by https://stackoverflow.com/questions/77151593.