### PR TITLE
Make it clear for java classes recursive comparison

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -362,8 +362,17 @@ public class RecursiveComparisonDifferenceCalculator {
         continue;
       }
 
-      if (shouldHonorEquals(dualValue, recursiveComparisonConfiguration)) {
-        if (!actualFieldValue.equals(expectedFieldValue)) comparisonState.addDifference(dualValue);
+      boolean shouldHonorJavaTypeEquals = dualValue.hasSomeJavaTypeValue() && !dualValue.isExpectedAContainer();
+      boolean shouldHonorOverriddenEquals = shouldHonorOverriddenEquals(dualValue, recursiveComparisonConfiguration);
+
+      if (shouldHonorJavaTypeEquals || shouldHonorOverriddenEquals) {
+        if (!actualFieldValue.equals(expectedFieldValue)) {
+          String description =
+            shouldHonorJavaTypeEquals ?
+              "Comparison objects are of Java types and were then compared with equals method" :
+              "Comparison objects were compared with equals method";
+          comparisonState.addDifference(dualValue, description);
+          }
         continue;
       }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -367,12 +367,11 @@ public class RecursiveComparisonDifferenceCalculator {
 
       if (shouldHonorJavaTypeEquals || shouldHonorOverriddenEquals) {
         if (!actualFieldValue.equals(expectedFieldValue)) {
-          String description =
-            shouldHonorJavaTypeEquals ?
-              "Comparison objects are of Java types and were then compared with equals method" :
-              "Comparison objects were compared with equals method";
+          String description = shouldHonorJavaTypeEquals
+              ? "Comparison objects are of Java types and were then compared with equals method"
+              : "Comparison objects were compared with equals method";
           comparisonState.addDifference(dualValue, description);
-          }
+        }
         continue;
       }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_Test.java
@@ -114,7 +114,8 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference numberDifference = diff("home.address.number", actual.home.address.number, expected.home.address.number);
+    ComparisonDifference numberDifference = diff("home.address.number", actual.home.address.number, expected.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, numberDifference);
   }
 
@@ -138,7 +139,8 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference nameDifference = diff("name", actual.name, expected.name);
+    ComparisonDifference nameDifference = diff("name", actual.name, expected.name,
+                                               "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, nameDifference);
   }
 
@@ -152,8 +154,10 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference nameDifference = diff("name", actual.name, expected.name);
-    ComparisonDifference numberDifference = diff("home.address.number", actual.home.address.number, expected.home.address.number);
+    ComparisonDifference nameDifference = diff("name", actual.name, expected.name,
+                                               "Comparison objects are of Java types and were then compared with equals method");
+    ComparisonDifference numberDifference = diff("home.address.number", actual.home.address.number, expected.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, numberDifference, nameDifference);
   }
 
@@ -290,7 +294,8 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference friendNumberDifference = diff("friends[0].home.address.number", 99, 10);
+    ComparisonDifference friendNumberDifference = diff("friends[0].home.address.number", 99, 10,
+                                                       "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, friendNumberDifference);
   }
 
@@ -391,8 +396,10 @@ class RecursiveComparisonAssert_isEqualTo_Test extends RecursiveComparisonAssert
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference difference1 = diff("_children.importantValue._value", "10", "1");
-    ComparisonDifference difference2 = diff("_children.someNotImportantValue._value", 1, 10);
+    ComparisonDifference difference1 = diff("_children.importantValue._value", "10", "1",
+                                            "Comparison objects are of Java types and were then compared with equals method");
+    ComparisonDifference difference2 = diff("_children.someNotImportantValue._value", 1, 10,
+                                            "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, difference1, difference2);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
@@ -123,16 +123,17 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
   }
 
   private static Stream<Arguments> failComparingTopLevelFields() {
-    return Stream.of(arguments(billie, john, types(String.class), "different name", array(diff("name", billie.name, john.name))),
+    String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
+    return Stream.of(arguments(billie, john, types(String.class), "different name", array(diff("name", billie.name, john.name, javaComparisonInformation))),
                      arguments(billie, anotherBillie, types(OptionalInt.class, OptionalDouble.class), "different age and weight",
-                               array(diff("age", billie.age, anotherBillie.age),
-                                     diff("weight", billie.weight, anotherBillie.weight))),
+                               array(diff("age", billie.age, anotherBillie.age, javaComparisonInformation),
+                                     diff("weight", billie.weight, anotherBillie.weight, javaComparisonInformation))),
                      arguments(john, jill, types(Person.class),
                                "different neighbour.name, neighbour.age and neighbour.home.address.number",
-                               array(diff("neighbour.age", john.neighbour.age, jill.neighbour.age),
+                               array(diff("neighbour.age", john.neighbour.age, jill.neighbour.age, javaComparisonInformation),
                                      diff("neighbour.home.address.number", john.neighbour.home.address.number,
-                                          jill.neighbour.home.address.number),
-                                     diff("neighbour.name", john.neighbour.name, jill.neighbour.name))));
+                                          jill.neighbour.home.address.number, javaComparisonInformation),
+                                     diff("neighbour.name", john.neighbour.name, jill.neighbour.name, javaComparisonInformation))));
   }
 
   @Test
