### PR TITLE
DualValue avoid calling actual.hashCode() and expected.hashCode()

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
@@ -61,7 +60,8 @@ public final class DualValue {
     this.fieldLocation = requireNonNull(fieldLocation, "fieldLocation must not be null");
     actual = actualFieldValue;
     expected = expectedFieldValue;
-    hashCode = Objects.hash(actual, expected);
+    // System.identityHashCode for a null reference is zero
+    hashCode = 31 * (31 * (31 + System.identityHashCode(actual)) + System.identityHashCode(expected)) + fieldLocation.hashCode();
   }
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/DualValue_mutatedValues_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/DualValue_mutatedValues_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DualValue_mutatedValues_Test {
+
+  private static final class MutableType {
+    String changeMe;
+    private MutableType(String startingValue) {
+      changeMe = startingValue;
+    }
+
+    private void setChangeMe(String nextValue) {
+      changeMe = nextValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      MutableType that = (MutableType) o;
+      return Objects.equals(changeMe, that.changeMe);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(changeMe);
+    }
+  }
+
+  @Test
+  void isMutableValue_should_return_same_hashcode_after_mutation() {
+    // GIVEN
+    MutableType actual = new MutableType("One");
+    MutableType expected = new MutableType("One");
+    DualValue dualValue1 = new DualValue(Lists.list("changeMe"), actual, expected);
+    // WHEN
+    actual.setChangeMe("Another value");
+    DualValue dualValue2 = new DualValue(Lists.list("changeMe"), actual, expected);
+    // THEN
+    assertThat(dualValue1)
+      .isEqualTo(dualValue2)
+      .hasSameHashCodeAs(dualValue2);
+  }
+
+}


### PR DESCRIPTION
The hashCode of `DualValue` needs to match the object references of actual and expected, because that's what `equals` uses.

The current implementation caches the hashCode of both objects at construction, but this doesn't really match the requirement exactly.

The motivation for changing this is around avoiding calling hashCode unnecessarily on actual and expected objects, but I think it fixes potential bugs too. You could:
- Create a DualValue.
- Mutate a value in actual or expected that's present in the object's hashCode method.
- Create another DualValue.

Both of the DualValues would be equal to each other according to equals() but would have different hashcodes.

We can continue to cache the hashCode if you prefer, but better to generate it based on the object references using `System.identityHashCode`.

#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
