### PR TITLE
feat: Add cron expression assertion, Related to #3212

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCronExpressionAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCronExpressionAssert.java
@@ -1,0 +1,278 @@
+package org.assertj.core.api;
+
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressions;
+import org.assertj.core.util.VisibleForTesting;
+
+/**
+ * Base class for all implementations of assertions for {@link CronExpression}s.
+ * <p>
+ * Make the given
+ * <a href="https://www.manpagez.com/man/5/crontab/">crontab expression</a>
+ * string into a {@code CronExpression}.
+ * <p>The following rules apply:
+ * <ul>
+ * <li>
+ * A field may be an asterisk ({@code *}), which always stands for
+ * "first-last". For the "day of the month" or "day of the week" fields, a
+ * question mark ({@code ?}) may be used instead of an asterisk.
+ * </li>
+ * <li>
+ * Ranges of numbers are expressed by two numbers separated with a hyphen
+ * ({@code -}). The specified range is inclusive.
+ * </li>
+ * <li>Following a range (or {@code *}) with {@code /n} specifies
+ * the interval of the number's value through the range.
+ * </li>
+ * <li>
+ * English names can also be used for the "month" and "day of week" fields.
+ * Use the first three letters of the particular day or month (case does not
+ * matter).
+ * </li>
+ * <li>
+ * The "day of month" and "day of week" fields can contain a
+ * {@code L}-character, which stands for "last", and has a different meaning
+ * in each field:
+ * <ul>
+ * <li>
+ * In the "day of month" field, {@code L} stands for "the last day of the
+ * month". If followed by an negative offset (i.e. {@code L-n}), it means
+ * "{@code n}th-to-last day of the month". If followed by {@code W} (i.e.
+ * {@code LW}), it means "the last weekday of the month".
+ * </li>
+ * <li>
+ * In the "day of week" field, {@code dL} or {@code DDDL} stands for
+ * "the last day of week {@code d} (or {@code DDD}) in the month".
+ * </li>
+ * </ul>
+ * </li>
+ * <li>
+ * The "day of month" field can be {@code nW}, which stands for "the nearest
+ * weekday to day of the month {@code n}".
+ * If {@code n} falls on Saturday, this yields the Friday before it.
+ * If {@code n} falls on Sunday, this yields the Monday after,
+ * which also happens if {@code n} is {@code 1} and falls on a Saturday
+ * (i.e. {@code 1W} stands for "the first weekday of the month").
+ * </li>
+ * <li>
+ * The "day of week" field can be {@code d#n} (or {@code DDD#n}), which
+ * stands for "the {@code n}-th day of week {@code d} (or {@code DDD}) in
+ * the month".
+ * </li>
+ * </ul>
+ *
+ * <p>Example expressions:
+ * <ul>
+ * <li>{@code "0 0 * * * *"} = the top of every hour of every day.</li>
+ * <li><code>"*&#47;10 * * * * *"</code> = every ten seconds.</li>
+ * <li>{@code "0 0 8-10 * * *"} = 8, 9 and 10 o'clock of every day.</li>
+ * <li>{@code "0 0 6,19 * * *"} = 6:00 AM and 7:00 PM every day.</li>
+ * <li>{@code "0 0/30 8-10 * * *"} = 8:00, 8:30, 9:00, 9:30, 10:00 and 10:30 every day.</li>
+ * <li>{@code "0 0 9-17 * * MON-FRI"} = on the hour nine-to-five weekdays</li>
+ * <li>{@code "0 0 0 25 12 ?"} = every Christmas Day at midnight</li>
+ * <li>{@code "0 0 0 L * *"} = last day of the month at midnight</li>
+ * <li>{@code "0 0 0 L-3 * *"} = third-to-last day of the month at midnight</li>
+ * <li>{@code "0 0 0 1W * *"} = first weekday of the month at midnight</li>
+ * <li>{@code "0 0 0 LW * *"} = last weekday of the month at midnight</li>
+ * <li>{@code "0 0 0 * * 5L"} = last Friday of the month at midnight</li>
+ * <li>{@code "0 0 0 ? * 5#2"} = the second Friday in the month at midnight</li>
+ * <li>{@code "0 0 0 ? * MON#1"} = the first Monday in the month at midnight</li>
+ * </ul>
+ *
+ * <p>The following macros are also supported:
+ * <ul>
+ * <li>{@code "@yearly"} (or {@code "@annually"}) to run un once a year, i.e. {@code "0 0 0 1 1 *"},</li>
+ * <li>{@code "@monthly"} to run once a month, i.e. {@code "0 0 0 1 * *"},</li>
+ * <li>{@code "@weekly"} to run once a week, i.e. {@code "0 0 0 * * 0"},</li>
+ * <li>{@code "@daily"} (or {@code "@midnight"}) to run once a day, i.e. {@code "0 0 0 * * *"},</li>
+ * <li>{@code "@hourly"} to run once an hour, i.e. {@code "0 0 * * * *"}.</li>
+ * </ul>
+ * @param <SELF> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
+ *               target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
+ *               for more details.
+ * @author Neil Wang
+ */
+public class AbstractCronExpressionAssert<SELF extends AbstractCronExpressionAssert<SELF>> extends AbstractAssert<SELF, CronExpression> {
+
+  @VisibleForTesting
+  CronExpressions cronExpressions = CronExpressions.instance();
+
+  protected AbstractCronExpressionAssert(CronExpression cronExpression, Class<?> selfType) {
+    super(cronExpression, selfType);
+  }
+
+  /**
+   * Verifies that the actual value is a valid cron expression.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThatCronExpression("* * * * * *").isValid();
+   * assertThat("* 0/5 * * * ?").isTrue();
+   *
+   * // assertions will fail
+   * assertThat("* * * * *").isValid();
+   * assertThat("5-1 * * * * *").isValid();</code></pre>
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not valid.
+   */
+  public SELF isValid() {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertIsValid(info, actual);
+    return myself;
+  }
+
+  /**
+   * Asserts that the seconds of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("1,2 * * * * *")).containsExactlySeconds("1", "2");
+   * assertThat(new CronExpression("* * * * * *")).containsExactlySeconds("*");
+   * assertThat(new CronExpression("0/25 * * * * *")).containsExactlySeconds("25", "50");
+   *  // assertions will fail
+   *  assertThat(new CronExpression("0/25 * * * * *").containsExactlySeconds("50", "25");
+   *  assertThat(new CronExpression("* * * * * *").containsExactlySeconds("0");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public SELF containsExactlySeconds(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlySeconds(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Asserts that the minutes of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* 1,2 * * * *")).containsExactlyMinutes("1", "2");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyMinutes("*");
+   * assertThat(new CronExpression("* 0/25 * * * *").containsExactlyMinutes("25", "50");
+   * // assertions will fail
+   * assertThat(new CronExpression("* 0/25 * * * *").containsExactlyMinutes("50", "25");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyMinutes("0");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public SELF containsExactlyMinutes(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyMinutes(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Asserts that the hours of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* * 1,2 * * *").containsExactlyHours("1", "2");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyHours("*");
+   * assertThat(new CronExpression("* * 1/9 * * *").containsExactlyHours("1", "10", "19");
+   * // assertions will fail
+   * assertThat(new CronExpression("* * 1/9 * * *").containsExactlyHours("1", "19", "10");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyHours("1", "2", "3");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public SELF containsExactlyHours(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyHours(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Asserts that the day of month of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* * * 1,2 * *").containsExactlyDayOfMonth("1", "2");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyDayOfMonth("*");
+   * assertThat(new CronExpression("* * * LW * *").containsExactlyDayOfMonth("LW");
+   * assertThat(new CronExpression("* * * 1/9 * *").containsExactlyDayOfMonth("1", "10", "19", "28");
+   * // assertions will fail
+   * assertThat(new CronExpression("* * * 1/9 * *")).containsExactlyDayOfMonth("1", "10", "28", "19");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyDayOfMonth("1", "2", "3");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public SELF containsExactlyDayOfMonth(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyDayOfMonth(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Asserts that the month of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* * * * JAN,FEB *").containsExactlyMonth("1", "2");
+   * assertThat(new CronExpression("* * * * 1,2 *").containsExactlyMonth(*);
+   * assertThat(new CronExpression("* * * * 1/9 *").containsExactlyMonth("1", "10");
+   * // assertions will fail
+   * assertThat(new CronExpression("* * * * JAN,FEB *").containsExactlyMonth("JAN", "FEB");
+   * assertThat(new CronExpression("* * * * JAN,FEB *").containsExactlyMonth("2", "1");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyMonth("1", "2", "3");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public SELF containsExactlyMonth(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyMonth(info, actual, values);
+    return myself;
+  }
+
+
+  /**
+   * Asserts that the day of week of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* * * * * 6#2").containsExactlyDayOfWeek("6#2");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyDayOfWeek("*");
+   * assertThat(new CronExpression("* * * * * 1,2,3").containsExactlyDayOfWeek("1", "2", "3");
+   * assertThat(new CronExpression("* * * * * 4L").containsExactlyDayOfWeek("4L");
+   * // assertions will fail
+   * assertThat(new CronExpression("* * * * * 2005").containsExactlyDayOfWeek("2005");
+   * assertThat(new CronExpression("* * * * * 1,2,3").containsExactlyDayOfWeek("2", "1", "3");
+   * assertThat(new CronExpression("* * * * * *").containsExactlyDayOfWeek("1", "2", "3");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   * @throws AssertionError       if the given {@code CronExpression} is like "* * * * 2005", The sixth field is year. Should use {@link #containsExactlyYear} instead.
+   */
+  public SELF containsExactlyDayOfWeek(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyDayOfWeek(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Asserts that the year of the cron expression exactly equals to the given values.
+   * Examples:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new CronExpression("* * * * * 2005").containsExactlyYear("2005");
+   * assertThat(new CronExpression("* * * * * 2005-2009").containsExactlyYear("2005", "2006", "2007", "2008", "2009");
+   * assertThat(new CronExpression("* * * * * 2000-2023/10").containsExactlyYear("2000", "2010", "2020");
+   * // assertions will fail
+   * assertThat(new CronExpression("* * * * * 2005").containsExactlyYear("2008");
+   * assertThat(new CronExpression("* * * * * 2000-2023/10").containsExactlyYear("2000", "2020", "2010");
+   * // or use assertThatCronExpression(...) instead
+   * </code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   * @throws AssertionError       if the given {@code CronExpression} is like "* * * * 2005", The sixth field is day of week. Should use {@link #containsExactlyDayOfWeek} instead.
+   */
+  public SELF containsExactlyYear(String... values) {
+    objects.assertNotNull(info, actual);
+    cronExpressions.assertContainsExactlyYear(info, actual, values);
+    return myself;
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -98,6 +98,7 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
+import org.assertj.core.internal.CronExpression;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.presentation.BinaryRepresentation;
 import org.assertj.core.presentation.HexadecimalRepresentation;
@@ -176,8 +177,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #assertThat(Predicate)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Predicate)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.
@@ -1037,6 +1038,26 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
+  }
+
+  /**
+   * Create assertion for {@link CronExpression}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractCronExpressionAssert<?> assertThat(CronExpression actual) {
+    return new CronExpressionAssert(actual);
+  }
+
+  /**
+   * Create assertion for {@link CronExpression}.
+   *
+   * @param cronExpression the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractCronExpressionAssert<?> assertThatCronExpression(String cronExpression) {
+    return new CronExpressionAssert(new CronExpression(cronExpression));
   }
 
   /**
@@ -2538,7 +2559,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param unit the {@link TemporalUnit} of the offset.
    * @return the created {@code Offset}.
    * @since 3.7.0
-   * @see #within(long, TemporalUnit) 
+   * @see #within(long, TemporalUnit)
    */
   public static TemporalUnitOffset byLessThan(long value, TemporalUnit unit) {
     return new TemporalUnitLessThanOffset(value, unit);
@@ -3274,8 +3295,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -3312,8 +3333,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link IteratorAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -3339,8 +3360,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link CollectionAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <E> the type of elements.
    * @param actual the actual value.
@@ -3365,8 +3386,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -3411,8 +3432,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    * <p>
    * <b>Be aware that the {@code Stream} under test will be converted to a {@code List} when an assertions require to inspect its content.
    * Once this is done the {@code Stream} can't reused as it would have been consumed.</b>
@@ -3562,8 +3583,8 @@ public class Assertions implements InstanceOfAssertFactories {
   /**
    * Creates a new instance of {@link PathAssert}
    * <p>
-   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -3604,8 +3625,8 @@ public class Assertions implements InstanceOfAssertFactories {
    * Creates a new instance of <code>{@link UniversalComparableAssert}</code> with
    * standard comparison semantics.
    * <p>
-   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <T> the type of actual.
    * @param actual the actual value.

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -111,8 +111,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -137,8 +137,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of <code>{@link IteratorAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -164,8 +164,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of <code>{@link CollectionAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <E> the type of elements.
    * @param actual the actual value.
@@ -190,8 +190,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -236,8 +236,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    * <p>
    * <b>Be aware that the {@code Stream} under test will be converted to a {@code List} when an assertions require to inspect its content.
    * Once this is done the {@code Stream} can't reused as it would have been consumed.</b>
@@ -407,8 +407,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Creates a new instance of {@link PathAssert}
    * <p>
-   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -449,8 +449,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * Creates a new instance of <code>{@link UniversalComparableAssert}</code> with
    * standard comparison semantics.
    * <p>
-   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <T> the type of actual.
    * @param actual the actual value.
@@ -531,8 +531,8 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #assertThat(Predicate)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Predicate)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.
@@ -563,6 +563,17 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    */
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return LongPredicateAssert.assertThatLongPredicate(actual);
+  }
+
+  /**
+   * Create assertion for {@link CronExpressionPredicate}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @since 3.5.0
+   */
+  public static CronExpressionPredicateAssert assertThat(CronExpressionPredicate actual) {
+    return CronExpressionPredicateAssert.assertThatCronExpressionPredicate(actual);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -92,6 +92,7 @@ import org.assertj.core.data.TemporalUnitOffset;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
+import org.assertj.core.internal.CronExpression;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.presentation.BinaryRepresentation;
 import org.assertj.core.presentation.HexadecimalRepresentation;
@@ -203,8 +204,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #then(Predicate)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Predicate)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.
@@ -477,8 +478,8 @@ public class BDDAssertions extends Assertions {
    * Creates a new instance of <code>{@link UniversalComparableAssert}</code> with
    * standard comparison semantics.
    * <p>
-   * Use this over {@link #then(Comparable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Comparable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param <T> the type of actual.
    * @param actual the actual value.
@@ -503,8 +504,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
    * <p>
-   * Use this over {@link #then(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -542,8 +543,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of <code>{@link IteratorAssert}</code>.
    * <p>
-   * Use this over {@link #then(Iterator)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Iterator)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -777,8 +778,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of {@link PathAssert}
    * <p>
-   * Use this over {@link #then(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -907,8 +908,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of <code>{@link CollectionAssert}</code>.
    * <p>
-   * Use this over {@link #then(Collection)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Collection)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param <E> the type of elements.
    * @param actual the actual value.
@@ -933,8 +934,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code>.
    * <p>
-   * Use this over {@link #then(List)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(List)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -1080,6 +1081,16 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    */
   public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link org.assertj.core.api.CronExpressionAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractCronExpressionAssert<?> then(CronExpression actual) {
     return assertThat(actual);
   }
 
@@ -1746,8 +1757,8 @@ public class BDDAssertions extends Assertions {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #then(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    * <p>
    * <b>Be aware that the {@code Stream} under test will be converted to a {@code List} when an assertions require to inspect its content.
    * Once this is done the {@code Stream} can't reused as it would have been consumed.</b>

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -12,6 +12,9 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.util.CheckReturnValue;
+
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -41,8 +44,6 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import org.assertj.core.util.CheckReturnValue;
-
 @CheckReturnValue
 public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvider {
 
@@ -59,8 +60,8 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   /**
    * Creates a new instance of {@link PathAssert}
    * <p>
-   * Use this over {@link #then(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -267,8 +268,8 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #then(Predicate)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Predicate)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.
@@ -313,6 +314,16 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   }
 
   /**
+   * Create assertion for {@link CronExpressionPredicate}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  default AbstractCronExpressionAssert<?> then(CronExpression actual) {
+    return proxy(CronExpressionAssert.class, CronExpression.class, actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
@@ -331,8 +342,8 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #then(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>then</code> for. 
+   * Use this over {@link #then(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>then</code> for.
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only

--- a/assertj-core/src/main/java/org/assertj/core/api/CronExpressionAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/CronExpressionAssert.java
@@ -1,0 +1,19 @@
+package org.assertj.core.api;
+
+import org.assertj.core.internal.CronExpression;
+
+/**
+ * Assertion methods for {@link CronExpression}s.
+ * <p>
+ * To create an instance of this class, invoke <code>{@link Assertions#assertThat(CronExpression)}</code> or
+ * <code>{@link Assertions#assertThatCronExpression(String)}</code>.
+ * </p>
+ * @author Neil Wang
+ */
+public class CronExpressionAssert extends AbstractCronExpressionAssert<CronExpressionAssert> {
+
+  public CronExpressionAssert(CronExpression cronExpression) {
+    super(cronExpression, CronExpressionAssert.class);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/CronExpressionPredicate.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/CronExpressionPredicate.java
@@ -1,0 +1,8 @@
+package org.assertj.core.api;
+
+import org.assertj.core.internal.CronExpression;
+
+import java.util.function.Predicate;
+
+public interface CronExpressionPredicate extends Predicate<CronExpression> {
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/CronExpressionPredicateAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/CronExpressionPredicateAssert.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.internal.CronExpression;
+
+import java.util.function.LongPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Assertions for {@link CronExpressionAssert}.
+ * @author Neil Wang
+ */
+public class CronExpressionPredicateAssert extends AbstractPredicateLikeAssert<CronExpressionPredicateAssert, CronExpressionPredicate, CronExpression> {
+
+  public static CronExpressionPredicateAssert assertThatCronExpressionPredicate(CronExpressionPredicate actual) {
+    return new CronExpressionPredicateAssert(actual);
+  }
+
+  public CronExpressionPredicateAssert(CronExpressionPredicate actual) {
+    super(actual, toPredicate(actual), CronExpressionPredicateAssert.class);
+  }
+
+  private static Predicate<CronExpression> toPredicate(CronExpressionPredicate actual) {
+    return actual != null ? actual::test : null;
+  }
+
+  /**
+   * Verifies that {@link CronExpressionPredicate} evaluates all the given values to {@code true}.
+   * <p>
+   * Example :
+   * <pre><code class='java'> CronExpressionPredicate cronExpressions = n -&gt; n % 2 == 0;
+   *
+   * // assertion succeeds:
+   * assertThat(new CronExp).accepts(2, 4, 6);
+   *
+   * // assertion fails because of 3:
+   * assertThat(evenNumber).accepts(2, 3, 4);</code></pre>
+   * @param values values that the actual {@code Predicate} should accept.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Predicate} does not accept all given values.
+   */
+  public CronExpressionPredicateAssert accepts(CronExpression... values) {
+    if (values.length == 1) return acceptsInternal(values[0]);
+    return acceptsAllInternal(Stream.of(values).collect(Collectors.toList()));
+  }
+
+  /**
+   * Verifies that {@link LongPredicate} evaluates all the given values to {@code false}.
+   * <p>
+   * Example :
+   * <pre><code class='java'> LongPredicate evenNumber = n -&gt; n % 2 == 0;
+   *
+   * // assertion succeeds:
+   * assertThat(evenNumber).rejects(1, 3, 5);
+   *
+   * // assertion fails because of 2:
+   * assertThat(evenNumber).rejects(1, 2, 3);</code></pre>
+   * @param values values that the actual {@code Predicate} should reject.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Predicate} accepts one of the given values.
+   */
+  public CronExpressionPredicateAssert rejects(CronExpression... values) {
+    if (values.length == 1) return rejectsInternal(values[0]);
+    return rejectsAllInternal(Stream.of(values).collect(Collectors.toList()));
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.internal.CronExpression;
+
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -399,6 +401,12 @@ public interface InstanceOfAssertFactories {
    * {@link InstanceOfAssertFactory} for a {@code long} or its corresponding boxed type {@link Long}.
    */
   InstanceOfAssertFactory<Long, AbstractLongAssert<?>> LONG = new InstanceOfAssertFactory<>(Long.class,
+                                                                                            Assertions::assertThat);
+
+  /**
+   * {@link InstanceOfAssertFactory} for a {@code cronExpression} or its corresponding boxed type {@link org.assertj.core.internal.CronExpression}.
+   */
+  InstanceOfAssertFactory<CronExpression, AbstractCronExpressionAssert<?>> CRON_EXPRESSION = new InstanceOfAssertFactory<>(CronExpression.class,
                                                                                             Assertions::assertThat);
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -41,6 +41,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.internal.CronExpression;
 import org.assertj.core.util.CheckReturnValue;
 
 @CheckReturnValue
@@ -59,8 +60,8 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
   /**
    * Creates a new, proxied instance of a {@link PathAssert}
    * <p>
-   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -210,6 +211,16 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
   }
 
   /**
+   * Creates a new instance of <code>{@link CronExpressionAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  default CronExpressionAssert assertThat(CronExpression actual) {
+    return proxy(CronExpressionAssert.class, CronExpression.class, actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link PeriodAssert}</code>.
    *
    * @param actual the actual value.
@@ -266,8 +277,8 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.
@@ -330,8 +341,8 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -90,6 +90,7 @@ import org.assertj.core.data.TemporalUnitOffset;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
+import org.assertj.core.internal.CronExpression;
 import org.assertj.core.presentation.BinaryRepresentation;
 import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
@@ -414,6 +415,16 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
+   * Creates a new instance of <code>{@link CronExpression}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  default AbstractCronExpressionAssert<?> assertThat(final CronExpression actual) {
+    return Assertions.assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of <code>{@link ThrowableAssert}</code>.
    *
    * @param <T> the type of the actual throwable.
@@ -724,8 +735,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link UniversalComparableAssert}</code> with standard comparison semantics.
    * <p>
-   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Comparable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <T> the type of actual.
    * @param actual the actual value.
@@ -750,8 +761,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -830,8 +841,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link IteratorAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterator)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -1014,8 +1025,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of {@link PathAssert}
    * <p>
-   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Path)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the path to test
    * @return the created assertion object
@@ -1132,8 +1143,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link CollectionAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Collection)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <E> the type of elements.
    * @param actual the actual value.
@@ -1158,8 +1169,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code>.
    * <p>
-   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(List)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -1280,8 +1291,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
    * <p>
-   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Stream)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    * <p>
    * <b>Be aware that the {@code Stream} under test will be converted to a {@code List} when an assertions require to inspect its content.
    * Once this is done the {@code Stream} can't reused as it would have been consumed.</b>
@@ -3217,8 +3228,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   /**
    * Create assertion for {@link Predicate}.
    * <p>
-   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test 
-   * implements several interfaces Assertj provides <code>assertThat</code> for. 
+   * Use this over {@link #assertThat(Iterable)} in case of ambiguous method resolution when the object under test
+   * implements several interfaces Assertj provides <code>assertThat</code> for.
    *
    * @param actual the actual value.
    * @param <T> the type of the value contained in the {@link Predicate}.

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldCronExpressionBeValid.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldCronExpressionBeValid.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that
+ * {@code CronField} or {@code CornExpression} should valid.
+ * @author Neil Wang
+ */
+public class ShouldCronExpressionBeValid extends BasicErrorMessageFactory {
+
+  private static final String MESSAGE = "%n" +
+    "actual cron expression is invalid.%n" +
+    "actual was:%n" +
+    "  %s%n";
+
+  /**
+   * Creates a new <code>{@link ShouldCronExpressionBeValid}</code>.
+   * @param actual the actual cron field or cron expression.
+   * @return the created {@code ErrorMessageFactory}
+   */
+  public static ErrorMessageFactory shouldCronExpressionBeValid(Object actual) {
+    return new ShouldCronExpressionBeValid(actual);
+  }
+
+  private ShouldCronExpressionBeValid(Object actual) {
+    super(MESSAGE, actual);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/CronExpression.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CronExpression.java
@@ -1,0 +1,122 @@
+package org.assertj.core.internal;
+
+import org.assertj.core.api.AssertionInfo;
+
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+import static org.assertj.core.internal.CronUnit.*;
+
+/**
+ * CronExpression contains a cronable string that to set up a scheduled task.
+ * @author Neil Wang
+ */
+public class CronExpression {
+
+  private final String value;
+
+  private static final String[] MACROS = new String[]{
+    "@yearly", "0 0 0 1 1 *",
+    "@annually", "0 0 0 1 1 *",
+    "@monthly", "0 0 0 1 * *",
+    "@weekly", "0 0 0 * * 0",
+    "@daily", "0 0 0 * * *",
+    "@midnight", "0 0 0 * * *",
+    "@hourly", "0 0 * * * *"
+  };
+  /**
+   * <pre>
+   * &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; second (0-59) {@link CronExpression#seconds}
+   * &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; minute (0 - 59) {@link CronExpression#minutes}
+   * &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; hour (0 - 23) {@link CronExpression#hours}
+   * &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; day of the month (1 - 31)  {@link CronExpression#dayOfMonth}
+   * &#9474; &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; month (1 - 12) (or JAN-DEC)  {@link CronExpression#month}
+   * &#9474; &#9474; &#9474; &#9474; &#9474; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472; day of the week (0 - 7) or year (1970-2099)
+   * &#9474; &#9474; &#9474; &#9474; &#9474; &#9474;                      {@link CronExpression#dayOfWeek} or {@link CronExpression#year}
+   * &#9474; &#9474; &#9474; &#9474; &#9474; &#9474;          (0 or 7 is Sunday, or MON-SUN)
+   * &#9474; &#9474; &#9474; &#9474; &#9474; &#9474;
+   * &#42; &#42; &#42; &#42; &#42; &#42;
+   * </pre>
+   */
+  private CronField seconds;
+  private CronField minutes;
+  private CronField hours;
+  private CronField dayOfMonth;
+  private CronField month;
+  private CronField dayOfWeek;
+  private CronField year;
+
+
+  public CronExpression(String value) {
+    this.value = value;
+  }
+
+  void assertIsValid(AssertionInfo info, Failures failures) {
+    String expression = resolveMacros(this.value);
+    Objects.instance().assertNotNull(info, expression);
+    String[] fields = expression.split(" ");
+    if (fields.length != 6) {
+      throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+    }
+    this.seconds = new CronField(SECONDS, fields[0]);
+    CronFieldValidation.instance().assertIsValid(info, this.seconds, failures);
+    this.minutes = new CronField(MINUTES, fields[1]);
+    CronFieldValidation.instance().assertIsValid(info, this.minutes, failures);
+    this.hours = new CronField(HOURS, fields[2]);
+    CronFieldValidation.instance().assertIsValid(info, this.hours, failures);
+    this.dayOfMonth = new CronField(DAY_OF_MONTH, fields[3]);
+    CronFieldValidation.instance().assertIsValid(info, this.dayOfMonth, failures);
+    this.month = new CronField(MONTH, fields[4]);
+    CronFieldValidation.instance().assertIsValid(info, this.month, failures);
+    try {
+      this.dayOfWeek = new CronField(DAY_OF_WEEK, fields[5]);
+      CronFieldValidation.instance().assertIsValid(info, this.dayOfWeek, failures);
+    } catch (AssertionError e) {
+      this.dayOfWeek = null;
+      this.year = new CronField(YEAR, fields[5]);
+      CronFieldValidation.instance().assertIsValid(info, this.year, failures);
+    }
+  }
+
+  public void assertContainsExactlySeconds(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(seconds, info, failures, values);
+  }
+
+  public void assertContainsExactlyMinutes(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(minutes, info, failures, values);
+  }
+
+  public void assertContainsExactlyHours(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(hours, info, failures, values);
+  }
+
+  public void assertContainsExactlyDayOfMonth(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(dayOfMonth, info, failures, values);
+  }
+
+  public void assertContainsExactlyMonth(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(month, info, failures, values);
+  }
+
+  public void assertContainsExactlyDayOfWeek(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(dayOfWeek, info, failures, values);
+  }
+
+  public void assertContainsExactlyYear(AssertionInfo info, Failures failures, String[] values) {
+    assertContainsExactly(year, info, failures, values);
+  }
+
+  private void assertContainsExactly(CronField field, AssertionInfo info, Failures failures, String[] values) {
+    Objects.instance().assertNotNull(info, field);
+    field.parse(info, failures);
+    Iterables.instance().assertContainsExactly(info, field.parsedValues(), values);
+  }
+
+  private static String resolveMacros(String expression) {
+    expression = expression.trim();
+    for (int i = 0; i < MACROS.length; i = i + 2) {
+      if (MACROS[i].equalsIgnoreCase(expression)) {
+        return MACROS[i + 1];
+      }
+    }
+    return expression;
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/CronExpressions.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CronExpressions.java
@@ -1,0 +1,139 @@
+package org.assertj.core.internal;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.Condition;
+import org.assertj.core.util.VisibleForTesting;
+
+/**
+ * Reusable assertions for <code>{@link CronExpression}</code>s.
+ * @author Neil Wang
+ */
+public class CronExpressions {
+
+  private static final CronExpressions INSTANCE = new CronExpressions();
+
+  /**
+   * Returns the singleton instance of this class.
+   * @return the singleton instance of this class.
+   */
+  public static CronExpressions instance() {
+    return INSTANCE;
+  }
+
+  @VisibleForTesting
+  Failures failures = Failures.instance();
+
+  @VisibleForTesting
+  CronExpressions() {
+  }
+
+  /**
+   * Verify the given
+   * <a href="https://www.manpagez.com/man/5/crontab/">crontab expression</a>
+   * string is a {@code CronExpression} or not.
+   * @param actual the expression string to parse
+   * @throws AssertionError       if {@code actual} is invalid.
+   * @throws NullPointerException if {@code actual} is {@code null}.
+   */
+  public void assertIsValid(AssertionInfo info, CronExpression actual) {
+    assertNotNull(info, actual);
+    actual.assertIsValid(info, failures);
+  }
+
+  /**
+   * Asserts that the seconds of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlySeconds(info, new CronExpression("1,2 * * * * *"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlySeconds(AssertionInfo info, CronExpression actual, String... values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlySeconds(info, failures, values);
+  }
+
+  /**
+   * Asserts that the minutes of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyMinutes(info, new CronExpression("* 1,2 * * * *"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyMinutes(AssertionInfo info, CronExpression actual, String... values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyMinutes(info, failures, values);
+  }
+
+  /**
+   * Asserts that the hours of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyHours(info, new CronExpression("* * 1,2 * * *"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyHours(AssertionInfo info, CronExpression actual, String... values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyHours(info, failures, values);
+  }
+
+  /**
+   * Asserts that the day of month of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyDayOfMonth(info, new CronExpression("* * * 1,2 * *"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyDayOfMonth(AssertionInfo info, CronExpression actual, String[] values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyDayOfMonth(info, failures, values);
+  }
+
+  /**
+   * Asserts that the month of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyMonth(info, new CronExpression("* * * * 1,2 *"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyMonth(AssertionInfo info, CronExpression actual, String[] values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyMonth(info, failures, values);
+  }
+
+  /**
+   * Asserts that the day of week of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyMonth(info, new CronExpression("* * * * * 1,2"), "1", "2");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws NullPointerException if the given {@code CronExpression} is like "* * * * 2005", The sixth field is year. Should use {@link #assertContainsExactlyYear(AssertionInfo, CronExpression, String[])} instead.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyDayOfWeek(AssertionInfo info, CronExpression actual, String[] values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyDayOfWeek(info, failures, values);
+  }
+
+  /**
+   * Asserts that the year of the cron expression exactly equals to the given values.
+   * @param actual the expression string to parse
+   * Examples:
+   * <code>CronExpressions.assertContainsExactlyYear(info, new CronExpression("* * * * * 2005"), "2005");</code>
+   * @throws NullPointerException if the given {@code CronExpression} is {@code null}.
+   * @throws NullPointerException if the given {@code CronExpression} is like "* * * * 6#2", The sixth field is day of week. Should use {@link #assertContainsExactlyDayOfWeek(AssertionInfo, CronExpression, String[])} instead.
+   * @throws AssertionError       if the actual value does not exactly same as the given values.
+   */
+  public void assertContainsExactlyYear(AssertionInfo info, CronExpression actual, String[] values) {
+    assertIsValid(info, actual);
+    actual.assertContainsExactlyYear(info, failures, values);
+  }
+
+  private void assertNotNull(AssertionInfo info, CronExpression actual) {
+    Objects.instance().assertNotNull(info, actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/CronField.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CronField.java
@@ -1,0 +1,142 @@
+package org.assertj.core.internal;
+
+import org.assertj.core.api.AssertionInfo;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+
+/**
+ * CronExpression contains a cronable string endpoint that be assembled to set up a scheduled task.
+ * @author Neil Wang
+ */
+public class CronField {
+
+  private final CronUnit type;
+  private final String value;
+  private final Set<String> parsedValues = new HashSet<>();
+
+  public CronField(CronUnit type, String value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  public List<String> parsedValues() {
+    return parsedValues.stream().sorted(Comparator.comparingInt(Integer::parseInt)).collect(Collectors.toList());
+  }
+
+  void assertIsValid(AssertionInfo info, Failures failures) {
+    assertNotNull(info, value);
+    if (Pattern.matches(this.type.wildcardPattern(), this.value)) {
+      return;
+    }
+    for (String child : this.value.split(",")) {
+      if (child.contains("/")) {
+        final int allowSlashSize = 1;
+        String[] v = child.split("/");
+        if (v.length != allowSlashSize + 1) {
+          throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+        }
+        if (v[0].equals("*")) {
+          continue;
+        }
+        assertIsValidWithBar(v[0], info, failures);
+        assertNumberIsPositive(v[1], info, failures);
+        continue;
+      }
+      assertIsValidWithBar(child, info, failures);
+    }
+  }
+
+  public void parse(AssertionInfo info, Failures failures) {
+    assertIsValid(info, failures);
+    if (Pattern.matches(this.type.wildcardPattern(), this.value)) {
+      this.parsedValues.add(this.value);
+      return;
+    }
+    for (String child : this.value.split(",")) {
+      if (child.contains("/")) {
+        String[] v = child.split("/");
+        if (!v[0].contains("-")) {
+          int start;
+          if (v[0].equals("*")) {
+            start = 0;
+          } else {
+            start = assertNumberIsInt(v[0], info, failures);
+          }
+          int step = assertNumberIsInt(v[1], info, failures);
+          IntStream.rangeClosed(start, this.type.max()).filter(i -> (i - start) % step == 0).forEachOrdered(i -> this.parsedValues.add(String.valueOf(i)));
+        } else {
+          String[] v1 = v[0].split("-");
+          int start = assertNumberIsInt(v1[0], info, failures);
+          int end = assertNumberIsInt(v1[1], info, failures);
+          int step = assertNumberIsInt(v[1], info, failures);
+          IntStream.rangeClosed(start, end).filter(i -> (i - start) % step == 0).forEachOrdered(i -> this.parsedValues.add(String.valueOf(i)));
+        }
+        continue;
+      }
+      if (child.contains("-")) {
+        String[] v = child.split("-");
+        int start = assertNumberIsInt(v[0], info, failures);
+        int end = assertNumberIsInt(v[1], info, failures);
+        IntStream.rangeClosed(start, end).forEachOrdered(i -> this.parsedValues.add(String.valueOf(i)));
+        continue;
+      }
+      this.parsedValues.add(String.valueOf(assertNumberIsInt(child, info, failures)));
+    }
+  }
+
+  private void assertIsValidWithBar(String value, AssertionInfo info, Failures failures) {
+    String[] children = value.split("-");
+    if (children.length == 1) {
+      assertNumberIsValid(children[0], info, failures);
+      return;
+    }
+    if (children.length != 2) {
+      throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+    }
+    for (int i = 0; i < children.length; i++) {
+      assertNumberIsValid(children[i], info, failures);
+      if (i == children.length - 1) {
+        break;
+      }
+      if (assertNumberIsInt(children[i], info, failures) > assertNumberIsInt(children[i + 1], info, failures)) {
+        throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+      }
+    }
+  }
+
+  private void assertNumberIsValid(String actual, AssertionInfo info, Failures failures) {
+    int value = assertNumberIsInt(actual, info, failures);
+    if (value < this.type.min() || value > this.type.max()) {
+      throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+    }
+  }
+
+  private void assertNumberIsPositive(String value, AssertionInfo info, Failures failures) {
+    if (assertNumberIsInt(value, info, failures) < 0) {
+      throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+    }
+  }
+
+  private int assertNumberIsInt(String value, AssertionInfo info, Failures failures) {
+    if (type.mappings().containsKey(value.toUpperCase())) {
+      value = type.mappings().get(value);
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw failures.failure(info, shouldCronExpressionBeValid(this.value));
+    }
+  }
+
+  private void assertNotNull(AssertionInfo info, String actual) {
+    Objects.instance().assertNotNull(info, actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/CronFieldValidation.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CronFieldValidation.java
@@ -1,0 +1,26 @@
+package org.assertj.core.internal;
+
+import org.assertj.core.api.AssertionInfo;
+
+public class CronFieldValidation {
+
+  private static final CronFieldValidation INSTANCE = new CronFieldValidation();
+
+  /**
+   * Returns the singleton instance of this class.
+   * @return the singleton instance of this class.
+   */
+  public static CronFieldValidation instance() {
+    return INSTANCE;
+  }
+
+  public void assertIsValid(AssertionInfo info, CronField actual, Failures failures) {
+    assertNotNull(info, actual);
+    actual.assertIsValid(info, failures);
+  }
+
+  private void assertNotNull(AssertionInfo info, CronField actual) {
+    Objects.instance().assertNotNull(info, actual);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/CronUnit.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CronUnit.java
@@ -1,0 +1,90 @@
+package org.assertj.core.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CronExpression contains every unit of cron expression.
+ * @author Neil Wang
+ */
+public enum CronUnit {
+  SECONDS(0, 59, "^[*]$"),
+  MINUTES(0, 59, "^[*]$"),
+  HOURS(0, 23, "^[*]$"),
+  DAY_OF_MONTH(1, 31, "^[*?L]$|^[0-9]W$|^[1-2][0-9]W$|^3[0-1]W$|^LW$"),
+  MONTH(1, 12, "^[*]$",
+    "JAN", "1", "jan", "1",
+    "FEB", "2", "feb", "2",
+    "MAR", "3", "mar", "3",
+    "APR", "4", "apr", "4",
+    "MAY", "5", "may", "5",
+    "JUN", "6", "jun", "6",
+    "JUL", "7", "jul", "7",
+    "AUG", "8", "aug", "8",
+    "SEP", "9", "sep", "9",
+    "OCT", "10", "oct", "10",
+    "NOV", "11", "nov", "11",
+    "DEC", "12", "dec", "12"),
+  DAY_OF_WEEK(0, 7, "^[*,?]$|^[0-7]#\\d+$|^[0-7]L$",
+    "MON", "1", "mon", "1",
+    "TUE", "2", "tue", "2",
+    "WED", "3", "wed", "3",
+    "THU", "4", "thu", "4",
+    "FRI", "5", "fri", "5",
+    "SAT", "6", "sat", "6",
+    "SUN", "7", "sun", "7"
+  ),
+  YEAR(1970, 2099, "^[*,?]$");
+
+  /**
+   * min value of the unit.
+   */
+  private final int min;
+
+  /**
+   * max value of the unit.
+   */
+  private final int max;
+
+  /**
+   * wildcard pattern of the unit. If the value matches the pattern, it means the value is valid.
+   */
+  private final String wildcardPattern;
+
+  /**
+   * mappings of the unit. If the parsed value matches the key, it will be replaced by the value.
+   * For example, if the parsed value is "MON-SUN", it will be replaced by "1-7".
+   */
+  private final Map<String, String> mappings;
+
+  CronUnit(int min, int max, String wildcardPattern, String... mappings) {
+    this.min = min;
+    this.max = max;
+    this.wildcardPattern = wildcardPattern;
+    this.mappings = createMappings(mappings);
+  }
+
+  public int min() {
+    return min;
+  }
+
+  public int max() {
+    return max;
+  }
+
+  public String wildcardPattern() {
+    return wildcardPattern;
+  }
+
+  public Map<String, String> mappings() {
+    return mappings;
+  }
+
+  private Map<String, String> createMappings(String[] mappings) {
+    Map<String, String> result = new HashMap<>();
+    for (int i = 0; i < mappings.length; i += 2) {
+      result.put(mappings[i], mappings[i + 1]);
+    }
+    return result;
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThatCronExpression_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Assertions_assertThatCronExpression_Test.java
@@ -1,0 +1,93 @@
+package org.assertj.core.api;
+
+import org.assertj.core.internal.CronExpression;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+
+/**
+ * Tests for code {@link Assertions#assertThat(CronExpression)}.
+ * @author Neil Wang
+ */
+public class Assertions_assertThatCronExpression_Test {
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_if_actual_cron_expression_is_not_valid(String cron, String throwMessage) {
+    CronExpression actual = new CronExpression(cron);
+    Throwable error = catchThrowable(() -> assertThat(actual).isValid());
+    assertThat(error).isInstanceOf(AssertionError.class)
+      .hasMessage(shouldCronExpressionBeValid(throwMessage).create());
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("*", "*"),
+      Arguments.of("0 0 2 1-0 * *", "1-0")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_if_actual_cron_expression_is_valid(String cron, String[] expectSeconds, String[] expectedMinutes, String[] expectedHours,
+                                                      String[] expectedDayOfMonth, String[] expectedMonth, boolean useYear,
+                                                      String[] expectedYearOrDayOfWeek) {
+    CronExpression actual = new CronExpression(cron);
+    assertThat(actual).isValid();
+    assertThat(actual).containsExactlySeconds(expectSeconds)
+      .containsExactlyMinutes(expectedMinutes)
+      .containsExactlyHours(expectedHours)
+      .containsExactlyDayOfMonth(expectedDayOfMonth)
+      .containsExactlyMonth(expectedMonth);
+    if (useYear) {
+      assertThat(actual).containsExactlyYear(expectedYearOrDayOfWeek);
+    } else {
+      assertThat(actual).containsExactlyDayOfWeek(expectedYearOrDayOfWeek);
+    }
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("@yearly",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"0"}, new String[]{"1"}, new String[]{"1"}, false, new String[]{"*"}),
+      Arguments.of("@annually",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"0"}, new String[]{"1"}, new String[]{"1"}, false, new String[]{"*"}),
+      Arguments.of("@monthly",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"0"}, new String[]{"1"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("@daily",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"0"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("@midnight",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"0"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("@hourly",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"*"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("* * * * * *",
+        new String[]{"*"}, new String[]{"*"}, new String[]{"*"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("0 0 2 1 * *",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"2"}, new String[]{"1"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("0 15 10 ? * MON-FRI",
+        new String[]{"0"}, new String[]{"15"}, new String[]{"10"}, new String[]{"?"}, new String[]{"*"}, false, new String[]{"1", "2", "3", "4", "5"}),
+      Arguments.of("0 15 10 ? * 6L",
+        new String[]{"0"}, new String[]{"15"}, new String[]{"10"}, new String[]{"?"}, new String[]{"*"}, false, new String[]{"6L"}),
+      Arguments.of("0 0 10,14,16 * * ?",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"10", "14", "16"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"?"}),
+      Arguments.of("0 0/30 9-11 * * ?",
+        new String[]{"0"}, new String[]{"0", "30"}, new String[]{"9", "10", "11"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"?"}),
+      Arguments.of("0 0 12 ? * WED",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"12"}, new String[]{"?"}, new String[]{"*"}, false, new String[]{"3"}),
+      Arguments.of("0 0 12 * * ?",
+        new String[]{"0"}, new String[]{"0"}, new String[]{"12"}, new String[]{"*"}, new String[]{"*"}, false, new String[]{"?"}),
+      Arguments.of("0,1,2,3,4 15-18/5 10-10/2 ? * *",
+        new String[]{"0", "1", "2", "3", "4"}, new String[]{"15"}, new String[]{"10"}, new String[]{"?"}, new String[]{"*"}, false, new String[]{"*"}),
+      Arguments.of("0 15 10 * * 2005",
+        new String[]{"0"}, new String[]{"15"}, new String[]{"10"}, new String[]{"*"}, new String[]{"*"}, true, new String[]{"2005"}),
+      Arguments.of("0 15 10 ? * 6#3",
+        new String[]{"0"}, new String[]{"15"}, new String[]{"10"}, new String[]{"?"}, new String[]{"*"}, false, new String[]{"6#3"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -98,6 +98,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URI_TYPE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URL_TYPE;
 import static org.assertj.core.api.InstanceOfAssertFactories.ZONED_DATE_TIME;
+import static org.assertj.core.api.InstanceOfAssertFactories.CRON_EXPRESSION;
 import static org.assertj.core.api.InstanceOfAssertFactories.array;
 import static org.assertj.core.api.InstanceOfAssertFactories.atomicIntegerFieldUpdater;
 import static org.assertj.core.api.InstanceOfAssertFactories.atomicLongFieldUpdater;
@@ -173,6 +174,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.internal.CronExpression;
 import org.assertj.core.util.Strings;
 import org.junit.jupiter.api.Test;
 
@@ -1220,6 +1222,16 @@ class InstanceOfAssertFactoriesTest {
     MapAssert<String, String> result = assertThat(value).asInstanceOf(map(String.class, String.class));
     // THEN
     result.containsExactly(entry("key", "value"));
+  }
+
+  @Test
+  void cron_expression_factory_should_allow_typed_cron_expression_assertions() {
+    // GIVEN
+    Object value = new CronExpression("* * * * * *");
+    // WHEN
+    AbstractCronExpressionAssert<?> result = assertThat(value).asInstanceOf(CRON_EXPRESSION);
+    // THEN
+    result.isValid();
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionAssert_isValid_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionAssert_isValid_Test.java
@@ -1,0 +1,29 @@
+package org.assertj.core.api.cronexpressions;
+
+import org.assertj.core.api.CronExpressionAssert;
+import org.assertj.core.internal.CronExpression;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link CronExpressionAssert#isValid()}</code>.
+ *
+ * @author Neil Wang
+ */
+public class CronExpressionAssert_isValid_Test {
+
+  @Test
+  public void should_return_this() {
+    CronExpressionAssert assertions = new CronExpressionAssert(new CronExpression("* * * * * *"));
+    CronExpressionAssert returned = assertions.isValid();
+    assertThat(returned).isSameAs(assertions);
+  }
+
+  @Test
+  public void should_verify_cron_expressions() {
+    CronExpressionAssert assertions = new CronExpressionAssert(new CronExpression("* * * * * *"));
+    assertions.isValid();
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionPredicateAssertBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionPredicateAssertBaseTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.cronexpressions;
+
+import org.assertj.core.api.BaseTestTemplate;
+import org.assertj.core.api.CronExpressionAssert;
+import org.assertj.core.api.CronExpressionPredicate;
+import org.assertj.core.api.CronExpressionPredicateAssert;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.Iterables;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Base class for {@link org.assertj.core.api.CronExpressionAssert} tests.
+ * @author Neil Wang
+ */
+public abstract class CronExpressionPredicateAssertBaseTest extends BaseTestTemplate<CronExpressionPredicateAssert, CronExpressionPredicate> {
+
+  protected Iterables iterables;
+  protected Predicate<Long> wrapped;
+
+  @Override
+  protected CronExpressionPredicateAssert create_assertions() {
+    return new CronExpressionPredicateAssert(Objects::nonNull);
+  }
+
+  @Override
+  protected void inject_internal_objects() {
+    super.inject_internal_objects();
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionPredicateAssert_accepts_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/cronexpressions/CronExpressionPredicateAssert_accepts_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.api.cronexpressions;
+
+import org.assertj.core.api.CronExpressionPredicate;
+import org.assertj.core.api.CronExpressionPredicateAssert;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.function.LongPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test codes for {@link CronExpressionPredicateAssert#accepts(CronExpression...)}.
+ * @author Neil Wang
+ */
+class CronExpressionPredicateAssert_accepts_Test extends CronExpressionPredicateAssertBaseTest {
+
+  @Test
+  void should_fail_when_predicate_is_null() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat((CronExpressionPredicate) null).accepts(new CronExpression("* * * * * *"), new CronExpression("* * * * * ?")))
+      .withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_pass_when_predicate_accepts_value() {
+    CronExpressionPredicate predicate = Objects::nonNull;
+    assertThat(predicate).accepts(new CronExpression("* * * * * *"));
+  }
+
+  @Test
+  void should_fail_when_predicate_does_not_accept_values() {
+    CronExpressionPredicate predicate = Objects::isNull;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(predicate).accepts(new CronExpression("* * * * * *")));
+  }
+
+  @Override
+  protected CronExpressionPredicateAssert invoke_api_method() {
+    return assertions.accepts(new CronExpression("* * * * * *"), new CronExpression("* * * * * ?"));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/CronFieldShouldInRange_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/CronFieldShouldInRange_create_Test.java
@@ -1,0 +1,24 @@
+package org.assertj.core.error;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+
+/**
+ * Tests for <code>{@link ShouldCronExpressionBeValid}</code>.
+ * @author Neil Wang
+ */
+class CronFieldShouldInRange_create_Test {
+
+  @Test
+  void should_create_error_message_with_expected_type() {
+    // WHEN
+    String errorMessage = shouldCronExpressionBeValid("1").create();
+    // THEN
+    then(errorMessage).isEqualTo("\n" +
+      "actual cron expression is invalid.\n" +
+      "actual was:\n" +
+      "  \"1\"\n");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/CronExpressionsBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/CronExpressionsBaseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.assertj.core.api.WritableAssertionInfo;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Base class for {@link CronExpressions} unit tests
+ * <p>
+ * Is in <code>org.assertj.core.internal</code> package to be able to set {@link CronExpressions#failures} appropriately.
+ * @author Neil Wang
+ */
+public abstract class CronExpressionsBaseTest {
+
+  protected static final WritableAssertionInfo INFO = someInfo();
+
+  protected Failures failures;
+  protected CronExpressions expressions;
+
+  @BeforeEach
+  public void setUp() {
+    failures = spy(new Failures());
+    expressions = new CronExpressions();
+    expressions.failures = failures;
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyDayOfMonth_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyDayOfMonth_Test.java
@@ -1,0 +1,54 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyDayOfMonth(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyDayOfMonth_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_day_of_month_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyDayOfMonth(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* * * 1 * *", new String[]{"1"}),
+      Arguments.of("* * * LW * *", new String[]{"LW"}),
+      Arguments.of("* * * 1/7 * *", new String[]{"1", "8", "15", "22", "29"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_day_of_month_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyDayOfMonth(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* * * 1,2,3 * *", new String[]{"1", "2"}),
+      Arguments.of("* * * 1,2,3 * *", new String[]{"1", "4"}),
+      Arguments.of("* * * 0/7 * *", new String[]{"1", "15", "8", "22", "29"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyDayOfWeek_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyDayOfWeek_Test.java
@@ -1,0 +1,56 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyDayOfWeek(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyDayOfWeek_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_day_of_week_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyDayOfWeek(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* * * * * 1", new String[]{"1"}),
+      Arguments.of("* * * * * 6#2", new String[]{"6#2"}),
+      Arguments.of("* * * * * MON-FRI", new String[]{"1", "2", "3", "4", "5"}),
+      Arguments.of("* * * * * 1/3", new String[]{"1", "4", "7"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_day_of_week_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyDayOfWeek(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* * * * * 1,2,3", new String[]{"1", "2"}),
+      Arguments.of("* * * * * 1,2,3", new String[]{"1", "4"}),
+      Arguments.of("* * * * * 1/3", new String[]{"1", "7", "4"}),
+      Arguments.of("* * * * * 2005", new String[]{"2005"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyHours_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyHours_Test.java
@@ -1,0 +1,54 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyHours(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyHours_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_hours_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyHours(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* * 0 * * *", new String[]{"0"}),
+      Arguments.of("* * * * * *", new String[]{"*"}),
+      Arguments.of("* * 0/7 * * *", new String[]{"0", "7", "14", "21"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_hours_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyHours(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* * 1,2,3 * * *", new String[]{"1", "2"}),
+      Arguments.of("* * 1,2,3 * * *", new String[]{"1", "4"}),
+      Arguments.of("* * 0/7 * * *", new String[]{"0", "14", "7", "21"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyMinutes_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyMinutes_Test.java
@@ -1,0 +1,54 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyMinutes(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyMinutes_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_minutes_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyMinutes(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* 0 * * * *", new String[]{"0"}),
+      Arguments.of("* * * * * *", new String[]{"*"}),
+      Arguments.of("* 0/7 * * * *", new String[]{"0", "7", "14", "21", "28", "35", "42", "49", "56"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_minutes_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyMinutes(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* 1,2,3 * * * *", new String[]{"1", "2"}),
+      Arguments.of("* 1,2,3 * * * *", new String[]{"1", "4"}),
+      Arguments.of("* 0/7 * * * *", new String[]{"0", "14", "7", "21", "28", "35", "42", "49", "56"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyMonth_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyMonth_Test.java
@@ -1,0 +1,55 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyMonth(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyMonth_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_month_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyMonth(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* * * * 1 *", new String[]{"1"}),
+      Arguments.of("* * * * JAN *", new String[]{"1"}),
+      Arguments.of("* * * * JAN-FEB *", new String[]{"1", "2"}),
+      Arguments.of("* * * * 1/7 *", new String[]{"1", "8"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_month_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyMonth(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* * * * 1,2,3 *", new String[]{"1", "2"}),
+      Arguments.of("* * * * 1,2,3 *", new String[]{"1", "4"}),
+      Arguments.of("* * * * 1/7 *", new String[]{"8", "1"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlySeconds_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlySeconds_Test.java
@@ -1,0 +1,54 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlySeconds(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlySeconds_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_seconds_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlySeconds(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("0 * * * * *", new String[]{"0"}),
+      Arguments.of("* * * * * *", new String[]{"*"}),
+      Arguments.of("0/7 * * * * *", new String[]{"0", "7", "14", "21", "28", "35", "42", "49", "56"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_seconds_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlySeconds(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("1,2,3 * * * * *", new String[]{"1", "2"}),
+      Arguments.of("1,2,3 * * * * *", new String[]{"1", "4"}),
+      Arguments.of("0/7 * * * * *", new String[]{"0", "14", "7", "21", "28", "35", "42", "49", "56"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyYear_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertContainsExactlyYear_Test.java
@@ -1,0 +1,54 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.CronExpressions#assertContainsExactlyYear(AssertionInfo, CronExpression, String...)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertContainsExactlyYear_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_year_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertContainsExactlyYear(info, actual, expects);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("* * * * * 2005", new String[]{"2005"}),
+      Arguments.of("* * * * * 2005-2009", new String[]{"2005", "2006", "2007", "2008", "2009"}),
+      Arguments.of("* * * * * 2000-2023/10", new String[]{"2000", "2010", "2020"})
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_year_contains_exactly(String cron, String[] expects) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable throwable = catchThrowable(() -> expressions.assertContainsExactlyYear(info, actual, expects));
+    assertThat(throwable).isInstanceOf(AssertionError.class);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("* * * * * 1,2,3", new String[]{"1", "2"}),
+      Arguments.of("* * * * * 2009,2010", new String[]{"2008"}),
+      Arguments.of("* * * * * 2000-2023/10", new String[]{"2000", "2010", "2030", "2020"})
+    );
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertIsValid_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronExpressions_assertIsValid_Test.java
@@ -1,0 +1,73 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronExpression;
+import org.assertj.core.internal.CronExpressions;
+import org.assertj.core.internal.CronExpressionsBaseTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CronExpressions#assertIsValid(AssertionInfo, CronExpression)}</code>.
+ * @author Neil Wang
+ */
+public class CronExpressions_assertIsValid_Test extends CronExpressionsBaseTest {
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_if_actual_cron_expression_is_not_valid(String cron, String throwMessage) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    Throwable error = catchThrowable(() -> expressions.assertIsValid(info, actual));
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldCronExpressionBeValid(throwMessage));
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("*", "*"),
+      Arguments.of("0 0 2 1-0 * *", "1-0")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_if_actual_cron_expression_is_valid(String cron) {
+    AssertionInfo info = someInfo();
+    CronExpression actual = new CronExpression(cron);
+    expressions.assertIsValid(info, actual);
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("@yearly"),
+      Arguments.of("@annually"),
+      Arguments.of("@monthly"),
+      Arguments.of("@daily"),
+      Arguments.of("@midnight"),
+      Arguments.of("@hourly"),
+      Arguments.of("* * * * * *"),
+      Arguments.of("0 0 2 1 * *"),
+      Arguments.of("0 15 10 ? * MON-FRI"),
+      Arguments.of("0 15 10 ? * 6L"),
+      Arguments.of("0 0 10,14,16 * * ?"),
+      Arguments.of("0 0/30 9-17 * * ?"),
+      Arguments.of("0 0 12 ? * WED"),
+      Arguments.of("0 0 12 * * ?"),
+      Arguments.of("0,1,2,3,4 15-18/5 10-10/2 ? * *"),
+      Arguments.of("0 15 10 * * 2005"),
+      Arguments.of("0 15 10 ? * 6#3")
+    );
+  }
+
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronFieldValidation_assertIsValid_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronFieldValidation_assertIsValid_Test.java
@@ -1,0 +1,156 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronField;
+import org.assertj.core.internal.CronFieldValidation;
+import org.assertj.core.internal.CronUnit;
+import org.assertj.core.internal.Failures;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldCronExpressionBeValid.shouldCronExpressionBeValid;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.internal.CronUnit.*;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link CronFieldValidation#assertIsValid(AssertionInfo, CronField, org.assertj.core.internal.Failures)}</code>.
+ * @author Neil Wang
+ */
+public class CronFieldValidation_assertIsValid_Test {
+
+  @ParameterizedTest
+  @MethodSource("succeedParams")
+  void should_pass_when_cron_field_is_valid(String cronField, CronUnit cronUnit) {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN THEN
+    CronFieldValidation.instance().assertIsValid(info, new CronField(cronUnit, cronField), Failures.instance());
+  }
+
+  public static Stream<Arguments> succeedParams() {
+    return Stream.of(
+      Arguments.of("*", HOURS),
+      Arguments.of("5", HOURS),
+      Arguments.of("1,2", HOURS),
+      Arguments.of("1-5", HOURS),
+      Arguments.of("1,2,3-6", HOURS),
+      Arguments.of("1,3-7/100", HOURS),
+      Arguments.of("?", YEAR),
+      Arguments.of("?", DAY_OF_WEEK),
+      Arguments.of("JAN-MAY", MONTH),
+      Arguments.of("mon", DAY_OF_WEEK),
+      Arguments.of("?", DAY_OF_MONTH),
+      Arguments.of("L", DAY_OF_MONTH),
+      Arguments.of("2001-2005", YEAR)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("failedParams")
+  void should_fail_when_cron_field_is_invalid(String cronField, CronUnit cronUnit, String expectedMessage) {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN
+    Throwable throwable = catchThrowable(() -> CronFieldValidation.instance().assertIsValid(info, new CronField(cronUnit, cronField), Failures.instance()));
+    // THEN
+    assertThat(throwable).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(expectedMessage);
+  }
+
+  public static Stream<Arguments> failedParams() {
+    return Stream.of(
+      Arguments.of("-1", HOURS, shouldCronExpressionBeValid("-1").create()),
+      Arguments.of("1,-1", HOURS, shouldCronExpressionBeValid("1,-1").create()),
+      Arguments.of("e", HOURS, shouldCronExpressionBeValid("e").create()),
+      Arguments.of("1,e", HOURS, shouldCronExpressionBeValid("1,e").create()),
+      Arguments.of("1,2-e", HOURS, shouldCronExpressionBeValid("1,2-e").create()),
+      Arguments.of("1,3-7/10/2", HOURS, shouldCronExpressionBeValid("1,3-7/10/2").create()),
+      Arguments.of("1-2-3", HOURS, shouldCronExpressionBeValid("1-2-3").create()),
+      Arguments.of("3-1", HOURS, shouldCronExpressionBeValid("3-1").create()),
+      Arguments.of("?", HOURS, shouldCronExpressionBeValid("?").create())
+    );
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN
+    Throwable throwable = catchThrowable(() -> CronFieldValidation.instance().assertIsValid(info, null, Failures.instance()));
+    // THEN
+    assertThat(throwable).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(shouldNotBeNull("actual").create());
+  }
+
+  @Test
+  void should_fail_if_value_in_actual_is_null() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN
+    Throwable throwable = catchThrowable(() -> CronFieldValidation.instance().assertIsValid(info, new CronField(HOURS, null), Failures.instance()));
+    // THEN
+    assertThat(throwable).isInstanceOf(AssertionError.class)
+      .hasMessageContaining(shouldNotBeNull("actual").create());
+  }
+
+  @Nested
+  class CronUnit_matchesPattern_Test {
+
+    @ParameterizedTest
+    @CsvSource({
+      "SECONDS,       *",
+      "MINUTES,       *",
+      "HOURS,         *",
+      "DAY_OF_MONTH,  *",
+      "DAY_OF_MONTH,  L",
+      "DAY_OF_MONTH,  ?",
+      "DAY_OF_MONTH,  6W",
+      "DAY_OF_MONTH,  12W",
+      "DAY_OF_MONTH,  31W",
+      "DAY_OF_MONTH,  LW",
+      "MONTH,         *",
+      "DAY_OF_WEEK,   *",
+      "DAY_OF_WEEK,   ?",
+      "DAY_OF_WEEK,   1#1",
+      "DAY_OF_WEEK,   6#10",
+      "DAY_OF_WEEK,   6L",
+      "YEAR,          *",
+      "YEAR,          ?"
+    })
+    void should_matches_pattern(CronUnit unit, String actual) {
+      assertThat(Pattern.matches(unit.wildcardPattern(), actual)).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+      "SECONDS,       abc",
+      "MINUTES,       2,3",
+      "HOURS,         ef",
+      "DAY_OF_MONTH,  WL",
+      "DAY_OF_MONTH,  W",
+      "DAY_OF_MONTH,  ?a",
+      "DAY_OF_MONTH,  -2W",
+      "DAY_OF_MONTH,  32W",
+      "DAY_OF_WEEK,   -1#1",
+      "DAY_OF_WEEK,   1#",
+      "DAY_OF_WEEK,   #2",
+      "DAY_OF_WEEK,   3#a",
+      "DAY_OF_WEEK,   8L",
+    })
+    void should_fail_to_matches_pattern(CronUnit unit, String actual) {
+      assertThat(Pattern.matches(unit.wildcardPattern(), actual)).isFalse();
+    }
+
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronField_parse_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/cronexpressions/CronField_parse_Test.java
@@ -1,0 +1,45 @@
+package org.assertj.core.internal.cronexpressions;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.CronField;
+import org.assertj.core.internal.CronUnit;
+import org.assertj.core.internal.Failures;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.TestData.someInfo;
+
+/**
+ * Tests for <code>{@link CronField#parse(AssertionInfo, Failures)}</code>.
+ * @author Neil Wang
+ */
+class CronField_parse_Test {
+
+  @ParameterizedTest
+  @MethodSource("source")
+  void should_parse_as_expect(CronUnit unit, String actual, String[] expect) {
+    AssertionInfo info = someInfo();
+    CronField cronField = new CronField(unit, actual);
+    cronField.parse(info, Failures.instance());
+    assertThat(cronField.parsedValues()).containsExactly(expect);
+  }
+
+  public static Stream<Arguments> source() {
+    return Stream.of(
+      Arguments.of(CronUnit.SECONDS, "*", new String[]{"*"}),
+      Arguments.of(CronUnit.SECONDS, "1", new String[]{"1"}),
+      Arguments.of(CronUnit.SECONDS, "1,2", new String[]{"1", "2"}),
+      Arguments.of(CronUnit.SECONDS, "1,1-5", new String[]{"1", "2", "3", "4", "5"}),
+      Arguments.of(CronUnit.SECONDS, "1,1-7/2", new String[]{"1", "3", "5", "7"}),
+      Arguments.of(CronUnit.SECONDS, "1,0/10", new String[]{"0", "1", "10", "20", "30", "40", "50"}),
+      Arguments.of(CronUnit.SECONDS, "1,3/10", new String[]{"1", "3", "13", "23", "33", "43", "53"}),
+      Arguments.of(CronUnit.SECONDS, "1,*/10", new String[]{"0", "1", "10", "20", "30", "40", "50"}),
+      Arguments.of(CronUnit.YEAR, "?", new String[]{"?"})
+    );
+  }
+
+}


### PR DESCRIPTION
It contains following apis:
~~~java
CronExpression cronExpression = new CronExpression("* * * * * *"); 
assertThat(cronExpression).isValid();
assertThat(cronExpression).containsExactlySeconds(...); 
assertThat(cronExpression).containsExactlyMinutes(...); 
assertThat(cronExpression).containsExactlyHours(...); 
assertThat(cronExpression).containsExactlyDayOfMonth(...); 
assertThat(cronExpression).containsExactlyMonth(...); 
assertThat(cronExpression).containsExactlyDayOfWeek(...); 
assertThat(cronExpression).containsExactlyYear(...);
~~~

#### Check List:
* Fixes #3212 (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
