### PR TITLE
Revert "Provide value when assertThatThrownBy/thenThrownBy fail"

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -12,7 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
 import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.data.Percentage.withPercentage;
 
@@ -76,7 +75,6 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallableWithValue;
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
 import org.assertj.core.api.filter.InFilter;
@@ -98,7 +96,6 @@ import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
-import org.assertj.core.internal.Failures;
 import org.assertj.core.presentation.BinaryRepresentation;
 import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
@@ -1213,26 +1210,6 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Similar to {@link #assertThatThrownBy(ThrowingCallable)}, but when the called code returns a value instead of
-   * throwing, the assertion error shows the returned value to help understand what went wrong.
-   *
-   * @param shouldRaiseThrowable The {@link ThrowingCallableWithValue} or lambda with the code that should raise the throwable.
-   * @return the created {@link ThrowableAssert}.
-   * @since 3.25.0
-   */
-  @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(
-                                                                                   ThrowingCallableWithValue shouldRaiseThrowable) {
-    Object value;
-    try {
-      value = shouldRaiseThrowable.call();
-    } catch (Throwable throwable) {
-      return assertThat(throwable);
-    }
-    throw Failures.instance().failure(format("Expecting code to raise a throwable, but it returned [%s] instead", value));
-  }
-
-  /**
    * Allows to capture and then assert on a {@link Throwable} like {@code assertThatThrownBy(ThrowingCallable)} but this method
    * let you set the assertion description the same way you do with {@link AbstractAssert#as(String, Object...) as(String, Object...)}.
    * <p>
@@ -1268,26 +1245,6 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
-  }
-
-  /**
-   * Similar to {@link #assertThatThrownBy(ThrowingCallable, String, Object...)}, but when the called code returns a value
-   * instead of throwing, the assertion error shows the returned value to help understand what went wrong.
-   *
-   * @param shouldRaiseThrowable The {@link ThrowingCallableWithValue} or lambda with the code that should raise the throwable.
-   * @return the created {@link ThrowableAssert}.
-   * @since 3.25.0
-   */
-  @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallableWithValue shouldRaiseThrowable,
-                                                                                   String description, Object... args) {
-    Object value;
-    try {
-      value = shouldRaiseThrowable.call();
-    } catch (Throwable throwable) {
-      return assertThat(throwable).as(description, args);
-    }
-    throw Failures.instance().failure(format("Expecting code to raise a throwable, but it returned [%s] instead", value));
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -12,8 +12,6 @@
  */
 package org.assertj.core.api;
 
-import static java.lang.String.format;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,7 +72,6 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallableWithValue;
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.InFilter;
 import org.assertj.core.api.filter.NotFilter;
@@ -92,7 +89,6 @@ import org.assertj.core.data.TemporalUnitOffset;
 import org.assertj.core.description.Description;
 import org.assertj.core.groups.Properties;
 import org.assertj.core.groups.Tuple;
-import org.assertj.core.internal.Failures;
 import org.assertj.core.presentation.BinaryRepresentation;
 import org.assertj.core.presentation.HexadecimalRepresentation;
 import org.assertj.core.presentation.Representation;
@@ -1335,25 +1331,6 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Similar to {@link #thenThrownBy(ThrowingCallable)}, but when the called code returns a value instead of
-   * throwing, the assertion error shows the returned value to help understand what went wrong.
-   *
-   * @param shouldRaiseThrowable The {@link ThrowingCallableWithValue} or lambda with the code that should raise the throwable.
-   * @return the created {@link ThrowableAssert}.
-   * @since 3.25.0
-   */
-  @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallableWithValue shouldRaiseThrowable) {
-    Object value;
-    try {
-      value = shouldRaiseThrowable.call();
-    } catch (Throwable throwable) {
-      return assertThat(throwable);
-    }
-    throw Failures.instance().failure(format("Expecting code to raise a throwable, but it returned [%s] instead", value));
-  }
-
-  /**
    * Allows to capture and then assert on a {@link Throwable} like {@code thenThrownBy(ThrowingCallable)} but this method
    * let you set the assertion description the same way you do with {@link AbstractAssert#as(String, Object...) as(String, Object...)}.
    * <p>
@@ -1388,26 +1365,6 @@ public class BDDAssertions extends Assertions {
   public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
-  }
-
-  /**
-   * Similar to {@link #thenThrownBy(ThrowingCallable, String, Object...)}, but when the called code returns a value instead of
-   * throwing, the assertion error shows the returned value to help understand what went wrong.
-   *
-   * @param shouldRaiseThrowable The {@link ThrowingCallableWithValue} or lambda with the code that should raise the throwable.
-   * @return the created {@link ThrowableAssert}.
-   * @since 3.25.0
-   */
-  @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallableWithValue shouldRaiseThrowable,
-                                                                             String description, Object... args) {
-    Object value;
-    try {
-      value = shouldRaiseThrowable.call();
-    } catch (Throwable throwable) {
-      return assertThat(throwable).as(description, args);
-    }
-    throw Failures.instance().failure(format("Expecting code to raise a throwable, but it returned [%s] instead", value));
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -33,10 +33,6 @@ public class ThrowableAssert<ACTUAL extends Throwable> extends AbstractThrowable
     void call() throws Throwable;
   }
 
-  public interface ThrowingCallableWithValue {
-    Object call() throws Throwable;
-  }
-
   public ThrowableAssert(ACTUAL actual) {
     super(actual, ThrowableAssert.class);
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_from_ThrowingCallable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_from_ThrowingCallable_Test.java
@@ -12,10 +12,8 @@
  */
 package org.assertj.core.api.throwable;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
@@ -52,14 +50,7 @@ class ThrowableAssert_built_from_ThrowingCallable_Test {
           // no exception
         }
       });
-    }).withMessage(format("%nExpecting code to raise a throwable."));
+    }).withMessage(String.format("%nExpecting code to raise a throwable."));
   }
 
-  @Test
-  void should_fail_and_show_value_returned_by_callable_code() {
-    // GIVEN
-    ThrowingCallable code = () -> assertThatThrownBy(() -> 42);
-    // WHEN/THEN
-    assertThatAssertionErrorIsThrownBy(code).withMessage("Expecting code to raise a throwable, but it returned [42] instead");
-  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_with_then_method_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_built_with_then_method_Test.java
@@ -14,11 +14,11 @@ package org.assertj.core.api.throwable;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
-import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
+// TODO build two throwable assert with then and assertThat and compare them.
 class ThrowableAssert_built_with_then_method_Test {
 
   @Test
@@ -54,11 +54,4 @@ class ThrowableAssert_built_with_then_method_Test {
     }).withMessage(String.format("%nExpecting code to raise a throwable."));
   }
 
-  @Test
-  void should_fail_if_value_is_returned_by_callable_code() {
-    // GIVEN
-    ThrowingCallable code = () -> thenThrownBy(() -> 42);
-    // WHEN/THEN
-    assertThatAssertionErrorIsThrownBy(code).withMessage("Expecting code to raise a throwable, but it returned [42] instead");
-  }
 }


### PR DESCRIPTION
This reverts commit cf06398587da23ac530b03a941e0efe6cf29aef7, related to #3043.

Fixes #3314.