### PR TITLE
Add `doesNotContainKey` and `doesNotContainKeys` to Guava `Multimap` assertions

### DIFF
--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -363,10 +363,10 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
    * @throws NullPointerException if the varargs of keys is null
    */
   public MultimapAssert<K, V> doesNotContainKeys(K... keys) {
-    return doesNotContainKeysForProxy(keys);
+    return assertDoesNotContainKeys(keys);
   }
 
-  private MultimapAssert<K, V> doesNotContainKeysForProxy(K[] keys) {
+  private MultimapAssert<K, V> assertDoesNotContainKeys(K[] keys) {
     isNotNull();
     requireNonNull(keys, "The array of keys to look for should not be null");
     Set<K> foundKeys = findKeys(actual, keys);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -363,17 +363,15 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
    * @throws NullPointerException if the varargs of keys is null
    */
   public MultimapAssert<K, V> doesNotContainKeys(K... keys) {
-    return assertDoesNotContainKeys(keys);
+    isNotNull();
+    assertDoesNotContainKeys(keys);
+    return this;
   }
 
-  private MultimapAssert<K, V> assertDoesNotContainKeys(K[] keys) {
-    isNotNull();
+  private void assertDoesNotContainKeys(K[] keys) {
     requireNonNull(keys, "The array of keys to look for should not be null");
     Set<K> foundKeys = findKeys(actual, keys);
-    if (!foundKeys.isEmpty()) {
-      throw assertionError(shouldNotContainKeys(actual, foundKeys));
-    }
-    return this;
+    if (!foundKeys.isEmpty()) throw assertionError(shouldNotContainKeys(actual, foundKeys));
   }
 
   private static <K> Set<K> findKeys(Multimap<K, ?> actual, K[] expectedKeys) {
@@ -386,4 +384,5 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     }
     return foundKeys;
   }
+
 }

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -335,6 +335,7 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
    * @return {@code this} assertions object
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map contains the given key.
+   * @since 3.26.0
    */
   public MultimapAssert<K, V> doesNotContainKey(K key) {
     return doesNotContainKeys(key);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -369,21 +369,21 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
   protected MultimapAssert<K, V> doesNotContainKeysForProxy(K[] keys) {
     isNotNull();
     requireNonNull(keys, "The array of keys to look for should not be null");
-    Set<K> found = findKeys(actual, keys);
-    if (!found.isEmpty()) {
-      throw assertionError(ShouldNotContainKeys.shouldNotContainKeys(actual, found));
+    Set<K> foundKeys = findKeys(actual, keys);
+    if (!foundKeys.isEmpty()) {
+      throw assertionError(ShouldNotContainKeys.shouldNotContainKeys(actual, foundKeys));
     }
     return this;
   }
 
   private static <K> Set<K> findKeys(Multimap<K, ?> actual, K[] expectedKeys) {
     // Stream API avoided for performance reasons
-    Set<K> found = new LinkedHashSet<>();
+    Set<K> foundKeys = new LinkedHashSet<>();
     for (K expectedKey : expectedKeys) {
       if (actual.containsKey(expectedKey)) {
-        found.add(expectedKey);
+        foundKeys.add(expectedKey);
       }
     }
-    return found;
+    return foundKeys;
   }
 }

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -362,6 +362,7 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
    * @throws AssertionError if the actual map is {@code null}.
    * @throws AssertionError if the actual map contains the given key.
    * @throws NullPointerException if the varargs of keys is null
+   * @since 3.26.0
    */
   public MultimapAssert<K, V> doesNotContainKeys(K... keys) {
     isNotNull();

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -21,6 +21,7 @@ import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
 import static org.assertj.guava.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.guava.error.ShouldContainValues.shouldContainValues;
 import static org.assertj.guava.util.ExceptionUtils.throwIllegalArgumentExceptionIfTrue;
@@ -35,7 +36,6 @@ import org.assertj.core.data.MapEntry;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
-import org.assertj.core.error.ShouldNotContainKeys;
 
 /**
  * Assertions for guava {@link Multimap}.
@@ -366,12 +366,12 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     return doesNotContainKeysForProxy(keys);
   }
 
-  protected MultimapAssert<K, V> doesNotContainKeysForProxy(K[] keys) {
+  private MultimapAssert<K, V> doesNotContainKeysForProxy(K[] keys) {
     isNotNull();
     requireNonNull(keys, "The array of keys to look for should not be null");
     Set<K> foundKeys = findKeys(actual, keys);
     if (!foundKeys.isEmpty()) {
-      throw assertionError(ShouldNotContainKeys.shouldNotContainKeys(actual, foundKeys));
+      throw assertionError(shouldNotContainKeys(actual, foundKeys));
     }
     return this;
   }

--- a/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
+++ b/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
@@ -12,34 +12,39 @@
  */
 package org.assertj.guava.api;
 
-import com.google.common.collect.LinkedHashMultimap;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.set;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.guava.testkit.AssertionErrors.expectAssertionError;
+
 import org.junit.jupiter.api.Test;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.guava.api.Assertions.assertThat;
+import com.google.common.collect.LinkedHashMultimap;
 
-public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTest {
+class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTest {
 
   @Test
-  public void should_fail_if_actual_is_null() {
+  void should_fail_if_actual_is_null() {
     // GIVEN
     actual = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Nets", "Bulls", "Knicks"));
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKeys("Nets", "Bulls", "Knicks"));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(actualIsNull());
+    then(error).hasMessage(actualIsNull());
   }
 
   @Test
-  public void should_pass_if_actual_does_not_contains_given_key() {
+  void should_pass_if_actual_does_not_contains_given_key() {
+    // WHEN/THEN
     assertThat(actual).doesNotContainKeys("apples");
   }
 
   @Test
-  public void should_pass_if_actual_does_not_contains_given_keys() {
+  void should_pass_if_actual_does_not_contains_given_keys() {
+    // WHEN/THEN
     assertThat(actual).doesNotContainKeys("apples", "oranges");
   }
 
@@ -48,17 +53,11 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
     // GIVEN
     actual = LinkedHashMultimap.create();
     actual.put(null, "apples");
-
+    String key = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKey(null));
-
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKey(key));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("%n" +
-                                                      "Expecting actual:%n" +
-                                                      "  {null=[apples]}%n" +
-                                                      "not to contain key:%n" +
-                                                      "  null"));
+    then(error).hasMessage(shouldNotContainKeys(actual, set(key)).create());
   }
 
   @Test
@@ -66,69 +65,46 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
     // GIVEN
     actual = LinkedHashMultimap.create();
     actual.put(null, "apples");
-
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("cheese", null));
-
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("%n" +
-                                                      "Expecting actual:%n" +
-                                                      "  {null=[apples]}%n" +
-                                                      "not to contain key:%n" +
-                                                      "  null"));
+    String key = null;
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKeys("cheese", key));
+    // THEN
+    then(error).hasMessage(shouldNotContainKeys(actual, set(key)).create());
   }
 
   @Test
   void should_fail_with_null_array() {
+    // GIVEN
+    String[] keys = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys(null));
-
+    Throwable thrown = catchThrowable(() -> assertThat(actual).doesNotContainKeys(keys));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(NullPointerException.class)
-                                   .hasMessage("The array of keys to look for should not be null");
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage("The array of keys to look for should not be null");
   }
 
   @Test
   void should_fail_if_single_key_is_present() {
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKey("Bulls"));
-
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKey("Bulls"));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("%n" +
-                                                      "Expecting actual:%n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
-                                                      +
-                                                      "not to contain key:%n" +
-                                                      "  \"Bulls\""));
+    then(error).hasMessage(shouldNotContainKeys(actual, set("Bulls")).create());
   }
 
   @Test
   void should_fail_if_one_key_is_present() {
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks"));
-
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks"));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("%n" +
-                                                      "Expecting actual:%n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
-                                                      +
-                                                      "not to contain key:%n" +
-                                                      "  \"Bulls\""));
+    then(error).hasMessage(shouldNotContainKeys(actual, set("Bulls")).create());
   }
 
   @Test
   void should_fail_if_multiple_keys_are_present() {
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks", "Spurs"));
-
+    AssertionError error = expectAssertionError(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks", "Spurs"));
     // THEN
-    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("%n" +
-                                                      "Expecting actual:%n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
-                                                      +
-                                                      "not to contain keys:%n" +
-                                                      "  [\"Bulls\", \"Spurs\"]"));
+    then(error).hasMessage(shouldNotContainKeys(actual, set("Bulls", "Spurs")).create());
   }