@@ -151,8 +152,14 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     AssertionError assertionError = compareRecursivelyFailsAsExpected(billie, anotherBillie);
     // THEN
-    ComparisonDifference ageDifference = diff("age", billie.age, anotherBillie.age);
-    ComparisonDifference weightDifference = diff("weight", billie.weight, anotherBillie.weight);
+    ComparisonDifference ageDifference = diff("age",
+                                              billie.age,
+                                              anotherBillie.age,
+                                              "Comparison objects are of Java types and were then compared with equals method");
+    ComparisonDifference weightDifference = diff("weight",
+                                                  billie.weight,
+                                                  anotherBillie.weight,
+                                                  "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(billie, anotherBillie, ageDifference, weightDifference);
   }
 
@@ -173,7 +180,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     compareRecursivelyFailsAsExpected(john, jill);
     // THEN
-    ComparisonDifference idDifference = diff("name", john.name, jill.name);
+    ComparisonDifference idDifference = diff("name",
+                                             john.name,
+                                             jill.name,
+                                             "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(john, jill, idDifference);
   }
 
@@ -194,7 +204,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     compareRecursivelyFailsAsExpected(john, jill);
     // THEN
-    ComparisonDifference nameDifference = diff("name", john.name, jill.name);
+    ComparisonDifference nameDifference = diff("name",
+                                               john.name,
+                                               jill.name,
+                                               "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(john, jill, nameDifference);
   }
 
@@ -216,7 +229,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     compareRecursivelyFailsAsExpected(billie, anotherBillie);
     // THEN
-    ComparisonDifference weightDifference = diff("weight", billie.weight, anotherBillie.weight);
+    ComparisonDifference weightDifference = diff("weight",
+                                                 billie.weight,
+                                                 anotherBillie.weight,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(billie, anotherBillie, weightDifference);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
@@ -124,7 +124,8 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
 
   private static Stream<Arguments> failComparingTopLevelFields() {
     String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
-    return Stream.of(arguments(billie, john, types(String.class), "different name", array(diff("name", billie.name, john.name, javaComparisonInformation))),
+    return Stream.of(arguments(billie, john, types(String.class), "different name",
+                               array(diff("name", billie.name, john.name, javaComparisonInformation))),
                      arguments(billie, anotherBillie, types(OptionalInt.class, OptionalDouble.class), "different age and weight",
                                array(diff("age", billie.age, anotherBillie.age, javaComparisonInformation),
                                      diff("weight", billie.weight, anotherBillie.weight, javaComparisonInformation))),
@@ -133,7 +134,8 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
                                array(diff("neighbour.age", john.neighbour.age, jill.neighbour.age, javaComparisonInformation),
                                      diff("neighbour.home.address.number", john.neighbour.home.address.number,
                                           jill.neighbour.home.address.number, javaComparisonInformation),
-                                     diff("neighbour.name", john.neighbour.name, jill.neighbour.name, javaComparisonInformation))));
+                                     diff("neighbour.name", john.neighbour.name, jill.neighbour.name,
+                                          javaComparisonInformation))));
   }
 
   @Test
@@ -157,9 +159,9 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
                                               anotherBillie.age,
                                               "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference weightDifference = diff("weight",
-                                                  billie.weight,
-                                                  anotherBillie.weight,
-                                                  "Comparison objects are of Java types and were then compared with equals method");
+                                                 billie.weight,
+                                                 anotherBillie.weight,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(billie, anotherBillie, ageDifference, weightDifference);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test.java
@@ -20,7 +20,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
-
 import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
 import org.assertj.core.internal.objects.data.Home;
 import org.assertj.core.internal.objects.data.Person;
@@ -262,7 +261,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     compareRecursivelyFailsAsExpected(sherlock, moriarty);
     // THEN
