### PR TITLE
Added Throwable Stacktrace to ShouldHaveCauseExactlyInstance

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveCauseExactlyInstance.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveCauseExactlyInstance.java
@@ -33,7 +33,7 @@ public class ShouldHaveCauseExactlyInstance extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldHaveCauseExactlyInstance(Throwable actual,
                                                                    Class<? extends Throwable> expectedCauseType) {
     return actual.getCause() == null
-        ? new ShouldHaveCauseExactlyInstance(expectedCauseType)
+        ? new ShouldHaveCauseExactlyInstance(expectedCauseType, actual)
         : new ShouldHaveCauseExactlyInstance(actual, expectedCauseType);
   }
 
@@ -47,8 +47,8 @@ public class ShouldHaveCauseExactlyInstance extends BasicErrorMessageFactory {
           expectedCauseType, actual.getCause().getClass());
   }
 
-  private ShouldHaveCauseExactlyInstance(Class<? extends Throwable> expectedCauseType) {
-    super("%nExpecting a throwable with cause being exactly an instance of:%n  %s%nbut current throwable has no cause.",
-          expectedCauseType);
+  private ShouldHaveCauseExactlyInstance(Class<? extends Throwable> expectedCauseType, Throwable actual) {
+    super("%nExpecting a throwable with cause being exactly an instance of:%n  %s%nbut current throwable has no cause." +
+          "%nThrowable that failed the check:%n" + escapePercent(getStackTrace(actual)), expectedCauseType);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveCauseExactlyInstance_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveCauseExactlyInstance_create_Test.java
@@ -31,7 +31,8 @@ class ShouldHaveCauseExactlyInstance_create_Test {
     // THEN
     then(message).isEqualTo("%nExpecting a throwable with cause being exactly an instance of:%n" +
                             "  %s%n" +
-                            "but current throwable has no cause.", expected);
+                            "but current throwable has no cause." +
+                            "%nThrowable that failed the check:%n%s", expected, getStackTrace(actual));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
@@ -45,7 +45,7 @@ class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest
     Throwable actual = null;
     // WHEN
     AssertionError error = expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, actual,
-      IllegalArgumentException.class));
+                                                                                                 IllegalArgumentException.class));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -58,7 +58,7 @@ class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest
     Throwable throwable = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause, type));
     // THEN
     then(throwable).isInstanceOf(NullPointerException.class)
-      .hasMessage("The given type should not be null");
+                   .hasMessage("The given type should not be null");
   }
 
   @Test
@@ -77,11 +77,10 @@ class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
     // WHEN
     expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause,
-      expectedCauseType));
+                                                                          expectedCauseType));
     // THEN
     verify(failures).failure(INFO, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
-
 
   @Test
   void should_fail_if_cause_is_not_exactly_instance_of_expected_type() {
@@ -89,7 +88,7 @@ class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest
     Class<RuntimeException> expectedCauseType = RuntimeException.class;
     // WHEN
     expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause,
-      expectedCauseType));
+                                                                          expectedCauseType));
     // THEN
     verify(failures).failure(INFO, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
@@ -12,16 +12,14 @@
  */
 package org.assertj.core.internal.throwables;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldHaveCauseExactlyInstance.shouldHaveCauseExactlyInstance;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ThrowablesBaseTest;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * Tests for
  * {@link org.assertj.core.internal.Throwables#assertHasCauseExactlyInstanceOf(org.assertj.core.api.AssertionInfo, Throwable, Class)}
  * .
- * 
+ *
  * @author Jean-Christophe Gay
  */
 class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest {
@@ -43,51 +41,56 @@ class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest
 
   @Test
   void should_fail_if_actual_is_null() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> throwables.assertHasCauseExactlyInstanceOf(someInfo(), null,
-                                                                                                                IllegalArgumentException.class))
-                                                   .withMessage(actualIsNull());
+    // GIVEN
+    Throwable actual = null;
+    // WHEN
+    AssertionError error = expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, actual,
+      IllegalArgumentException.class));
+    // THEN
+    then(error).hasMessage(actualIsNull());
   }
 
   @Test
   void should_throw_NullPointerException_if_given_type_is_null() {
-    assertThatNullPointerException().isThrownBy(() -> throwables.assertHasCauseExactlyInstanceOf(someInfo(),
-                                                                                                 throwableWithCause,
-                                                                                                 null))
-                                    .withMessage("The given type should not be null");
+    // GIVEN
+    Class<? extends Throwable> type = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause, type));
+    // THEN
+    then(throwable).isInstanceOf(NullPointerException.class)
+      .hasMessage("The given type should not be null");
   }
 
   @Test
   void should_fail_if_actual_has_no_cause() {
-    AssertionInfo info = someInfo();
+    // GIVEN
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-
-    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, actual, expectedCauseType));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldHaveCauseExactlyInstance(actual, expectedCauseType));
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, actual, expectedCauseType));
+    // THEN
+    verify(failures).failure(INFO, shouldHaveCauseExactlyInstance(actual, expectedCauseType));
   }
 
   @Test
   void should_fail_if_cause_is_not_instance_of_expected_type() {
-    AssertionInfo info = someInfo();
+    // GIVEN
     Class<NullPointerException> expectedCauseType = NullPointerException.class;
-
-    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause,
-                                                                                      expectedCauseType));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause,
+      expectedCauseType));
+    // THEN
+    verify(failures).failure(INFO, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
+
 
   @Test
   void should_fail_if_cause_is_not_exactly_instance_of_expected_type() {
-    AssertionInfo info = someInfo();
+    // GIVEN
     Class<RuntimeException> expectedCauseType = RuntimeException.class;
-
-    Throwable error = catchThrowable(() -> throwables.assertHasCauseExactlyInstanceOf(info, throwableWithCause,
-                                                                                      expectedCauseType));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasCauseExactlyInstanceOf(INFO, throwableWithCause,
+      expectedCauseType));
+    // THEN
+    verify(failures).failure(INFO, shouldHaveCauseExactlyInstance(throwableWithCause, expectedCauseType));
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1355 
* Unit tests : YES (no new)
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

I'd like to help get this over the line 😄. I used this [commit](https://github.com/assertj/assertj/commit/9739d6995940b3cef37c9c99e6bd3d62ea84b704) as a guide/reference. Seems most of the changes where already done.