### PR TITLE
Better error message instead of "actual is not empty while group of values to look for is" #3230

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ActualIsNotEmpty.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ActualIsNotEmpty.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+public class ActualIsNotEmpty extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory actualIsNotEmpty(Object expected) {
+    return new ActualIsNotEmpty(expected);
+  }
+
+  private ActualIsNotEmpty(Object expected) {
+    super("%nActual:%n  %s%nis not empty while group of values to look for is.", expected);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Arrays.java
@@ -89,6 +89,7 @@ import java.util.Set;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.Condition;
 import org.assertj.core.data.Index;
+import org.assertj.core.error.ActualIsNotEmpty;
 import org.assertj.core.util.ArrayWrapperList;
 import org.assertj.core.util.VisibleForTesting;
 
@@ -196,7 +197,7 @@ public class Arrays {
 
   @VisibleForTesting
   public void assertContains(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values)) return;
+    if (commonChecks(info, failures, actual, values)) return;
     Set<Object> notFound = new LinkedHashSet<>();
     int valueCount = sizeOf(values);
     for (int i = 0; i < valueCount; i++) {
@@ -243,7 +244,7 @@ public class Arrays {
   }
 
   void assertContainsOnly(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values)) return;
+    if (commonChecks(info, failures, actual, values)) return;
     List<Object> notExpected = asList(actual);
     List<Object> notFound = asList(values);
 
@@ -274,7 +275,7 @@ public class Arrays {
   }
 
   void assertContainsExactly(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values)) return;
+    if (commonChecks(info, failures, actual, values)) return;
     assertIsArray(info, actual);
     assertIsArray(info, values);
 
@@ -297,7 +298,7 @@ public class Arrays {
   }
 
   void assertContainsExactlyInAnyOrder(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values)) return;
+    if (commonChecks(info, failures, actual, values)) return;
     List<Object> notExpected = asList(actual);
     List<Object> notFound = asList(values);
 
@@ -314,7 +315,7 @@ public class Arrays {
   }
 
   void assertContainsOnlyOnce(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values))
+    if (commonChecks(info, failures, actual, values))
       return;
     Iterable<?> actualDuplicates = comparisonStrategy.duplicatesFrom(asList(actual));
     Set<Object> notFound = new LinkedHashSet<>();