-    ComparisonDifference streetNumberDifference = diff("home.address.number", 221, 222);
+    ComparisonDifference streetNumberDifference = diff("home.address.number",
+                                                       221,
+                                                       222,
+                                                       "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(sherlock, moriarty, streetNumberDifference);
 
   }
@@ -276,7 +278,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFieldsOfTypes_Test extend
     // WHEN
     compareRecursivelyFailsAsExpected(lassie, snoopy);
     // THEN
-    ComparisonDifference weightDifference = diff("breed.name", lassie.breed.name, snoopy.breed.name);
+    ComparisonDifference weightDifference = diff("breed.name",
+                                                 lassie.breed.name,
+                                                 snoopy.breed.name,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(lassie, snoopy, weightDifference);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
@@ -114,9 +114,9 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
 
     // THEN
     ComparisonDifference dateOfBirthDifference = diff("dateOfBirth",
-                                                       actual.dateOfBirth,
-                                                       expected.dateOfBirth,
-                                                       "Comparison objects are of Java types and were then compared with equals method");
+                                                      actual.dateOfBirth,
+                                                      expected.dateOfBirth,
+                                                      "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference neighbourNameDifference = diff("neighbour.name",
                                                         actual.neighbour.name,
                                                         expected.neighbour.name,

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
@@ -113,11 +113,18 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth", actual.dateOfBirth, expected.dateOfBirth);
-    ComparisonDifference neighbourNameDifference = diff("neighbour.name", actual.neighbour.name, expected.neighbour.name);
+    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth",
+                                                       actual.dateOfBirth,
+                                                       expected.dateOfBirth,
+                                                       "Comparison objects are of Java types and were then compared with equals method");
+    ComparisonDifference neighbourNameDifference = diff("neighbour.name",
+                                                        actual.neighbour.name,
+                                                        expected.neighbour.name,
+                                                        "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference numberDifference = diff("neighbour.neighbour.home.address.number",
                                                  actual.neighbour.neighbour.home.address.number,
-                                                 expected.neighbour.neighbour.home.address.number);
+                                                 expected.neighbour.neighbour.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               dateOfBirthDifference, neighbourNameDifference, numberDifference);
   }
@@ -216,11 +223,17 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     recursiveComparisonConfiguration.compareOnlyFields("deleted");
     // THEN
     compareRecursivelyFailsAsExpected(staffWithLessFields, staff);
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(staffWithLessFields, staff,
-                                                              diff("deleted", staffWithLessFields.deleted, staff.deleted));
+    ComparisonDifference differenceWithFirst = diff("deleted",
+                                                    staffWithLessFields.deleted,
+                                                    staff.deleted,
+                                                    "Comparison objects are of Java types and were then compared with equals method");
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(staffWithLessFields, staff, differenceWithFirst);
     compareRecursivelyFailsAsExpected(staff, staffWithLessFields);
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(staff, staffWithLessFields,
-                                                              diff("deleted", staff.deleted, staffWithLessFields.deleted));
+    ComparisonDifference differenceWithLast = diff("deleted",
+                                                   staff.deleted,
+                                                   staffWithLessFields.deleted,
+                                                   "Comparison objects are of Java types and were then compared with equals method");
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(staff, staffWithLessFields, differenceWithLast);
   }
 
   // https://github.com/assertj/assertj/issues/2610
@@ -249,7 +262,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference difference = diff("a", actual.a, expected.a);
+    ComparisonDifference difference = diff("a",
+                                           actual.a,
+                                           expected.a,
+                                           "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, difference);
   }
 
@@ -271,7 +287,10 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     Student john2 = new Student("John", "math", 1);
     Student rohit = new Student("Rohit", "english", 2);
     Student rohyt = new Student("Rohyt", "english", 2);
-    ComparisonDifference difference = diff("[1].name", "Rohit", "Rohyt");
+    ComparisonDifference difference = diff("[1].name",
+                                           "Rohit",
+                                           "Rohyt",
+                                           "Comparison objects are of Java types and were then compared with equals method");
     return Stream.of(arguments(list(john1, rohit), list(john2, rohyt), difference),
                      arguments(array(john1, rohit), array(john2, rohyt), difference),
                      arguments(set(john1, rohit), set(john2, rohyt), difference));