+
 }

--- a/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
+++ b/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
@@ -54,10 +54,10 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
 
     // THEN
     org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("\n" +
-                                                      "Expecting actual:\n" +
-                                                      "  {null=[apples]}\n" +
-                                                      "not to contain key:\n" +
+                                   .hasMessage(format("%n" +
+                                                      "Expecting actual:%n" +
+                                                      "  {null=[apples]}%n" +
+                                                      "not to contain key:%n" +
                                                       "  null"));
   }
 
@@ -70,10 +70,10 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
     Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("cheese", null));
 
     org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("\n" +
-                                                      "Expecting actual:\n" +
-                                                      "  {null=[apples]}\n" +
-                                                      "not to contain key:\n" +
+                                   .hasMessage(format("%n" +
+                                                      "Expecting actual:%n" +
+                                                      "  {null=[apples]}%n" +
+                                                      "not to contain key:%n" +
                                                       "  null"));
   }
 
@@ -94,11 +94,11 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
 
     // THEN
     org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("\n" +
-                                                      "Expecting actual:\n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                   .hasMessage(format("%n" +
+                                                      "Expecting actual:%n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
                                                       +
-                                                      "not to contain key:\n" +
+                                                      "not to contain key:%n" +
                                                       "  \"Bulls\""));
   }
 
