### PR TITLE
Move Javadoc generation to separate job

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -23,4 +23,4 @@ jobs:
           release: ${{ matrix.java }}
           version: latest
       - name: Test
-        run: ./mvnw $MAVEN_ARGS verify javadoc:javadoc
+        run: ./mvnw $MAVEN_ARGS verify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,14 @@ env:
 jobs:
 
   test_os:
+
     name: OS ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java
@@ -23,9 +25,26 @@ jobs:
           java-version: 17
           cache: 'maven'
       - name: Test
-        run: ./mvnw $MAVEN_ARGS verify javadoc:javadoc
+        run: ./mvnw $MAVEN_ARGS verify
+
+  javadoc:
+
+    name: Javadoc
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: maven
+      - name: Generate Javadoc
+        run: ./mvnw $MAVEN_ARGS -DskipTests package javadoc:javadoc
 
   sonar:
+
     name: Sonar code analysis
     runs-on: ubuntu-latest
     if: github.repository == 'assertj/assertj' && github.event_name == 'push'
@@ -42,7 +61,7 @@ jobs:
           cache: 'maven'
       - name: Test with Sonar
         run: >
-          ./mvnw $MAVEN_ARGS verify javadoc:javadoc sonar:sonar
+          ./mvnw $MAVEN_ARGS verify sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=assertj
           -Dsonar.projectKey=joel-costigliola_assertj-core


### PR DESCRIPTION
Currently, most of the jobs are failing due to maxcellent/javadoc.io#180.

This change isolates the Javadoc generation into a separate job so that the unavailability of [javadoc.io](https://javadoc.io) doesn't cause other jobs to fail.