@@ -342,8 +361,14 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference difference1 = diff("[0].neighbour.neighbour.name", "John", "Jack");
-    ComparisonDifference difference2 = diff("[1].neighbour.neighbour.name", "Alice", "Joan");
+    ComparisonDifference difference1 = diff("[0].neighbour.neighbour.name",
+                                            "John",
+                                            "Jack",
+                                            "Comparison objects are of Java types and were then compared with equals method");
+    ComparisonDifference difference2 = diff("[1].neighbour.neighbour.name",
+                                            "Alice",
+                                            "Joan",
+                                            "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, difference1, difference2);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -96,7 +96,8 @@ class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2));
+    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2),
+                                                                         "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, comparisonDifference);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
@@ -170,7 +170,8 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2));
+    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2),
+                                                                         "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, comparisonDifference);
   }
 
@@ -187,7 +188,8 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2));
+    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2),
+                                                                         "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, comparisonDifference);
   }
 
@@ -206,7 +208,8 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2));
+    ComparisonDifference comparisonDifference = new ComparisonDifference(new DualValue(list("home.address.number"), 1, 2),
+                                                                         "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, comparisonDifference);
   }
 
@@ -313,11 +316,19 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth", actual.dateOfBirth, expected.dateOfBirth);
-    ComparisonDifference neighbourNameDifference = diff("neighbour.name", actual.neighbour.name, expected.neighbour.name);
+    String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
+    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth",
+                                                      actual.dateOfBirth,
+                                                      expected.dateOfBirth,
+                                                      javaComparisonInformation);
+    ComparisonDifference neighbourNameDifference = diff("neighbour.name",
+                                                        actual.neighbour.name,
+                                                        expected.neighbour.name,
+                                                        javaComparisonInformation);
     ComparisonDifference numberDifference = diff("neighbour.neighbour.home.address.number",
                                                  actual.neighbour.neighbour.home.address.number,
-                                                 expected.neighbour.neighbour.home.address.number);
+                                                 expected.neighbour.neighbour.home.address.number,
+                                                 javaComparisonInformation);
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               dateOfBirthDifference, neighbourNameDifference, numberDifference);
   }
@@ -408,10 +419,14 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth", actual.dateOfBirth, expected.dateOfBirth);
+    ComparisonDifference dateOfBirthDifference = diff("dateOfBirth",
+                                                      actual.dateOfBirth,
+                                                      expected.dateOfBirth,
+                                                      "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference neighbourDateOfBirthDifference = diff("neighbour.dateOfBirth",
                                                                actual.neighbour.dateOfBirth,
-                                                               expected.neighbour.dateOfBirth);
+                                                               expected.neighbour.dateOfBirth,
+                                                               "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               dateOfBirthDifference, neighbourDateOfBirthDifference);
   }
@@ -490,7 +505,8 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends RecursiveC
     ComparisonDifference addressDifference = diff("home.address", actual.home.address, expected.home.address);
     ComparisonDifference neighbourDateOfBirthDifference = diff("neighbour.neighbour.dateOfBirth",
                                                                actual.neighbour.neighbour.dateOfBirth,
-                                                               expected.neighbour.neighbour.dateOfBirth);
+                                                               expected.neighbour.neighbour.dateOfBirth,
+                                                               "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               addressDifference, neighbourDateOfBirthDifference);
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test.java
@@ -126,10 +126,14 @@ class RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference neighbourNameDifference = diff("neighbour.name", actual.neighbour.name, expected.neighbour.name);
+    ComparisonDifference neighbourNameDifference = diff("neighbour.name",
+                                                        actual.neighbour.name,
+                                                        expected.neighbour.name,
+                                                        "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference numberDifference = diff("neighbour.home.address.number",
                                                  actual.neighbour.home.address.number,
-                                                 expected.neighbour.home.address.number);
+                                                 expected.neighbour.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, numberDifference, neighbourNameDifference);
   }
 
@@ -200,10 +204,14 @@ class RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference neighbourNameDifference = diff("neighbour.name", actual.neighbour.name, expected.neighbour.name);
+    ComparisonDifference neighbourNameDifference = diff("neighbour.name",
+                                                        actual.neighbour.name,
+                                                        expected.neighbour.name,
+                                                        "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference numberDifference = diff("neighbour.home.address.number",
                                                  actual.neighbour.home.address.number,
-                                                 expected.neighbour.home.address.number);
+                                                 expected.neighbour.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, numberDifference, neighbourNameDifference);
   }
 