@@ -109,11 +109,11 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
 
     // THEN
     org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("\n" +
-                                                      "Expecting actual:\n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                   .hasMessage(format("%n" +
+                                                      "Expecting actual:%n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
                                                       +
-                                                      "not to contain key:\n" +
+                                                      "not to contain key:%n" +
                                                       "  \"Bulls\""));
   }
 
@@ -124,11 +124,11 @@ public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTe
 
     // THEN
     org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
-                                   .hasMessage(format("\n" +
-                                                      "Expecting actual:\n" +
-                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                   .hasMessage(format("%n" +
+                                                      "Expecting actual:%n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}%n"
                                                       +
-                                                      "not to contain keys:\n" +
+                                                      "not to contain keys:%n" +
                                                       "  [\"Bulls\", \"Spurs\"]"));
   }
 }

--- a/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
+++ b/assertj-guava/src/test/java/org/assertj/guava/api/MultimapAssert_doesNotContainKeys_Test.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import com.google.common.collect.LinkedHashMultimap;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+public class MultimapAssert_doesNotContainKeys_Test extends MultimapAssertBaseTest {
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Nets", "Bulls", "Knicks"));
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_given_key() {
+    assertThat(actual).doesNotContainKeys("apples");
+  }
+
+  @Test
+  public void should_pass_if_actual_does_not_contains_given_keys() {
+    assertThat(actual).doesNotContainKeys("apples", "oranges");
+  }
+
+  @Test
+  void should_fail_with_null_key() {
+    // GIVEN
+    actual = LinkedHashMultimap.create();
+    actual.put(null, "apples");
+
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKey(null));
+
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(format("\n" +
+                                                      "Expecting actual:\n" +
+                                                      "  {null=[apples]}\n" +
+                                                      "not to contain key:\n" +
+                                                      "  null"));
+  }
+
+  @Test
+  void should_fail_with_null_key_in_array() {
+    // GIVEN
+    actual = LinkedHashMultimap.create();
+    actual.put(null, "apples");
+
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("cheese", null));
+
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(format("\n" +
+                                                      "Expecting actual:\n" +
+                                                      "  {null=[apples]}\n" +
+                                                      "not to contain key:\n" +
+                                                      "  null"));
+  }
+
+  @Test
+  void should_fail_with_null_array() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys(null));
+
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(NullPointerException.class)
+                                   .hasMessage("The array of keys to look for should not be null");
+  }
+
+  @Test
+  void should_fail_if_single_key_is_present() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKey("Bulls"));
+
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(format("\n" +
+                                                      "Expecting actual:\n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                                      +
+                                                      "not to contain key:\n" +
+                                                      "  \"Bulls\""));
+  }
+
+  @Test
+  void should_fail_if_one_key_is_present() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks"));
+
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(format("\n" +
+                                                      "Expecting actual:\n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                                      +
+                                                      "not to contain key:\n" +
+                                                      "  \"Bulls\""));
+  }
+
+  @Test
+  void should_fail_if_multiple_keys_are_present() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).doesNotContainKeys("Bulls", "Knicks", "Spurs"));
+
+    // THEN
+    org.assertj.core.api.Assertions.assertThat(throwable).isInstanceOf(AssertionError.class)
+                                   .hasMessage(format("\n" +
+                                                      "Expecting actual:\n" +
+                                                      "  {Lakers=[Kobe Bryant, Magic Johnson, Kareem Abdul Jabbar], Bulls=[Michael Jordan, Scottie Pippen, Derrick Rose], Spurs=[Tony Parker, Tim Duncan, Manu Ginobili]}\n"
+                                                      +
+                                                      "not to contain keys:\n" +
+                                                      "  [\"Bulls\", \"Spurs\"]"));
+  }
+}


### PR DESCRIPTION
Behavior matches the asserts for regular java.util Map asserts in core.