@@ -344,7 +345,7 @@ public class Arrays {
   }
 
   void assertContainsSequence(AssertionInfo info, Failures failures, Object actual, Object sequence) {
-    if (commonChecks(info, actual, sequence)) return;
+    if (commonChecks(info, failures, actual, sequence)) return;
     // look for given sequence, stop check when there are not enough elements remaining in actual to contain sequence
     int lastIndexWhereSequenceCanBeFound = sizeOf(actual) - sizeOf(sequence);
     for (int actualIndex = 0; actualIndex <= lastIndexWhereSequenceCanBeFound; actualIndex++) {
@@ -354,7 +355,7 @@ public class Arrays {
   }
 
   void assertDoesNotContainSequence(AssertionInfo info, Failures failures, Object actual, Object sequence) {
-    if (commonChecks(info, actual, sequence)) return;
+    if (commonChecks(info, failures, actual, sequence)) return;
 
     // look for given sequence, stop check when there are not enough elements remaining in actual to contain sequence
     int lastIndexWhereSequenceCanBeFound = sizeOf(actual) - sizeOf(sequence);
@@ -383,7 +384,7 @@ public class Arrays {
   }
 
   void assertContainsSubsequence(AssertionInfo info, Failures failures, Object actual, Object subsequence) {
-    if (commonChecks(info, actual, subsequence)) return;
+    if (commonChecks(info, failures, actual, subsequence)) return;
 
     int sizeOfActual = sizeOf(actual);
     int sizeOfSubsequence = sizeOf(subsequence);
@@ -422,7 +423,7 @@ public class Arrays {
   }
 
   void assertDoesNotContainSubsequence(AssertionInfo info, Failures failures, Object actual, Object subsequence) {
-    if (commonChecks(info, actual, subsequence)) return;
+    if (commonChecks(info, failures, actual, subsequence)) return;
 
     int sizeOfActual = sizeOf(actual);
     int sizeOfSubsequence = sizeOf(subsequence);
@@ -480,7 +481,7 @@ public class Arrays {
   }
 
   void assertStartsWith(AssertionInfo info, Failures failures, Object actual, Object sequence) {
-    if (commonChecks(info, actual, sequence))
+    if (commonChecks(info, failures, actual, sequence))
       return;
     int sequenceSize = sizeOf(sequence);
     int arraySize = sizeOf(actual);
@@ -491,11 +492,11 @@ public class Arrays {
     }
   }
 
-  private static boolean commonChecks(AssertionInfo info, Object actual, Object sequence) {
+  private static boolean commonChecks(AssertionInfo info, Failures failures, Object actual, Object sequence) {
     checkNulls(info, actual, sequence);
     // if both actual and values are empty arrays, then assertion passes.
     if (isArrayEmpty(actual) && isArrayEmpty(sequence)) return true;
-    failIfEmptySinceActualIsNotEmpty(sequence);
+    failIfEmptySinceActualIsNotEmpty(info, failures, actual, sequence);
     return false;
 
   }
@@ -626,7 +627,7 @@ public class Arrays {
   }
 
   public void assertContainsAnyOf(AssertionInfo info, Failures failures, Object actual, Object values) {
-    if (commonChecks(info, actual, values)) return;
+    if (commonChecks(info, failures, actual, values)) return;
     assertIsArray(info, actual);
     assertIsArray(info, values);
 
@@ -770,8 +771,9 @@ public class Arrays {
     Objects.instance().assertNotNull(info, array);
   }
 
-  private static void failIfEmptySinceActualIsNotEmpty(Object values) {
-    if (isArrayEmpty(values)) throw new AssertionError("actual is not empty while group of values to look for is.");
+  private static void failIfEmptySinceActualIsNotEmpty(AssertionInfo info, Failures failures, Object actual,
+                                                       Object values) {
+    if (isArrayEmpty(values)) throw failures.failure(info, ActualIsNotEmpty.actualIsNotEmpty(actual));
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/internal/CommonValidations.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CommonValidations.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
 import static org.assertj.core.error.ShouldHaveLineCount.shouldHaveLinesCount;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
@@ -37,6 +38,7 @@ import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
 import org.assertj.core.data.Percentage;
+import org.assertj.core.error.ActualIsNotEmpty;
 
 /**
  * @author Alex Ruiz
@@ -93,8 +95,9 @@ public final class CommonValidations {
     checkIsNotEmpty(iterable);
   }
 
-  public static void failIfEmptySinceActualIsNotEmpty(Object[] values) {
-    if (values.length == 0) throw new AssertionError("actual is not empty while group of values to look for is.");
+  public static void failIfEmptySinceActualIsNotEmpty(AssertionInfo info, Failures failures, Object actual,
+                                                      Object[] values) {
+    if (values.length == 0) throw failures.failure(info, actualIsNotEmpty(actual));
   }
 
   public static void hasSameSizeAsCheck(AssertionInfo info, Object actual, Object other, int sizeOfActual) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -345,7 +345,7 @@ public class Iterables {
    */
   public void assertContains(AssertionInfo info, Iterable<?> actual, Object[] values) {
     final Collection<?> actualAsCollection = ensureActualCanBeReadMultipleTimes(actual);
-    if (commonCheckThatIterableAssertionSucceeds(info, actualAsCollection, values)) return;
+    if (commonCheckThatIterableAssertionSucceeds(info, failures, actualAsCollection, values)) return;
     // check for elements in values that are missing in actual.
     assertIterableContainsGivenValues(actual.getClass(), actualAsCollection, values, info);
   }
@@ -429,7 +429,7 @@ public class Iterables {
    *           {@code Iterable} contains values that are not in the given array.
    */
   public void assertContainsOnlyOnce(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, values)) return;
+    if (commonCheckThatIterableAssertionSucceeds(info, failures, actual, values)) return;
     // check for elements in values that are missing in actual.
     Set<Object> notFound = new LinkedHashSet<>();
     Set<Object> notOnlyOnce = new LinkedHashSet<>();
@@ -486,7 +486,7 @@ public class Iterables {
     // exhausted. Of course if 'actual' really is infinite then this could take a while :-D
     final Iterator<?> actualIterator = actual.iterator();
     if (!actualIterator.hasNext() && sequence.length == 0) return;
-    failIfEmptySinceActualIsNotEmpty(sequence);
+    failIfEmptySinceActualIsNotEmpty(info, failures, actual, sequence);
     // we only store sequence.length entries from actual in the LIFO, no need for more.
     Lifo lifo = new Lifo(sequence.length);
     while (actualIterator.hasNext()) {
@@ -557,7 +557,7 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not contain the given subsequence of objects.
    */
   public void assertContainsSubsequence(AssertionInfo info, Iterable<?> actual, Object[] subsequence) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, subsequence)) return;
+    if (commonCheckThatIterableAssertionSucceeds(info, failures, actual, subsequence)) return;
     if (sizeOf(actual) < subsequence.length) {
       throw failures.failure(info, actualDoesNotHaveEnoughElementsToContainSubsequence(actual, subsequence));
     }
@@ -736,7 +736,7 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not start with the given sequence of objects.
    */
   public void assertStartsWith(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, sequence)) return;
+    if (commonCheckThatIterableAssertionSucceeds(info, failures, actual, sequence)) return;
     int i = 0;
     for (Object actualCurrentElement : actual) {
       if (i >= sequence.length) break;
@@ -800,11 +800,12 @@ public class Iterables {
     }
   }
 
-  private boolean commonCheckThatIterableAssertionSucceeds(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
+  private boolean commonCheckThatIterableAssertionSucceeds(AssertionInfo info, Failures failures, Iterable<?> actual,
+                                                           Object[] sequence) {
     checkNotNullIterables(info, actual, sequence);
     // if both actual and values are empty, then assertion passes.
     if (!actual.iterator().hasNext() && sequence.length == 0) return true;
-    failIfEmptySinceActualIsNotEmpty(sequence);
+    failIfEmptySinceActualIsNotEmpty(info, failures, actual, sequence);
     return false;
   }
 
@@ -1381,7 +1382,7 @@ public class Iterables {
    * @throws AssertionError if the given {@code Iterable} does not contain any of given {@code values}.
    */
   public void assertContainsAnyOf(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    if (commonCheckThatIterableAssertionSucceeds(info, actual, values))
+    if (commonCheckThatIterableAssertionSucceeds(info, failures, actual, values))
       return;
 
     Iterable<Object> valuesToSearchFor = newArrayList(values);

--- a/assertj-core/src/test/java/org/assertj/core/error/ActualIsNotEmpty_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ActualIsNotEmpty_create_Test.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2023 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.TestCondition;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.data.Index.atIndex;
+import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
+import static org.assertj.core.error.ShouldBeAtIndex.shouldBeAtIndex;
+import static org.assertj.core.util.Lists.list;
+
+/**
+ * Tests for <code>{@link ActualIsNotEmpty#create(Description, org.assertj.core.presentation.Representation)}</code>.
+ *
+ * @author Paweł Baczyński
+ */
+class ActualIsNotEmpty_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = actualIsNotEmpty(Arrays.array("Yoda", "Luke"));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %nActual:%n  [\"Yoda\", \"Luke\"]%nis not empty while group of values to look for is."));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsSubsequence_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal.iterables;
 
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
 import static org.assertj.core.error.ShouldContainSubsequence.actualDoesNotHaveEnoughElementsToContainSubsequence;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -99,9 +100,9 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     // GIVEN
     Object[] subsequence = {};
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> iterables.assertContainsSubsequence(INFO, actual, subsequence));
+    expectAssertionError(() -> iterables.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    then(assertionError).hasMessage("actual is not empty while group of values to look for is.");
+    verify(failures).failure(INFO, actualIsNotEmpty(actual));
   }
 
   @Test
@@ -205,11 +206,10 @@ class Iterables_assertContainsSubsequence_Test extends IterablesBaseTest {
     // GIVEN
     Object[] subsequence = {};
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO,
-                                                                                                                                        actual,
-                                                                                                                                        subsequence));
+    expectAssertionError(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertContainsSubsequence(INFO, actual,
+                                                                                                        subsequence));
     // THEN
-    then(assertionError).hasMessage("actual is not empty while group of values to look for is.");
+    verify(failures).failure(INFO, actualIsNotEmpty(actual));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.internal.objectarrays;
 
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ActualIsNotEmpty.actualIsNotEmpty;
 import static org.assertj.core.error.ShouldContainSubsequence.actualDoesNotHaveEnoughElementsToContainSubsequence;
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
@@ -100,9 +101,9 @@ class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBaseTest {
     // GIVEN
     Object[] subsequence = {};
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> arrays.assertContainsSubsequence(INFO, actual, subsequence));
+    expectAssertionError(() -> arrays.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    then(assertionError).hasMessage("actual is not empty while group of values to look for is.");
+    verify(failures).failure(INFO, actualIsNotEmpty(actual));
   }
 
   @Test
@@ -190,11 +191,9 @@ class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBaseTest {
     // GIVEN
     Object[] subsequence = {};
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(INFO,
-                                                                                                                            actual,
-                                                                                                                            subsequence));
+    expectAssertionError(() -> arraysWithCustomComparisonStrategy.assertContainsSubsequence(INFO, actual, subsequence));
     // THEN
-    then(assertionError).hasMessage("actual is not empty while group of values to look for is.");
+    verify(failures).failure(INFO, actualIsNotEmpty(actual));
   }
 
   @Test


### PR DESCRIPTION
This changes the message for arrays and iterables as mentioned in #3230

#### Check List:
* Fixes #3230
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