@@ -271,10 +279,14 @@ class RecursiveComparisonAssert_isEqualTo_ignoringOverriddenEquals_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference neighbourNameDifference = diff("neighbour.name", actual.neighbour.name, expected.neighbour.name);
+    ComparisonDifference neighbourNameDifference = diff("neighbour.name",
+                                                        actual.neighbour.name,
+                                                        expected.neighbour.name,
+                                                        "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference numberDifference = diff("neighbour.home.address.number",
                                                  actual.neighbour.home.address.number,
-                                                 expected.neighbour.home.address.number);
+                                                 expected.neighbour.home.address.number,
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, numberDifference, neighbourNameDifference);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
@@ -28,11 +28,10 @@ class RecursiveComparisonAssert_isEqualTo_java_objects_Test extends RecursiveCom
     IntSummaryStatistics statistics1 = new IntSummaryStatistics();
     IntSummaryStatistics statistics2 = new IntSummaryStatistics();
 
-    ThrowableAssert.ThrowingCallable equalComparison =
-      () -> assertThat(statistics1).usingRecursiveComparison().isEqualTo(statistics2);
+    ThrowableAssert.ThrowingCallable equalComparison = () -> assertThat(statistics1).usingRecursiveComparison()
+                                                                                    .isEqualTo(statistics2);
     AssertionError assertionError = expectAssertionError(equalComparison);
 
-    assertThat(assertionError.getMessage())
-      .contains("Comparison objects are of Java types and were then compared with equals method");
+    assertThat(assertionError.getMessage()).contains("Comparison objects are of Java types and were then compared with equals method");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
@@ -25,13 +25,16 @@ class RecursiveComparisonAssert_isEqualTo_java_objects_Test extends RecursiveCom
   @Test
   void should_describe_cause_of_equals_use() {
 
+    // GIVEN two equal values of a type from a java package
     IntSummaryStatistics statisticsActual = new IntSummaryStatistics();
     IntSummaryStatistics statisticsExpected = new IntSummaryStatistics();
 
+    // WHEN recursive comparison is called
     ThrowableAssert.ThrowingCallable equalComparison = () -> assertThat(statisticsActual).usingRecursiveComparison()
                                                                                          .isEqualTo(statisticsExpected);
     AssertionError assertionError = expectAssertionError(equalComparison);
 
+    // THEN additional information explains how was the comparison done
     assertThat(assertionError.getMessage()).contains("Comparison objects are of Java types and were then compared with equals method");
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
@@ -25,11 +25,11 @@ class RecursiveComparisonAssert_isEqualTo_java_objects_Test extends RecursiveCom
   @Test
   void should_describe_cause_of_equals_use() {
 
-    IntSummaryStatistics statistics1 = new IntSummaryStatistics();
-    IntSummaryStatistics statistics2 = new IntSummaryStatistics();
+    IntSummaryStatistics statisticsActual = new IntSummaryStatistics();
+    IntSummaryStatistics statisticsExpected = new IntSummaryStatistics();
 
-    ThrowableAssert.ThrowingCallable equalComparison = () -> assertThat(statistics1).usingRecursiveComparison()
-                                                                                    .isEqualTo(statistics2);
+    ThrowableAssert.ThrowingCallable equalComparison = () -> assertThat(statisticsActual).usingRecursiveComparison()
+                                                                                         .isEqualTo(statisticsExpected);
     AssertionError assertionError = expectAssertionError(equalComparison);
 
     assertThat(assertionError.getMessage()).contains("Comparison objects are of Java types and were then compared with equals method");

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_java_objects_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.IntSummaryStatistics;
+import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparisonAssert_isEqualTo_java_objects_Test extends RecursiveComparisonAssert_isEqualTo_BaseTest {
+
+  @Test
+  void should_describe_cause_of_equals_use() {
+
+    IntSummaryStatistics statistics1 = new IntSummaryStatistics();
+    IntSummaryStatistics statistics2 = new IntSummaryStatistics();
+
+    ThrowableAssert.ThrowingCallable equalComparison =
+      () -> assertThat(statistics1).usingRecursiveComparison().isEqualTo(statistics2);
+    AssertionError assertionError = expectAssertionError(equalComparison);
+
+    assertThat(assertionError.getMessage())
+      .contains("Comparison objects are of Java types and were then compared with equals method");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test.java
@@ -86,10 +86,12 @@ class RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference phoneDifference = diff("phone.value", actual.phone.get(), expected.phone.get());
+    ComparisonDifference phoneDifference = diff("phone.value", actual.phone.get(), expected.phone.get(),
+                                                "Comparison objects are of Java types and were then compared with equals method");
     ComparisonDifference neighbourDateOfBirthDifference = diff("neighbour.dateOfBirth",
                                                                actual.neighbour.dateOfBirth,
-                                                               expected.neighbour.dateOfBirth);
+                                                               expected.neighbour.dateOfBirth,
+                                                               "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, neighbourDateOfBirthDifference, phoneDifference);
   }
 
@@ -316,7 +318,8 @@ class RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test
     compareRecursivelyFailsAsExpected(actual, expected);
 
     // THEN
-    ComparisonDifference valuesDifference = diff("values[1]", "B", "C");
+    ComparisonDifference valuesDifference = diff("values[1]", "B", "C",
+                                                 "Comparison objects are of Java types and were then compared with equals method");
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, valuesDifference);
 
     // Note that this succeeds when it should not:

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_arrays_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_arrays_Test.java
@@ -69,7 +69,7 @@ class RecursiveComparisonAssert_isEqualTo_with_arrays_Test extends RecursiveComp
     Author none = null;
     return Stream.of(Arguments.of(array(pratchett), array(georgeMartin),
                                   list("group", "[0]", "name"), "Terry Pratchett", "George Martin",
-                                  null),
+                                  "Comparison objects are of Java types and were then compared with equals method"),
                      Arguments.of(array(pratchett, georgeMartin), array(pratchett),
                                   list("group"), array(pratchett, georgeMartin), array(pratchett),
                                   "actual and expected values are arrays of different size, actual size=2 when expected size=1"),

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_iterables_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_iterables_Test.java
@@ -73,9 +73,12 @@ class RecursiveComparisonAssert_isEqualTo_with_iterables_Test extends RecursiveC
                                   diff("", actualAsIterable, expectAsIterable,
                                        format("The following expected elements were not matched in the actual HashSet:%n"
                                               + "  [PersonDto [name=Sheldon, home=HomeDto [address=AddressDto [number=1]]]]"))),
-                     Arguments.of(actualAsArray, expectedAsArray, diff("[0]", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
-                     Arguments.of(actualAsOptional, expectedAsOptional, diff("value", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
-                     Arguments.of(actualAsMap, expectedAsMap, diff("sheldon", sheldon, sheldonDto, overriddenEqualsComparisonInformation)));
+                     Arguments.of(actualAsArray, expectedAsArray,
+                                  diff("[0]", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
+                     Arguments.of(actualAsOptional, expectedAsOptional,
+                                  diff("value", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
+                     Arguments.of(actualAsMap, expectedAsMap,
+                                  diff("sheldon", sheldon, sheldonDto, overriddenEqualsComparisonInformation)));
   }
 
   @ParameterizedTest(name = "author 1 {0} / author 2 {1}")

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_iterables_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_iterables_Test.java
@@ -68,13 +68,14 @@ class RecursiveComparisonAssert_isEqualTo_with_iterables_Test extends RecursiveC
     Optional<PersonDto> expectedAsOptional = Optional.of(sheldonDto);
     Map<String, PersonDto> expectedAsMap = newHashMap("sheldon", sheldonDto);
     Map<String, Person> actualAsMap = newHashMap("sheldon", sheldon);
+    String overriddenEqualsComparisonInformation = "Comparison objects were compared with equals method";
     return Stream.of(Arguments.of(actualAsIterable, expectAsIterable,
                                   diff("", actualAsIterable, expectAsIterable,
                                        format("The following expected elements were not matched in the actual HashSet:%n"
                                               + "  [PersonDto [name=Sheldon, home=HomeDto [address=AddressDto [number=1]]]]"))),
-                     Arguments.of(actualAsArray, expectedAsArray, diff("[0]", sheldon, sheldonDto)),
-                     Arguments.of(actualAsOptional, expectedAsOptional, diff("value", sheldon, sheldonDto)),
-                     Arguments.of(actualAsMap, expectedAsMap, diff("sheldon", sheldon, sheldonDto)));
+                     Arguments.of(actualAsArray, expectedAsArray, diff("[0]", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
+                     Arguments.of(actualAsOptional, expectedAsOptional, diff("value", sheldon, sheldonDto, overriddenEqualsComparisonInformation)),
+                     Arguments.of(actualAsMap, expectedAsMap, diff("sheldon", sheldon, sheldonDto, overriddenEqualsComparisonInformation)));
   }
 
   @ParameterizedTest(name = "author 1 {0} / author 2 {1}")
@@ -143,7 +144,9 @@ class RecursiveComparisonAssert_isEqualTo_with_iterables_Test extends RecursiveC
     Author none = null;
     Set<Author> pratchettHashSet = newHashSet(pratchett);
     List<Author> pratchettList = list(pratchett);
-    return Stream.of(Arguments.of(pratchettList, list(georgeMartin), "group[0].name", "Terry Pratchett", "George Martin", null),
+    String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
+    return Stream.of(Arguments.of(pratchettList, list(georgeMartin), "group[0].name",
+                                  "Terry Pratchett", "George Martin", javaComparisonInformation),
                      Arguments.of(list(pratchett, georgeMartin), pratchettList, "group",
                                   list(pratchett, georgeMartin), pratchettList,
                                   "actual and expected values are collections of different size, actual size=2 when expected size=1"),
@@ -153,7 +156,7 @@ class RecursiveComparisonAssert_isEqualTo_with_iterables_Test extends RecursiveC
                      Arguments.of(pratchettHashSet, pratchettList, "group", pratchettHashSet, pratchettList,
                                   "expected field is an ordered collection but actual field is not (java.util.HashSet), ordered collections are: [java.util.List, java.util.SortedSet, java.util.LinkedHashSet]"),
                      Arguments.of(authorsTreeSet(pratchett), authorsTreeSet(georgeMartin), "group[0].name",
-                                  "Terry Pratchett", "George Martin", null),
+                                  "Terry Pratchett", "George Martin", javaComparisonInformation),
                      Arguments.of(newHashSet(pratchett, georgeMartin), pratchettHashSet, "group",
                                   newHashSet(pratchett, georgeMartin), pratchettHashSet,
                                   "actual and expected values are collections of different size, actual size=2 when expected size=1"),

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_java_types_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_java_types_Test.java
@@ -90,7 +90,9 @@ class RecursiveComparisonAssert_isEqualTo_with_java_types_Test extends Recursive
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff("value.value", "test1", "test2"));
+    ComparisonDifference diff = diff("value.value", "test1", "test2",
+                                     "Comparison objects are of Java types and were then compared with equals method");
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff);
   }
 
   @Test
@@ -101,7 +103,9 @@ class RecursiveComparisonAssert_isEqualTo_with_java_types_Test extends Recursive
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff("value", "test1", "test2"));
+    ComparisonDifference diff = diff("value", "test1", "test2",
+                                     "Comparison objects are of Java types and were then compared with equals method");
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff);
   }
 
   @Test
@@ -114,7 +118,9 @@ class RecursiveComparisonAssert_isEqualTo_with_java_types_Test extends Recursive
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff("value", actualLock, expectedLock));
+    ComparisonDifference diff = diff("value", actualLock, expectedLock,
+                                     "Comparison objects are of Java types and were then compared with equals method");
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff);
   }
 
   static class Wrapper {

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_optional_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_optional_Test.java
@@ -47,33 +47,35 @@ class RecursiveComparisonAssert_isEqualTo_with_optional_Test extends RecursiveCo
   @ParameterizedTest(name = "author 1 {0} / author 2 {1} / path {2} / value 1 {3}/ value 2 {4}")
   @MethodSource("differentBookWithOptionalCoAuthors")
   void should_fail_when_comparing_different_optional_fields(BookWithOptionalCoAuthor actual,
-                                                            BookWithOptionalCoAuthor expected, String path, Object value1,
-                                                            Object value2) {
+                                                            BookWithOptionalCoAuthor expected,
+                                                            ComparisonDifference diff) {
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
-    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff(path, value1, value2));
+    verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected, diff);
   }
 
   private static Stream<Arguments> differentBookWithOptionalCoAuthors() {
     BookWithOptionalCoAuthor pratchett = new BookWithOptionalCoAuthor("Terry Pratchett");
     BookWithOptionalCoAuthor georgeMartin = new BookWithOptionalCoAuthor("George Martin");
 
+    String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
+
     return Stream.of(Arguments.of(pratchett, georgeMartin,
-                                  "coAuthor.value.name", "Terry Pratchett", "George Martin"),
+                                  diff("coAuthor.value.name", "Terry Pratchett", "George Martin", javaComparisonInformation)),
                      Arguments.of(pratchett, new BookWithOptionalCoAuthor(null),
-                                  "coAuthor", Optional.of(new Author("Terry Pratchett")), Optional.empty()),
+                                  diff("coAuthor", Optional.of(new Author("Terry Pratchett")), Optional.empty())),
                      Arguments.of(new BookWithOptionalCoAuthor(null), pratchett,
-                                  "coAuthor", Optional.empty(), Optional.of(new Author("Terry Pratchett"))),
+                                  diff("coAuthor", Optional.empty(), Optional.of(new Author("Terry Pratchett")))),
                      Arguments.of(new BookWithOptionalCoAuthor("Terry Pratchett", 1, 2L, 3.0),
                                   new BookWithOptionalCoAuthor("Terry Pratchett", 2, 2L, 3.0),
-                                  "numberOfPages", OptionalInt.of(1), OptionalInt.of(2)),
+                                  diff("numberOfPages", OptionalInt.of(1), OptionalInt.of(2), javaComparisonInformation)),
                      Arguments.of(new BookWithOptionalCoAuthor("Terry Pratchett", 1, 2L, 3.0),
                                   new BookWithOptionalCoAuthor("Terry Pratchett", 1, 4L, 3.0),
-                                  "bookId", OptionalLong.of(2L), OptionalLong.of(4L)),
+                                  diff("bookId", OptionalLong.of(2L), OptionalLong.of(4L), javaComparisonInformation)),
                      Arguments.of(new BookWithOptionalCoAuthor("Terry Pratchett", 1, 2L, 3.0),
                                   new BookWithOptionalCoAuthor("Terry Pratchett", 1, 2L, 6.0),
-                                  "price", OptionalDouble.of(3.0), OptionalDouble.of(6.0)));
+                                  diff("price", OptionalDouble.of(3.0), OptionalDouble.of(6.0), javaComparisonInformation)));
   }
 
   @Test
@@ -85,9 +87,10 @@ class RecursiveComparisonAssert_isEqualTo_with_optional_Test extends RecursiveCo
     // WHEN
     compareRecursivelyFailsAsExpected(actual, expected);
     // THEN
+    String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               diff("bookId", null, 0l),
-                                                              diff("coAuthor", Optional.of(pratchett), pratchett),
+                                                              diff("coAuthor", Optional.of(pratchett), pratchett, javaComparisonInformation),
                                                               diff("numberOfPages", null, 0),
                                                               diff("price", null, 0.0));
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_optional_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_with_optional_Test.java
@@ -90,7 +90,8 @@ class RecursiveComparisonAssert_isEqualTo_with_optional_Test extends RecursiveCo
     String javaComparisonInformation = "Comparison objects are of Java types and were then compared with equals method";
     verifyShouldBeEqualByComparingFieldByFieldRecursivelyCall(actual, expected,
                                                               diff("bookId", null, 0l),
-                                                              diff("coAuthor", Optional.of(pratchett), pratchett, javaComparisonInformation),
+                                                              diff("coAuthor", Optional.of(pratchett), pratchett,
+                                                                   javaComparisonInformation),
                                                               diff("numberOfPages", null, 0),
                                                               diff("price", null, 0.0));
   }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively_create_Test.java
@@ -225,6 +225,7 @@ class ShouldBeEqualByComparingFieldByFieldRecursively_create_Test {
                                    "field/property 'last' differ:%n" +
                                    "- actual value  : \"Johnson\"%n" +
                                    "- expected value: \"Ginobili\"%n" +
+                                   "Comparison objects are of Java types and were then compared with equals method%n" +
                                    "%n" +
                                    "The recursive comparison was performed with this configuration:%n%s",
                                    CONFIGURATION_PROVIDER.representation().toStringOf(recursiveComparisonConfiguration)));


### PR DESCRIPTION
#### Check List:
- [x] Unit tests : YES
- [x] Javadoc with a code example (on API only) : NA
- [x] PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Types from java package are not comparable with recursive comparison.

To prevent developers from wasting time looking for the problem, this PR adds an explicit log.
To do so, an element is added in additionalInformation in differences when needed.

This PR does not change the behavior.

Logs before :
```
Top level actual and expected objects differ:
- actual value  : IntSummaryStatistics{count=0, sum=0, min=2147483647, average=0.000000, max=-2147483648} (IntSummaryStatistics@163e4e87)
- expected value: IntSummaryStatistics{count=0, sum=0, min=2147483647, average=0.000000, max=-2147483648} (IntSummaryStatistics@56de5251)
```

Logs after :
```
Top level actual and expected objects differ:
- actual value  : IntSummaryStatistics{count=0, sum=0, min=2147483647, average=0.000000, max=-2147483648} (IntSummaryStatistics@423e4cbb)
- expected value: IntSummaryStatistics{count=0, sum=0, min=2147483647, average=0.000000, max=-2147483648} (IntSummaryStatistics@6e16b8b5)
Comparison objects are of Java types and were then compared with equals method
```