### PR TITLE
Add `createAssert(ValueProvider)` to `AssertFactory`

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -265,6 +265,8 @@
             <parameter>
               <excludes>
                 <exclude>org.assertj.core.internal</exclude>
+                <!-- Workaround for https://github.com/siom79/japicmp/issues/384 -->
+                <exclude>org.assertj.core.api.InstanceOfAssertFactory#getType()</exclude>
               </excludes>
               <overrideCompatibilityChangeParameters>
                 <!-- Unlikely that AssertJ users will encounter an IncompatibleClassChangeError (ref: JLS 13.5.6) -->

--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -265,8 +265,6 @@
             <parameter>
               <excludes>
                 <exclude>org.assertj.core.internal</exclude>
-                <!-- Workaround for https://github.com/siom79/japicmp/issues/384 -->
-                <exclude>org.assertj.core.api.InstanceOfAssertFactory#getType()</exclude>
               </excludes>
               <overrideCompatibilityChangeParameters>
                 <!-- Unlikely that AssertJ users will encounter an IncompatibleClassChangeError (ref: JLS 13.5.6) -->

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -478,7 +478,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   @CheckReturnValue
   public <ASSERT extends AbstractAssert<?, ?>> ASSERT asInstanceOf(InstanceOfAssertFactory<?, ASSERT> instanceOfAssertFactory) {
     requireNonNull(instanceOfAssertFactory, shouldNotBeNull("instanceOfAssertFactory")::create);
-    objects.assertIsInstanceOf(info, actual, instanceOfAssertFactory.getType());
+    objects.assertIsInstanceOf(info, actual, instanceOfAssertFactory.getRawClass());
     return (ASSERT) instanceOfAssertFactory.createAssert(actual).withAssertionState(myself);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
@@ -12,13 +12,9 @@
  */
 package org.assertj.core.api;
 
-import java.lang.reflect.Type;
-import java.util.Optional;
-
 /**
- * A functional interface to create an {@link Assert} for a given value.
- * <p>
- * The factory typically wraps a call to <code>assertThat(actual)</code>
+ * A single method factory interface to create an {@link Assert} for a given value.
+ * This factory method typically wraps a call to <code>assertThat(actual)</code>
  * to produce a concrete assert type {@code ASSERT} for the input element of type {@code T}.
  * <p>
  * This interface is typically used by navigation assertions on iterable types like {@link AbstractIterableAssert}
@@ -33,28 +29,12 @@ import java.util.Optional;
 public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
 
   /**
-   * Create the custom {@link Assert} instance for the given element value.
+   * Creates the custom {@link Assert} instance for the given element value.
    * <p>
    * Typically, this will just invoke <code>assertThat(actual)</code>
    * @param actual the input value for the {@code Assert} instance
    * @return returns the custom {@code Assert} instance for the given element value
    */
   ASSERT createAssert(T actual);
-
-  /**
-   * Return the {@link Type} of the input this factory expects, or an empty {@code Optional}
-   * if the information is not available.
-   * 
-   * @implSpec Overriding implementations providing a non-empty optional are required to
-   * return a {@code Type} instance consistent with the value of the factory type parameter {@link T}.
-   * 
-   * @implNote The default implementation always returns an empty {@code Optional}.
-   * 
-   * @return the expected type, or an empty {@code Optional} if the information is not available.
-   * @since 3.26.0
-   */
-  default Optional<Type> getType() {
-    return Optional.empty();
-  }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
@@ -46,11 +46,11 @@ public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
    * Creates the custom {@link Assert} instance for the value provided by the
    * given {@code valueProvider}.
    * <p>
-   * Overriding implementations might provide a {@link Type} instance to express the desired type
-   * of the value returned by the provider. When doing so, the factory is required to be consistent
-   * with type parameter {@link T}.
-   * <p>
    * The default implementation always requests a value compatible with {@code Object}.
+   * <p>
+   * Overriding implementations might provide a more specific {@link Type} instance to express
+   * the desired type of the value returned by the provider. When doing so, the factory is required
+   * to be consistent with type parameter {@link T}.
    *
    * @param valueProvider the value provider for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the value provided by the given value provider

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
@@ -17,17 +17,19 @@ import java.lang.reflect.Type;
 import java.util.function.Function;
 
 /**
- * A single method factory interface to create an {@link Assert} for a given value.
- * This factory method typically wraps a call to <code>assertThat(actual)</code>
- * to produce a concrete assert type {@code ASSERT} for the input element of type {@code T}.
+ * A factory that creates an {@link Assert} instance for a given value of type {@link T}.
  * <p>
- * This interface is typically used by navigation assertions on iterable types like {@link AbstractIterableAssert}
- * when calling {@link Assertions#assertThat(Iterable, AssertFactory) assertThat(Iterable&lt;E&gt;, AssertFactory&lt;E, ASSERT&gt;)}
+ * The {@link #createAssert(Object)} factory method typically wraps a call to
+ * {@link Assertions#assertThat}.
  * <p>
- * @param <T> the type of the input to the factory.
- * @param <ASSERT> the type of the resulting {@code Assert}.
+ * More advanced use cases can be achieved via {@link #createAssert(ValueProvider)},
+ * where the provision of the value is externalized and the factory can require
+ * explicit type compatibility for the value to be provided.
  *
+ * @param <T> the type of the given value.
+ * @param <ASSERT> the type of the resulting {@code Assert}.
  * @since 2.5.0 / 3.5.0
+ * @see InstanceOfAssertFactory
  */
 @FunctionalInterface
 public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
@@ -46,11 +48,14 @@ public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
    * Creates the custom {@link Assert} instance for the value provided by the
    * given {@code valueProvider}.
    * <p>
+   * This is typically used by custom assertions that want to leverage existing
+   * factories and need to manipulate the value upfront.
+   * <p>
    * The default implementation always requests a value compatible with {@code Object}.
    * <p>
-   * Overriding implementations might provide a more specific {@link Type} instance to express
-   * the desired type of the value returned by the provider. When doing so, the factory is required
-   * to be consistent with type parameter {@link T}.
+   * Overriding implementations might provide a more specific {@link Type}
+   * instance to express the desired type of the value returned by the provider.
+   * When doing so, the factory is required to be consistent with the type parameter {@link T}.
    *
    * @param valueProvider the value provider for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the value provided by the given value provider
@@ -76,7 +81,8 @@ public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
      * The compatibility definition depends on the actual {@code type} instance:
      * <ul>
      *   <li>If {@code type} is a {@link Class}, the provided value must be an instance of it.</li>
-     *   <li>If {@code type} is a {@link ParameterizedType}, the provided value must be an instance of its {@link ParameterizedType#getRawType() raw type}.</li>
+     *   <li>If {@code type} is a {@link ParameterizedType}, the provided value must be
+     *   an instance of its {@link ParameterizedType#getRawType() raw type}.</li>
      * </ul>
      * All other {@link Type} subtypes are unsupported.
      *
@@ -90,7 +96,8 @@ public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
      *
      * @param type the given type
      * @return the provided value
-     * @throws IllegalArgumentException if {@code type} is neither a {@link Class} nor a {@link ParameterizedType} instance
+     * @throws IllegalArgumentException if {@code type} is neither a {@link Class}
+     * nor a {@link ParameterizedType} instance
      */
     default T apply(Type type) {
       if (!(type instanceof Class || type instanceof ParameterizedType)) {

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertFactory.java
@@ -12,9 +12,13 @@
  */
 package org.assertj.core.api;
 
+import java.lang.reflect.Type;
+import java.util.Optional;
+
 /**
- * A single method factory interface to create an {@link Assert} for a given value.
- * This factory method typically wraps a call to <code>assertThat(actual)</code>
+ * A functional interface to create an {@link Assert} for a given value.
+ * <p>
+ * The factory typically wraps a call to <code>assertThat(actual)</code>
  * to produce a concrete assert type {@code ASSERT} for the input element of type {@code T}.
  * <p>
  * This interface is typically used by navigation assertions on iterable types like {@link AbstractIterableAssert}
@@ -29,12 +33,28 @@ package org.assertj.core.api;
 public interface AssertFactory<T, ASSERT extends Assert<?, ?>> {
 
   /**
-   * Creates the custom {@link Assert} instance for the given element value.
+   * Create the custom {@link Assert} instance for the given element value.
    * <p>
    * Typically, this will just invoke <code>assertThat(actual)</code>
    * @param actual the input value for the {@code Assert} instance
    * @return returns the custom {@code Assert} instance for the given element value
    */
   ASSERT createAssert(T actual);
+
+  /**
+   * Return the {@link Type} of the input this factory expects, or an empty {@code Optional}
+   * if the information is not available.
+   * 
+   * @implSpec Overriding implementations providing a non-empty optional are required to
+   * return a {@code Type} instance consistent with the value of the factory type parameter {@link T}.
+   * 
+   * @implNote The default implementation always returns an empty {@code Optional}.
+   * 
+   * @return the expected type, or an empty {@code Optional} if the information is not available.
+   * @since 3.26.0
+   */
+  default Optional<Type> getType() {
+    return Optional.empty();
+  }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -596,16 +596,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}.
    *
-   * @param <OBJECT>   the {@code AtomicIntegerFieldUpdater} object type.
+   * @param <T>        the {@code AtomicIntegerFieldUpdater} object type.
    * @param objectType the object type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_INTEGER_FIELD_UPDATER
    */
   @SuppressWarnings("rawtypes")
-  static <OBJECT> InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<OBJECT>> atomicIntegerFieldUpdater(Class<OBJECT> objectType) {
-    return new InstanceOfAssertFactory<>(AtomicIntegerFieldUpdater.class, new Class[] { objectType },
-                                         Assertions::<OBJECT> assertThat);
+  static <T> InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<T>> atomicIntegerFieldUpdater(Class<T> objectType) {
+    return new InstanceOfAssertFactory<>(AtomicIntegerFieldUpdater.class, new Class[] { objectType }, Assertions::<T> assertThat);
   }
 
   /**
@@ -637,16 +636,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicIntegerFieldUpdater}.
    *
-   * @param <OBJECT>   the {@code AtomicLongFieldUpdater} object type.
+   * @param <T>        the {@code AtomicLongFieldUpdater} object type.
    * @param objectType the object type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_LONG_FIELD_UPDATER
    */
   @SuppressWarnings("rawtypes")
-  static <OBJECT> InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<OBJECT>> atomicLongFieldUpdater(Class<OBJECT> objectType) {
-    return new InstanceOfAssertFactory<>(AtomicLongFieldUpdater.class, new Class[] { objectType },
-                                         Assertions::<OBJECT> assertThat);
+  static <T> InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<T>> atomicLongFieldUpdater(Class<T> objectType) {
+    return new InstanceOfAssertFactory<>(AtomicLongFieldUpdater.class, new Class[] { objectType }, Assertions::<T> assertThat);
   }
 
   /**
@@ -660,15 +658,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReference}.
    *
-   * @param <VALUE>   the {@code AtomicReference} value type.
+   * @param <V>       the {@code AtomicReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_REFERENCE
    */
   @SuppressWarnings("rawtypes")
-  static <VALUE> InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<VALUE>> atomicReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicReference.class, new Class[] { valueType }, Assertions::<VALUE> assertThat);
+  static <V> InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<V>> atomicReference(Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(AtomicReference.class, new Class[] { valueType }, Assertions::<V> assertThat);
   }
 
   /**
@@ -682,16 +680,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceArray}.
    *
-   * @param <ELEMENT>   the {@code AtomicReferenceArray} element type.
+   * @param <E>         the {@code AtomicReferenceArray} element type.
    * @param elementType the element type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_REFERENCE_ARRAY
    */
   @SuppressWarnings("rawtypes")
-  static <ELEMENT> InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<ELEMENT>> atomicReferenceArray(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(AtomicReferenceArray.class, new Class[] { elementType },
-                                         Assertions::<ELEMENT> assertThat);
+  static <E> InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<E>> atomicReferenceArray(Class<E> elementType) {
+    return new InstanceOfAssertFactory<>(AtomicReferenceArray.class, new Class[] { elementType }, Assertions::<E> assertThat);
   }
 
   /**
@@ -706,8 +703,8 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicReferenceFieldUpdater}.
    *
-   * @param <FIELD>    the {@code AtomicReferenceFieldUpdater} field type.
-   * @param <OBJECT>   the {@code AtomicReferenceFieldUpdater} object type.
+   * @param <T>        the {@code AtomicReferenceFieldUpdater} field type.
+   * @param <V>        the {@code AtomicReferenceFieldUpdater} object type.
    * @param fieldType  the field type instance.
    * @param objectType the object type instance.
    * @return the factory instance.
@@ -715,10 +712,10 @@ public interface InstanceOfAssertFactories {
    * @see #ATOMIC_REFERENCE_FIELD_UPDATER
    */
   @SuppressWarnings("rawtypes")
-  static <FIELD, OBJECT> InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT>> atomicReferenceFieldUpdater(Class<FIELD> fieldType,
-                                                                                                                                                            Class<OBJECT> objectType) {
+  static <T, V> InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<T, V>> atomicReferenceFieldUpdater(Class<T> fieldType,
+                                                                                                                                          Class<V> objectType) {
     return new InstanceOfAssertFactory<>(AtomicReferenceFieldUpdater.class, new Class[] { fieldType, objectType },
-                                         Assertions::<FIELD, OBJECT> assertThat);
+                                         Assertions::<T, V> assertThat);
   }
 
   /**
@@ -732,16 +729,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicMarkableReference}.
    *
-   * @param <VALUE>   the {@code AtomicMarkableReference} value type.
+   * @param <V>       the {@code AtomicMarkableReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_MARKABLE_REFERENCE
    */
   @SuppressWarnings("rawtypes")
-  static <VALUE> InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<VALUE>> atomicMarkableReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicMarkableReference.class, new Class[] { valueType },
-                                         Assertions::<VALUE> assertThat);
+  static <V> InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<V>> atomicMarkableReference(Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(AtomicMarkableReference.class, new Class[] { valueType }, Assertions::<V> assertThat);
   }
 
   /**
@@ -755,15 +751,15 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicStampedReference}.
    *
-   * @param <VALUE>   the {@code AtomicStampedReference} value type.
+   * @param <V>       the {@code AtomicStampedReference} value type.
    * @param valueType the value type instance.
    * @return the factory instance.
    *
    * @see #ATOMIC_STAMPED_REFERENCE
    */
   @SuppressWarnings("rawtypes")
-  static <VALUE> InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<VALUE>> atomicStampedReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicStampedReference.class, new Class[] { valueType }, Assertions::<VALUE> assertThat);
+  static <V> InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<V>> atomicStampedReference(Class<V> valueType) {
+    return new InstanceOfAssertFactory<>(AtomicStampedReference.class, new Class[] { valueType }, Assertions::<V> assertThat);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -87,7 +87,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #predicate(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Predicate, PredicateAssert<Object>> PREDICATE = predicate(Object.class);
 
   /**
@@ -99,11 +99,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #PREDICATE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <T> InstanceOfAssertFactory<Predicate, PredicateAssert<T>> predicate(Class<T> type) {
-    return new InstanceOfAssertFactory<>(Predicate.class, Assertions::<T> assertThat);
+    return new InstanceOfAssertFactory<>(Predicate.class, new Class[] { type }, Assertions::<T> assertThat);
   }
 
   /**
@@ -129,7 +127,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #completableFuture(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<Object>> COMPLETABLE_FUTURE = completableFuture(Object.class);
 
   /**
@@ -141,11 +139,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #COMPLETABLE_FUTURE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <RESULT> InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<RESULT>> completableFuture(Class<RESULT> resultType) {
-    return new InstanceOfAssertFactory<>(CompletableFuture.class, Assertions::<RESULT> assertThat);
+    return new InstanceOfAssertFactory<>(CompletableFuture.class, new Class[] { resultType }, Assertions::<RESULT> assertThat);
   }
 
   /**
@@ -153,7 +149,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #completionStage(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<Object>> COMPLETION_STAGE = completionStage(Object.class);
 
   /**
@@ -165,11 +161,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #COMPLETION_STAGE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <RESULT> InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<RESULT>> completionStage(Class<RESULT> resultType) {
-    return new InstanceOfAssertFactory<>(CompletionStage.class, Assertions::<RESULT> assertThat);
+    return new InstanceOfAssertFactory<>(CompletionStage.class, new Class[] { resultType }, Assertions::<RESULT> assertThat);
   }
 
   /**
@@ -177,7 +171,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #optional(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Optional, OptionalAssert<Object>> OPTIONAL = optional(Object.class);
 
   /**
@@ -189,11 +183,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #OPTIONAL
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <VALUE> InstanceOfAssertFactory<Optional, OptionalAssert<VALUE>> optional(Class<VALUE> resultType) {
-    return new InstanceOfAssertFactory<>(Optional.class, Assertions::<VALUE> assertThat);
+    return new InstanceOfAssertFactory<>(Optional.class, new Class[] { resultType }, Assertions::<VALUE> assertThat);
   }
 
   /**
@@ -344,7 +336,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #future(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Future, FutureAssert<Object>> FUTURE = future(Object.class);
 
   /**
@@ -356,11 +348,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #FUTURE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <RESULT> InstanceOfAssertFactory<Future, FutureAssert<RESULT>> future(Class<RESULT> resultType) {
-    return new InstanceOfAssertFactory<>(Future.class, Assertions::<RESULT> assertThat);
+    return new InstanceOfAssertFactory<>(Future.class, new Class[] { resultType }, Assertions::<RESULT> assertThat);
   }
 
   /**
@@ -582,7 +572,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicIntegerFieldUpdater(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<Object>> ATOMIC_INTEGER_FIELD_UPDATER = atomicIntegerFieldUpdater(Object.class);
 
   /**
@@ -594,11 +584,10 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_INTEGER_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <OBJECT> InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<OBJECT>> atomicIntegerFieldUpdater(Class<OBJECT> objectType) {
-    return new InstanceOfAssertFactory<>(AtomicIntegerFieldUpdater.class, Assertions::<OBJECT> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicIntegerFieldUpdater.class, new Class[] { objectType },
+                                         Assertions::<OBJECT> assertThat);
   }
 
   /**
@@ -624,7 +613,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicLongFieldUpdater(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<Object>> ATOMIC_LONG_FIELD_UPDATER = atomicLongFieldUpdater(Object.class);
 
   /**
@@ -636,11 +625,10 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_LONG_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <OBJECT> InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<OBJECT>> atomicLongFieldUpdater(Class<OBJECT> objectType) {
-    return new InstanceOfAssertFactory<>(AtomicLongFieldUpdater.class, Assertions::<OBJECT> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicLongFieldUpdater.class, new Class[] { objectType },
+                                         Assertions::<OBJECT> assertThat);
   }
 
   /**
@@ -648,7 +636,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicReference(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<Object>> ATOMIC_REFERENCE = atomicReference(Object.class);
 
   /**
@@ -660,11 +648,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <VALUE> InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<VALUE>> atomicReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicReference.class, Assertions::<VALUE> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicReference.class, new Class[] { valueType }, Assertions::<VALUE> assertThat);
   }
 
   /**
@@ -672,7 +658,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicReferenceArray(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<Object>> ATOMIC_REFERENCE_ARRAY = atomicReferenceArray(Object.class);
 
   /**
@@ -684,11 +670,10 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE_ARRAY
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<ELEMENT>> atomicReferenceArray(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(AtomicReferenceArray.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicReferenceArray.class, new Class[] { elementType },
+                                         Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -696,7 +681,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicReferenceFieldUpdater(Class, Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<Object, Object>> ATOMIC_REFERENCE_FIELD_UPDATER = atomicReferenceFieldUpdater(Object.class,
                                                                                                                                                                        Object.class);
 
@@ -711,12 +696,11 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <FIELD, OBJECT> InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT>> atomicReferenceFieldUpdater(Class<FIELD> fieldType,
                                                                                                                                                             Class<OBJECT> objectType) {
-    return new InstanceOfAssertFactory<>(AtomicReferenceFieldUpdater.class, Assertions::<FIELD, OBJECT> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicReferenceFieldUpdater.class, new Class[] { fieldType, objectType },
+                                         Assertions::<FIELD, OBJECT> assertThat);
   }
 
   /**
@@ -724,7 +708,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicMarkableReference(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<Object>> ATOMIC_MARKABLE_REFERENCE = atomicMarkableReference(Object.class);
 
   /**
@@ -736,11 +720,10 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_MARKABLE_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <VALUE> InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<VALUE>> atomicMarkableReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicMarkableReference.class, Assertions::<VALUE> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicMarkableReference.class, new Class[] { valueType },
+                                         Assertions::<VALUE> assertThat);
   }
 
   /**
@@ -748,7 +731,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #atomicStampedReference(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<Object>> ATOMIC_STAMPED_REFERENCE = atomicStampedReference(Object.class);
 
   /**
@@ -760,11 +743,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_STAMPED_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <VALUE> InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<VALUE>> atomicStampedReference(Class<VALUE> valueType) {
-    return new InstanceOfAssertFactory<>(AtomicStampedReference.class, Assertions::<VALUE> assertThat);
+    return new InstanceOfAssertFactory<>(AtomicStampedReference.class, new Class[] { valueType }, Assertions::<VALUE> assertThat);
   }
 
   /**
@@ -816,7 +797,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #iterable(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Iterable, IterableAssert<Object>> ITERABLE = iterable(Object.class);
 
   /**
@@ -828,11 +809,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ITERABLE
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<Iterable, IterableAssert<ELEMENT>> iterable(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(Iterable.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(Iterable.class, new Class[] { elementType }, Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -840,7 +819,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #iterator(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Iterator, IteratorAssert<Object>> ITERATOR = iterator(Object.class);
 
   /**
@@ -852,11 +831,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ITERATOR
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<Iterator, IteratorAssert<ELEMENT>> iterator(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(Iterator.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(Iterator.class, new Class[] { elementType }, Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -865,7 +842,7 @@ public interface InstanceOfAssertFactories {
    * @see #collection(Class)
    * @since 3.21.0
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Collection, AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>>> COLLECTION = collection(Object.class);
 
   /**
@@ -878,11 +855,9 @@ public interface InstanceOfAssertFactories {
    * @see #COLLECTION
    * @since 3.21.0
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <E> InstanceOfAssertFactory<Collection, AbstractCollectionAssert<?, Collection<? extends E>, E, ObjectAssert<E>>> collection(Class<E> elementType) {
-    return new InstanceOfAssertFactory<>(Collection.class, Assertions::<E> assertThat);
+    return new InstanceOfAssertFactory<>(Collection.class, new Class[] { elementType }, Assertions::<E> assertThat);
   }
 
   /**
@@ -890,7 +865,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #list(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<List, ListAssert<Object>> LIST = list(Object.class);
 
   /**
@@ -902,11 +877,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #LIST
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<List, ListAssert<ELEMENT>> list(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(List.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(List.class, new Class[] { elementType }, Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -915,7 +888,7 @@ public interface InstanceOfAssertFactories {
    * @see #set(Class)
    * @since 3.26.0
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Set, AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>>> SET = set(Object.class);
 
   /**
@@ -928,11 +901,9 @@ public interface InstanceOfAssertFactories {
    * @see #SET
    * @since 3.26.0
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <E> InstanceOfAssertFactory<Set, AbstractCollectionAssert<?, Collection<? extends E>, E, ObjectAssert<E>>> set(Class<E> elementType) {
-    return new InstanceOfAssertFactory<>(Set.class, Assertions::<E> assertThat);
+    return new InstanceOfAssertFactory<>(Set.class, new Class[] { elementType }, Assertions::<E> assertThat);
   }
 
   /**
@@ -940,7 +911,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #stream(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Stream, ListAssert<Object>> STREAM = stream(Object.class);
 
   /**
@@ -952,11 +923,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #STREAM
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<Stream, ListAssert<ELEMENT>> stream(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(Stream.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(Stream.class, new Class[] { elementType }, Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -988,7 +957,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #spliterator(Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Spliterator, SpliteratorAssert<Object>> SPLITERATOR = spliterator(Object.class);
 
   /**
@@ -1000,11 +969,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #SPLITERATOR
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <ELEMENT> InstanceOfAssertFactory<Spliterator, SpliteratorAssert<ELEMENT>> spliterator(Class<ELEMENT> elementType) {
-    return new InstanceOfAssertFactory<>(Spliterator.class, Assertions::<ELEMENT> assertThat);
+    return new InstanceOfAssertFactory<>(Spliterator.class, new Class[] { elementType }, Assertions::<ELEMENT> assertThat);
   }
 
   /**
@@ -1012,7 +979,7 @@ public interface InstanceOfAssertFactories {
    *
    * @see #map(Class, Class)
    */
-  @SuppressWarnings("rawtypes") // rawtypes: using Class instance
+  @SuppressWarnings("rawtypes")
   InstanceOfAssertFactory<Map, MapAssert<Object, Object>> MAP = map(Object.class, Object.class);
 
   /**
@@ -1026,11 +993,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #MAP
    */
-  @SuppressWarnings({ "rawtypes", "unused", "unchecked", "RedundantSuppression" })
-  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
-  // IntelliJ can warn that this is redundant when it is not.
+  @SuppressWarnings("rawtypes")
   static <K, V> InstanceOfAssertFactory<Map, MapAssert<K, V>> map(Class<K> keyType, Class<V> valueType) {
-    return new InstanceOfAssertFactory<>(Map.class, Assertions::<K, V> assertThat);
+    return new InstanceOfAssertFactory<>(Map.class, new Class[] { keyType, valueType }, Assertions::<K, V> assertThat);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -494,7 +494,7 @@ public interface InstanceOfAssertFactories {
                                                                                             Assertions::assertThat);
 
   /**
-   * {@link InstanceOfAssertFactory} for a {@link java.time.temporal.Temporal}.
+   * {@link InstanceOfAssertFactory} for a {@link Temporal}.
    * @since 3.26.0
    */
   InstanceOfAssertFactory<Temporal, TemporalAssert> TEMPORAL = new InstanceOfAssertFactory<>(Temporal.class,
@@ -537,7 +537,7 @@ public interface InstanceOfAssertFactories {
                                                                                                             Assertions::assertThat);
 
   /**
-   * {@link InstanceOfAssertFactory} for a {@link LocalDate}.
+   * {@link InstanceOfAssertFactory} for a {@link YearMonth}.
    *
    * @since 3.26.0
    */

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -72,8 +72,8 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
   /**
    * Creates the custom {@link Assert} instance for the given value.
    * <p>
-   * The factory casts the value to the expected type before invoking the
-   * delegate.
+   * Before invoking the delegate, the factory casts the value to the raw
+   * {@link Class} defined during instantiation.
    *
    * @param actual the input value for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the given value
@@ -90,9 +90,9 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
    * This is typically used by custom assertions that want to leverage existing
    * factories and need to manipulate the value upfront.
    * <p>
-   * This implementation requests a value compatible with the {@link Class} or
-   * {@link Type} defined during instantiation and casts the provided value
-   * to it before invoking the delegate.
+   * This implementation requests a value compatible with the {@link Type}
+   * defined during instantiation and casts the provided value to the
+   * corresponding raw {@link Class} before invoking the delegate.
    *
    * @param valueProvider the value provider for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the provided value

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -103,7 +103,7 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
 
     @Override
     public Type getOwnerType() {
-      return rawClass.getDeclaringClass();
+      return null;
     }
 
     @Override

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * {@link AssertFactory} decorator which casts the input value to the given type before invoking the decorated factory.
+ * {@link AssertFactory} decorator that casts the input value to the given type before invoking the decorated factory.
  *
  * @param <T>      the type to use for the cast.
  * @param <ASSERT> the type of the resulting {@code Assert}.
@@ -69,14 +69,37 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     return type;
   }
 
-  public Class<T> getRawClass() {
+  Class<T> getRawClass() {
     return rawClass;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Creates the custom {@link Assert} instance for the given value.
+   * <p>
+   * The factory casts the value to the expected type before invoking the delegate.
+   *
+   * @param actual the input value for the {@code Assert} instance
+   * @return the custom {@code Assert} instance for the given value
+   */
   @Override
   public ASSERT createAssert(Object actual) {
     return delegate.createAssert(rawClass.cast(actual));
+  }
+
+  /**
+   * Creates the custom {@link Assert} instance for the value provided by the
+   * given {@code valueProvider}.
+   * <p>
+   * The factory casts the provided value to the expected type before invoking the delegate.
+   *
+   * @param valueProvider the value provider for the {@code Assert} instance
+   * @return the custom {@code Assert} instance for the provided value
+   * @since 3.26.0
+   */
+  @Override
+  public ASSERT createAssert(ValueProvider<?> valueProvider) {
+    Object actual = valueProvider.apply(type);
+    return createAssert(actual);
   }
 
   @Override

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -72,7 +72,8 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
   /**
    * Creates the custom {@link Assert} instance for the given value.
    * <p>
-   * The factory casts the value to the expected type before invoking the delegate.
+   * The factory casts the value to the expected type before invoking the
+   * delegate.
    *
    * @param actual the input value for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the given value
@@ -86,7 +87,12 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
    * Creates the custom {@link Assert} instance for the value provided by the
    * given {@code valueProvider}.
    * <p>
-   * The factory casts the provided value to the expected type before invoking the delegate.
+   * This is typically used by custom assertions that want to leverage existing
+   * factories and need to manipulate the value upfront.
+   * <p>
+   * This implementation requests a value compatible with the {@link Class} or
+   * {@link Type} defined during instantiation and casts the provided value
+   * to it before invoking the delegate.
    *
    * @param valueProvider the value provider for the {@code Assert} instance
    * @return the custom {@code Assert} instance for the provided value

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -65,7 +65,8 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     this.delegate = requireNonNull(delegate, shouldNotBeNull("delegate")::create);
   }
 
-  public Type getType() {
+  // FIXME delete
+  Type getType() {
     return type;
   }
 
@@ -161,6 +162,7 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     public String toString() {
       return getTypeName();
     }
+
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -15,6 +15,13 @@ package org.assertj.core.api;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 
+import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
  * {@link AssertFactory} decorator which casts the input value to the given type before invoking the decorated factory.
  *
@@ -26,33 +33,111 @@ import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
  */
 public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> implements AssertFactory<Object, ASSERT> {
 
-  private final Class<T> type;
+  private final Type type;
+  private final Class<T> rawClass;
   private final AssertFactory<T, ASSERT> delegate;
 
   /**
-   * Instantiates a new {@code InstanceOfAssertFactory}.
+   * Instantiates a new {@code InstanceOfAssertFactory} for a given type.
    *
-   * @param type     the {@code Class} instance of the given type.
-   * @param delegate the {@code AssertFactory} to decorate.
+   * @param type     the {@link Class} instance of the given type.
+   * @param delegate the {@link AssertFactory} to decorate.
    */
   public InstanceOfAssertFactory(Class<T> type, AssertFactory<T, ASSERT> delegate) {
+    this(type, type, delegate);
+  }
+
+  /**
+   * Instantiates a new {@code InstanceOfAssertFactory} for a given type with type arguments.
+   *
+   * @param rawClass      the raw {@link Class} instance of the given type.
+   * @param typeArguments the {@link Type} arguments of the given type.
+   * @param delegate      the {@link AssertFactory} to decorate.
+   * @since 3.26.0
+   */
+  public InstanceOfAssertFactory(Class<T> rawClass, Type[] typeArguments, AssertFactory<T, ASSERT> delegate) {
+    this(new SyntheticParameterizedType(rawClass, typeArguments), rawClass, delegate);
+  }
+
+  private InstanceOfAssertFactory(Type type, Class<T> rawClass, AssertFactory<T, ASSERT> delegate) {
     this.type = requireNonNull(type, shouldNotBeNull("type")::create);
+    this.rawClass = requireNonNull(rawClass, shouldNotBeNull("rawClass")::create);
     this.delegate = requireNonNull(delegate, shouldNotBeNull("delegate")::create);
   }
 
-  Class<T> getType() {
+  public Type getType() {
     return type;
+  }
+
+  public Class<T> getRawClass() {
+    return rawClass;
   }
 
   /** {@inheritDoc} */
   @Override
   public ASSERT createAssert(Object actual) {
-    return delegate.createAssert(type.cast(actual));
+    return delegate.createAssert(rawClass.cast(actual));
   }
 
   @Override
   public String toString() {
-    return type.getSimpleName() + " InstanceOfAssertFactory";
+    return "InstanceOfAssertFactory for " + type.getTypeName();
+  }
+
+  private static final class SyntheticParameterizedType implements ParameterizedType, Serializable {
+
+    private final Class<?> rawType;
+    private final Type[] typeArguments;
+
+    public SyntheticParameterizedType(Class<?> rawType, Type[] typeArguments) {
+      this.rawType = rawType;
+      this.typeArguments = typeArguments;
+    }
+
+    @Override
+    public String getTypeName() {
+      return rawType.getTypeName() + Arrays.stream(typeArguments)
+                                           .map(Type::getTypeName)
+                                           .collect(Collectors.joining(", ", "<", ">"));
+    }
+
+    @Override
+    public Type getOwnerType() {
+      return null;
+    }
+
+    @Override
+    public Class<?> getRawType() {
+      return rawType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+      return typeArguments;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof ParameterizedType)) {
+        return false;
+      }
+      ParameterizedType otherType = (ParameterizedType) other;
+      return (otherType.getOwnerType() == null && rawType.equals(otherType.getRawType()) &&
+              Arrays.equals(typeArguments, otherType.getActualTypeArguments()));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(rawType, Arrays.hashCode(typeArguments));
+    }
+
+    @Override
+    public String toString() {
+      return getTypeName();
+    }
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -21,7 +21,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * {@link AssertFactory} decorator which casts the input value to the given type before invoking the decorated factory.
@@ -66,12 +65,11 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     this.delegate = requireNonNull(delegate, shouldNotBeNull("delegate")::create);
   }
 
-  /** {@inheritDoc} */
-  public Optional<Type> getType() {
-    return Optional.of(type);
+  public Type getType() {
+    return type;
   }
 
-  Class<T> getRawClass() {
+  public Class<T> getRawClass() {
     return rawClass;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -21,6 +21,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * {@link AssertFactory} decorator which casts the input value to the given type before invoking the decorated factory.
@@ -65,11 +66,12 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     this.delegate = requireNonNull(delegate, shouldNotBeNull("delegate")::create);
   }
 
-  public Type getType() {
-    return type;
+  /** {@inheritDoc} */
+  public Optional<Type> getType() {
+    return Optional.of(type);
   }
 
-  public Class<T> getRawClass() {
+  Class<T> getRawClass() {
     return rawClass;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -65,11 +65,6 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
     this.delegate = requireNonNull(delegate, shouldNotBeNull("delegate")::create);
   }
 
-  // FIXME delete
-  Type getType() {
-    return type;
-  }
-
   Class<T> getRawClass() {
     return rawClass;
   }

--- a/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/InstanceOfAssertFactory.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 
 import java.io.Serializable;
@@ -20,7 +21,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * {@link AssertFactory} decorator which casts the input value to the given type before invoking the decorated factory.
@@ -86,29 +86,29 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
 
   private static final class SyntheticParameterizedType implements ParameterizedType, Serializable {
 
-    private final Class<?> rawType;
+    private final Class<?> rawClass;
     private final Type[] typeArguments;
 
-    public SyntheticParameterizedType(Class<?> rawType, Type[] typeArguments) {
-      this.rawType = rawType;
-      this.typeArguments = typeArguments;
+    public SyntheticParameterizedType(Class<?> rawClass, Type[] typeArguments) {
+      this.rawClass = requireNonNull(rawClass, shouldNotBeNull("rawClass")::create);
+      this.typeArguments = requireNonNull(typeArguments, shouldNotBeNull("typeArguments")::create);
     }
 
     @Override
     public String getTypeName() {
-      return rawType.getTypeName() + Arrays.stream(typeArguments)
-                                           .map(Type::getTypeName)
-                                           .collect(Collectors.joining(", ", "<", ">"));
+      return rawClass.getTypeName() + Arrays.stream(typeArguments)
+                                            .map(Type::getTypeName)
+                                            .collect(joining(", ", "<", ">"));
     }
 
     @Override
     public Type getOwnerType() {
-      return null;
+      return rawClass.getDeclaringClass();
     }
 
     @Override
     public Class<?> getRawType() {
-      return rawType;
+      return rawClass;
     }
 
     @Override
@@ -125,13 +125,13 @@ public class InstanceOfAssertFactory<T, ASSERT extends AbstractAssert<?, ?>> imp
         return false;
       }
       ParameterizedType otherType = (ParameterizedType) other;
-      return (otherType.getOwnerType() == null && rawType.equals(otherType.getRawType()) &&
+      return (otherType.getOwnerType() == null && rawClass.equals(otherType.getRawType()) &&
               Arrays.equals(typeArguments, otherType.getActualTypeArguments()));
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(rawType, Arrays.hashCode(typeArguments));
+      return Objects.hash(rawClass, Arrays.hashCode(typeArguments));
     }
 
     @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -1321,18 +1321,18 @@ class InstanceOfAssertFactoriesTest {
   @MethodSource("nonParameterizedFactories")
   void getType_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
     // WHEN
-    Type type = underTest.getType();
+    Optional<Type> type = underTest.getType();
     // THEN
-    then(type).isEqualTo(rawClass);
+    then(type).hasValue(rawClass);
   }
 
   @ParameterizedTest
   @MethodSource("parameterizedFactories")
   void getType_for_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass, Class<?>[] typeArguments) {
     // WHEN
-    Type type = underTest.getType();
+    Optional<Type> type = underTest.getType();
     // THEN
-    then(type).asInstanceOf(type(ParameterizedType.class))
+    then(type).get(type(ParameterizedType.class))
               .returns(typeArguments, from(ParameterizedType::getActualTypeArguments))
               .returns(rawClass, from(ParameterizedType::getRawType))
               .returns(null, from(ParameterizedType::getOwnerType));

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -140,6 +140,7 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
@@ -160,6 +161,7 @@ import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -1388,11 +1390,24 @@ class InstanceOfAssertFactoriesTest {
                      arguments(OFFSET_TIME, OffsetTime.class),
                      arguments(OPTIONAL_DOUBLE, OptionalDouble.class),
                      arguments(OPTIONAL_INT, OptionalInt.class),
-                     arguments(OPTIONAL_LONG, OptionalLong.class));
+                     arguments(OPTIONAL_LONG, OptionalLong.class),
+                     arguments(PATH, Path.class),
+                     arguments(PERIOD, Period.class),
+                     arguments(SHORT, Short.class),
+                     arguments(SHORT_2D_ARRAY, short[][].class),
+                     arguments(SHORT_ARRAY, short[].class),
+                     arguments(STRING, String.class),
+                     arguments(STRING_BUFFER, StringBuffer.class),
+                     arguments(STRING_BUILDER, StringBuilder.class),
+                     arguments(THROWABLE, Throwable.class),
+                     arguments(URI_TYPE, URI.class),
+                     arguments(URL_TYPE, URL.class),
+                     arguments(ZONED_DATE_TIME, ZonedDateTime.class));
   }
 
   static Stream<Arguments> parameterizedFactories() {
     return Stream.of(arguments(ATOMIC_INTEGER_FIELD_UPDATER, AtomicIntegerFieldUpdater.class, classes(Object.class)),
+                     arguments(ATOMIC_INTEGER_FIELD_UPDATER, AtomicIntegerFieldUpdater.class, classes(Object.class)),
                      arguments(ATOMIC_LONG_FIELD_UPDATER, AtomicLongFieldUpdater.class, classes(Object.class)),
                      arguments(ATOMIC_MARKABLE_REFERENCE, AtomicMarkableReference.class, classes(Object.class)),
                      arguments(ATOMIC_REFERENCE, AtomicReference.class, classes(Object.class)),
@@ -1409,7 +1424,11 @@ class InstanceOfAssertFactoriesTest {
                      arguments(ITERATOR, Iterator.class, classes(Object.class)),
                      arguments(LIST, List.class, classes(Object.class)),
                      arguments(MAP, Map.class, classes(Object.class, Object.class)),
-                     arguments(OPTIONAL, Optional.class, classes(Object.class)));
+                     arguments(OPTIONAL, Optional.class, classes(Object.class)),
+                     arguments(PREDICATE, Predicate.class, classes(Object.class)),
+                     arguments(SET, Set.class, classes(Object.class)),
+                     arguments(SPLITERATOR, Spliterator.class, classes(Object.class)),
+                     arguments(STREAM, Stream.class, classes(Object.class)));
   }
 
   private static Class<?>[] classes(Class<?>... classes) {

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -123,6 +123,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.assertj.core.api.InstanceOfAssertFactories.optional;
 import static org.assertj.core.api.InstanceOfAssertFactories.predicate;
 import static org.assertj.core.api.InstanceOfAssertFactories.set;
+import static org.assertj.core.api.InstanceOfAssertFactories.spliterator;
 import static org.assertj.core.api.InstanceOfAssertFactories.stream;
 import static org.assertj.core.api.InstanceOfAssertFactories.throwable;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
@@ -1402,19 +1403,22 @@ class InstanceOfAssertFactoriesTest {
                      arguments(THROWABLE, Throwable.class),
                      arguments(URI_TYPE, URI.class),
                      arguments(URL_TYPE, URL.class),
-                     arguments(ZONED_DATE_TIME, ZonedDateTime.class));
+                     arguments(ZONED_DATE_TIME, ZonedDateTime.class),
+                     arguments(array(String[].class), String[].class),
+                     arguments(array2D(String[][].class), String[][].class),
+                     arguments(comparable(Integer.class), Integer.class),
+                     arguments(throwable(RuntimeException.class), RuntimeException.class),
+                     arguments(type(String.class), String.class));
   }
 
   static Stream<Arguments> parameterizedFactories() {
     return Stream.of(arguments(ATOMIC_INTEGER_FIELD_UPDATER, AtomicIntegerFieldUpdater.class, classes(Object.class)),
-                     arguments(ATOMIC_INTEGER_FIELD_UPDATER, AtomicIntegerFieldUpdater.class, classes(Object.class)),
                      arguments(ATOMIC_LONG_FIELD_UPDATER, AtomicLongFieldUpdater.class, classes(Object.class)),
                      arguments(ATOMIC_MARKABLE_REFERENCE, AtomicMarkableReference.class, classes(Object.class)),
                      arguments(ATOMIC_REFERENCE, AtomicReference.class, classes(Object.class)),
                      arguments(ATOMIC_REFERENCE_ARRAY, AtomicReferenceArray.class, classes(Object.class)),
                      arguments(ATOMIC_REFERENCE_FIELD_UPDATER, AtomicReferenceFieldUpdater.class,
                                classes(Object.class, Object.class)),
-                     arguments(ATOMIC_REFERENCE_ARRAY, AtomicReferenceArray.class, classes(Object.class)),
                      arguments(ATOMIC_STAMPED_REFERENCE, AtomicStampedReference.class, classes(Object.class)),
                      arguments(COLLECTION, Collection.class, classes(Object.class)),
                      arguments(COMPLETABLE_FUTURE, CompletableFuture.class, classes(Object.class)),
@@ -1428,7 +1432,31 @@ class InstanceOfAssertFactoriesTest {
                      arguments(PREDICATE, Predicate.class, classes(Object.class)),
                      arguments(SET, Set.class, classes(Object.class)),
                      arguments(SPLITERATOR, Spliterator.class, classes(Object.class)),
-                     arguments(STREAM, Stream.class, classes(Object.class)));
+                     arguments(STREAM, Stream.class, classes(Object.class)),
+                     arguments(atomicIntegerFieldUpdater(VolatileFieldContainer.class), AtomicIntegerFieldUpdater.class,
+                               classes(VolatileFieldContainer.class)),
+                     arguments(atomicLongFieldUpdater(VolatileFieldContainer.class), AtomicLongFieldUpdater.class,
+                               classes(VolatileFieldContainer.class)),
+                     arguments(atomicMarkableReference(Integer.class), AtomicMarkableReference.class, classes(Integer.class)),
+                     arguments(atomicReference(Integer.class), AtomicReference.class, classes(Integer.class)),
+                     arguments(atomicReferenceArray(Integer.class), AtomicReferenceArray.class, classes(Integer.class)),
+                     arguments(atomicReferenceFieldUpdater(String.class, VolatileFieldContainer.class),
+                               AtomicReferenceFieldUpdater.class,
+                               classes(String.class, VolatileFieldContainer.class)),
+                     arguments(atomicStampedReference(Integer.class), AtomicStampedReference.class, classes(Integer.class)),
+                     arguments(collection(String.class), Collection.class, classes(String.class)),
+                     arguments(completableFuture(String.class), CompletableFuture.class, classes(String.class)),
+                     arguments(completionStage(String.class), CompletionStage.class, classes(String.class)),
+                     arguments(future(String.class), Future.class, classes(String.class)),
+                     arguments(iterable(String.class), Iterable.class, classes(String.class)),
+                     arguments(iterator(String.class), Iterator.class, classes(String.class)),
+                     arguments(list(String.class), List.class, classes(String.class)),
+                     arguments(map(String.class, String.class), Map.class, classes(String.class, String.class)),
+                     arguments(optional(String.class), Optional.class, classes(String.class)),
+                     arguments(predicate(String.class), Predicate.class, classes(String.class)),
+                     arguments(set(String.class), Set.class, classes(String.class)),
+                     arguments(spliterator(String.class), Spliterator.class, classes(String.class)),
+                     arguments(stream(String.class), Stream.class, classes(String.class)));
   }
 
   private static Class<?>[] classes(Class<?>... classes) {

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -12,7 +12,9 @@
  */
 package org.assertj.core.api;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.api.BDDAssertions.from;
@@ -130,7 +132,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.stream;
 import static org.assertj.core.api.InstanceOfAssertFactories.throwable;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.test.Maps.mapOf;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -139,7 +141,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
@@ -157,7 +158,6 @@ import java.time.OffsetTime;
 import java.time.Period;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.util.Collection;
 import java.util.Date;
@@ -203,1380 +203,3877 @@ import org.assertj.core.api.AssertFactory.ValueProvider;
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.assertj.core.util.Strings;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.AdditionalAnswers;
 
 /**
  * @author Stefano Cordio
  */
 class InstanceOfAssertFactoriesTest {
 
-  @Test
-  void predicate_factory_createAssert_should_create_predicate_assertions() {
-    // GIVEN
-    Object value = (Predicate<Object>) Objects::isNull;
-    // WHEN
-    PredicateAssert<Object> result = PREDICATE.createAssert(value);
-    // THEN
-    result.accepts((Object) null);
-  }
-
-  @Test
-  void predicate_factory_createAssert_with_ValueProvider_should_create_predicate_assertions() {
-    // GIVEN
-    ValueProvider<Predicate<Object>> valueProvider = mockThatDelegatesTo(type -> Objects::isNull);
-    // WHEN
-    PredicateAssert<Object> result = PREDICATE.createAssert(valueProvider);
-    // THEN
-    result.accepts((Object) null);
-    verify(valueProvider).apply(parameterizedType(Predicate.class, Object.class));
-  }
-
-  @Test
-  void predicate_typed_factory_createAssert_should_create_predicate_typed_assertions() {
-    // GIVEN
-    Object value = (Predicate<String>) Strings::isNullOrEmpty;
-    // WHEN
-    PredicateAssert<String> result = predicate(String.class).createAssert(value);
-    // THEN
-    result.accepts("");
-  }
-
-  @Test
-  void predicate_typed_factory_createAssert_with_ValueProvider_should_create_predicate_typed_assertions() {
-    // GIVEN
-    ValueProvider<Predicate<String>> valueProvider = mockThatDelegatesTo(type -> Strings::isNullOrEmpty);
-    // WHEN
-    PredicateAssert<String> result = predicate(String.class).createAssert(valueProvider);
-    // THEN
-    result.accepts("");
-    verify(valueProvider).apply(parameterizedType(Predicate.class, String.class));
-  }
-
-  @Test
-  void int_predicate_factory_createAssert_should_create_int_predicate_assertions() {
-    // GIVEN
-    Object value = (IntPredicate) i -> i == 0;
-    // WHEN
-    IntPredicateAssert result = INT_PREDICATE.createAssert(value);
-    // THEN
-    result.accepts(0);
-  }
-
-  @Test
-  void int_predicate_factory_createAssert_with_ValueProvider_should_create_int_predicate_assertions() {
-    // GIVEN
-    ValueProvider<IntPredicate> valueProvider = mockThatDelegatesTo(type -> i -> i == 0);
-    // WHEN
-    IntPredicateAssert result = INT_PREDICATE.createAssert(valueProvider);
-    // THEN
-    result.accepts(0);
-    verify(valueProvider).apply(IntPredicate.class);
-  }
-
-  @Test
-  void long_predicate_factory_createAssert_should_create_long_predicate_assertions() {
-    // GIVEN
-    Object value = (LongPredicate) l -> l == 0L;
-    // WHEN
-    LongPredicateAssert result = LONG_PREDICATE.createAssert(value);
-    // THEN
-    result.accepts(0L);
-  }
-
-  @Test
-  void double_predicate_factory_createAssert_should_create_double_predicate_assertions() {
-    // GIVEN
-    Object value = (DoublePredicate) d -> d == 0.0;
-    // WHEN
-    DoublePredicateAssert result = DOUBLE_PREDICATE.createAssert(value);
-    // THEN
-    result.accepts(0.0);
-  }
-
-  @Test
-  void completable_future_factory_createAssert_should_create_completable_future_assertions() {
-    // GIVEN
-    Object value = completedFuture("done");
-    // WHEN
-    CompletableFutureAssert<Object> result = COMPLETABLE_FUTURE.createAssert(value);
-    // THEN
-    result.isDone();
-  }
-
-  @Test
-  void completable_future_typed_factory_createAssert_should_create_completable_future_typed_assertions() {
-    // GIVEN
-    Object value = completedFuture("done");
-    // WHEN
-    CompletableFutureAssert<String> result = completableFuture(String.class).createAssert(value);
-    // THEN
-    result.isDone();
-  }
-
-  @Test
-  void completion_stage_factory_createAssert_should_create_completable_future_assertions() {
-    // GIVEN
-    Object value = completedFuture("done");
-    // WHEN
-    CompletableFutureAssert<Object> result = COMPLETION_STAGE.createAssert(value);
-    // THEN
-    result.isDone();
-  }
-
-  @Test
-  void completion_stage_typed_factory_createAssert_should_create_completable_future_typed_assertions() {
-    // GIVEN
-    Object value = completedFuture("done");
-    // WHEN
-    CompletableFutureAssert<String> result = completionStage(String.class).createAssert(value);
-    // THEN
-    result.isDone();
-  }
-
-  @Test
-  void optional_factory_createAssert_should_create_optional_assertions() {
-    // GIVEN
-    Object value = Optional.of("something");
-    // WHEN
-    OptionalAssert<Object> result = OPTIONAL.createAssert(value);
-    // THEN
-    result.isPresent();
-  }
-
-  @Test
-  void optional_typed_factory_createAssert_should_create_optional_typed_assertions() {
-    // GIVEN
-    Object value = Optional.of("something");
-    // WHEN
-    OptionalAssert<String> result = optional(String.class).createAssert(value);
-    // THEN
-    result.isPresent();
-  }
-
-  @Test
-  void optional_double_factory_createAssert_should_create_optional_double_assertions() {
-    // GIVEN
-    Object value = OptionalDouble.of(0.0);
-    // WHEN
-    OptionalDoubleAssert result = OPTIONAL_DOUBLE.createAssert(value);
-    // THEN
-    result.isPresent();
-  }
-
-  @Test
-  void optional_int_factory_createAssert_should_create_optional_int_assertions() {
-    // GIVEN
-    Object value = OptionalInt.of(0);
-    // WHEN
-    OptionalIntAssert result = OPTIONAL_INT.createAssert(value);
-    // THEN
-    result.isPresent();
-  }
-
-  @Test
-  void optional_long_factory_createAssert_should_create_optional_long_assertions() {
-    // GIVEN
-    Object value = OptionalLong.of(0L);
-    // WHEN
-    OptionalLongAssert result = OPTIONAL_LONG.createAssert(value);
-    // THEN
-    result.isPresent();
-  }
-
-  @Test
-  void matcher_factory_createAssert_should_create_matcher_assertions() {
-    // GIVEN
-    Object value = Pattern.compile("a*").matcher("aaa");
-    // WHEN
-    MatcherAssert result = MATCHER.createAssert(value);
-    // THEN
-    result.matches();
-  }
-
-  @Test
-  void big_decimal_factory_createAssert_should_create_big_decimal_assertions() {
-    // GIVEN
-    Object value = BigDecimal.valueOf(0.0);
-    // WHEN
-    AbstractBigDecimalAssert<?> result = BIG_DECIMAL.createAssert(value);
-    // THEN
-    result.isEqualTo("0.0");
-  }
-
-  @Test
-  void big_integer_factory_createAssert_should_create_big_integer_assertions() {
-    // GIVEN
-    Object value = BigInteger.valueOf(0L);
-    // WHEN
-    AbstractBigIntegerAssert<?> result = BIG_INTEGER.createAssert(value);
-    // THEN
-    result.isEqualTo(0L);
-  }
-
-  @Test
-  void uri_type_factory_createAssert_should_create_uri_assertions() {
-    // GIVEN
-    Object value = URI.create("http://localhost");
-    // WHEN
-    AbstractUriAssert<?> result = URI_TYPE.createAssert(value);
-    // THEN
-    result.hasHost("localhost");
-  }
-
-  @Test
-  void url_type_factory_createAssert_should_create_url_assertions() throws MalformedURLException {
-    // GIVEN
-    Object value = new URL("http://localhost");
-    // WHEN
-    AbstractUrlAssert<?> result = URL_TYPE.createAssert(value);
-    // THEN
-    result.hasHost("localhost");
-  }
-
-  @Test
-  void boolean_factory_createAssert_should_create_boolean_assertions() {
-    // GIVEN
-    Object value = true;
-    // WHEN
-    AbstractBooleanAssert<?> result = BOOLEAN.createAssert(value);
-    // THEN
-    result.isTrue();
-  }
-
-  @Test
-  void boolean_array_factory_createAssert_should_create_boolean_array_assertions() {
-    // GIVEN
-    Object value = new boolean[] { true, false };
-    // WHEN
-    AbstractBooleanArrayAssert<?> result = BOOLEAN_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(true, false);
-  }
-
-  @Test
-  void boolean_2d_array_factory_createAssert_should_create_boolean_2d_array_assertions() {
-    // GIVEN
-    Object value = new boolean[][] { { true, false }, { false, true } };
-    // WHEN
-    Boolean2DArrayAssert result = BOOLEAN_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void byte_factory_createAssert_should_create_byte_assertions() {
-    // GIVEN
-    Object value = (byte) 0;
-    // WHEN
-    AbstractByteAssert<?> result = BYTE.createAssert(value);
-    // THEN
-    result.isEqualTo((byte) 0);
-  }
-
-  @Test
-  void byte_array_factory_createAssert_should_create_byte_array_assertions() {
-    // GIVEN
-    Object value = new byte[] { 0, 1 };
-    // WHEN
-    AbstractByteArrayAssert<?> result = BYTE_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void byte_2d_array_factory_createAssert_should_create_byte_2d_array_assertions() {
-    // GIVEN
-    Object value = new byte[][] { { 0, 1 }, { 2, 3 } };
-    // WHEN
-    Byte2DArrayAssert result = BYTE_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void character_factory_createAssert_should_create_character_assertions() {
-    // GIVEN
-    Object value = 'a';
-    // WHEN
-    AbstractCharacterAssert<?> result = CHARACTER.createAssert(value);
-    // THEN
-    result.isLowerCase();
-  }
-
-  @Test
-  void char_array_factory_createAssert_should_create_char_array_assertions() {
-    // GIVEN
-    Object value = new char[] { 'a', 'b' };
-    // WHEN
-    AbstractCharArrayAssert<?> result = CHAR_ARRAY.createAssert(value);
-    // THEN
-    result.doesNotHaveDuplicates();
-  }
-
-  @Test
-  void char_2d_array_factory_createAssert_should_create_char_2d_array_assertions() {
-    // GIVEN
-    Object value = new char[][] { { 'a', 'b' }, { 'c', 'd' } };
-    // WHEN
-    Char2DArrayAssert result = CHAR_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void class_factory_createAssert_should_create_class_assertions() {
-    // GIVEN
-    Object value = Function.class;
-    // WHEN
-    ClassAssert result = CLASS.createAssert(value);
-    // THEN
-    result.hasAnnotations(FunctionalInterface.class);
-  }
-
-  @Test
-  void double_factory_createAssert_should_create_double_assertions() {
-    // GIVEN
-    Object value = 0.0;
-    // WHEN
-    AbstractDoubleAssert<?> result = DOUBLE.createAssert(value);
-    // THEN
-    result.isZero();
-  }
-
-  @Test
-  void double_array_factory_createAssert_should_create_double_array_assertions() {
-    // GIVEN
-    Object value = new double[] { 0.0, 1.0 };
-    // WHEN
-    AbstractDoubleArrayAssert<?> result = DOUBLE_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0.0, 1.0);
-  }
-
-  @Test
-  void double_2d_array_factory_createAssert_should_create_double_2d_array_assertions() {
-    // GIVEN
-    Object value = new double[][] { { 0.0, 1.0 }, { 2.0, 3.0 } };
-    // WHEN
-    Double2DArrayAssert result = DOUBLE_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void file_factory_createAssert_should_create_file_assertions() {
-    // GIVEN
-    Object value = new File("random-file-which-does-not-exist");
-    // WHEN
-    AbstractFileAssert<?> result = FILE.createAssert(value);
-    // THEN
-    result.doesNotExist();
-  }
-
-  @Test
-  void future_factory_createAssert_should_create_future_assertions() {
-    // GIVEN
-    Object value = mock(Future.class);
-    // WHEN
-    FutureAssert<Object> result = FUTURE.createAssert(value);
-    // THEN
-    result.isNotDone();
-  }
-
-  @Test
-  void future_typed_factory_createAssert_should_create_future_typed_assertions() {
-    // GIVEN
-    Object value = mock(Future.class);
-    // WHEN
-    FutureAssert<String> result = future(String.class).createAssert(value);
-    // THEN
-    result.isNotDone();
-  }
-
-  @Test
-  void input_stream_factory_createAssert_should_create_input_stream_assertions() {
-    // GIVEN
-    Object value = new ByteArrayInputStream("stream".getBytes());
-    // WHEN
-    AbstractInputStreamAssert<?, ?> result = INPUT_STREAM.createAssert(value);
-    // THEN
-    result.hasContent("stream");
-  }
-
-  @Test
-  void float_factory_createAssert_should_create_float_assertions() {
-    // GIVEN
-    Object value = 0.0f;
-    // WHEN
-    AbstractFloatAssert<?> result = FLOAT.createAssert(value);
-    // THEN
-    result.isZero();
-  }
-
-  @Test
-  void float_array_factory_createAssert_should_create_float_array_assertions() {
-    // GIVEN
-    Object value = new float[] { 0.0f, 1.0f };
-    // WHEN
-    AbstractFloatArrayAssert<?> result = FLOAT_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0.0f, 1.0f);
-  }
-
-  @Test
-  void float_2d_array_factory_createAssert_should_create_float_2d_array_assertions() {
-    // GIVEN
-    Object value = new float[][] { { 0.0f, 1.0f }, { 2.0f, 3.0f } };
-    // WHEN
-    Float2DArrayAssert result = FLOAT_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void integer_factory_createAssert_should_create_integer_assertions() {
-    // GIVEN
-    Object value = 0;
-    // WHEN
-    AbstractIntegerAssert<?> result = INTEGER.createAssert(value);
-    // THEN
-    result.isZero();
-  }
-
-  @Test
-  void int_array_factory_createAssert_should_create_int_array_assertions() {
-    // GIVEN
-    Object value = new int[] { 0, 1 };
-    // WHEN
-    AbstractIntArrayAssert<?> result = INT_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void int_2d_array_factory_createAssert_should_create_int_2d_array_assertions() {
-    // GIVEN
-    Object value = new int[][] { { 0, 1 }, { 2, 3 } };
-    // WHEN
-    Int2DArrayAssert result = INT_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void long_factory_createAssert_should_create_long_assertions() {
-    // GIVEN
-    Object value = 0L;
-    // WHEN
-    AbstractLongAssert<?> result = LONG.createAssert(value);
-    // THEN
-    result.isZero();
-  }
-
-  @Test
-  void long_array_factory_createAssert_should_create_long_array_assertions() {
-    // GIVEN
-    Object value = new long[] { 0L, 1L };
-    // WHEN
-    AbstractLongArrayAssert<?> result = LONG_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void long_2d_array_factory_createAssert_should_create_long_2d_array_assertions() {
-    // GIVEN
-    Object value = new long[][] { { 0L, 1L }, { 2L, 3L } };
-    // WHEN
-    Long2DArrayAssert result = LONG_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void type_factory_createAssert_should_create_object_typed_assertions() {
-    // GIVEN
-    Object value = "string";
-    // WHEN
-    ObjectAssert<String> result = type(String.class).createAssert(value);
-    // THEN
-    result.extracting(String::isEmpty).isEqualTo(false);
-  }
-
-  @Test
-  void array_factory_createAssert_should_create_array_assertions() {
-    // GIVEN
-    Object value = new Object[] { 0, "" };
-    // WHEN
-    ObjectArrayAssert<Object> result = ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, "");
-  }
-
-  @Test
-  void array_typed_factory_createAssert_should_create_array_typed_assertions() {
-    // GIVEN
-    Object value = new Integer[] { 0, 1 };
-    // WHEN
-    ObjectArrayAssert<Integer> result = array(Integer[].class).createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void array_2d_factory_createAssert_should_create_2d_array_assertions() {
-    // GIVEN
-    Object value = new Object[][] { { 0, "" }, { 3.0, 'b' } };
-    // WHEN
-    Object2DArrayAssert<Object> result = ARRAY_2D.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void array_2d_typed_factory_createAssert_should_create_2d_array_typed_assertions() {
-    // GIVEN
-    Object value = new Integer[][] { { 0, 1 }, { 2, 3 } };
-    // WHEN
-    Object2DArrayAssert<Integer> result = array2D(Integer[][].class).createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void short_factory_createAssert_should_create_short_assertions() {
-    // GIVEN
-    Object value = (short) 0;
-    // WHEN
-    AbstractShortAssert<?> result = SHORT.createAssert(value);
-    // THEN
-    result.isZero();
-  }
-
-  @Test
-  void short_array_factory_createAssert_should_create_short_array_assertions() {
-    // GIVEN
-    Object value = new short[] { 0, 1 };
-    // WHEN
-    AbstractShortArrayAssert<?> result = SHORT_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly((short) 0, (short) 1);
-  }
-
-  @Test
-  void short_2d_array_factory_createAssert_should_create_short_2d_array_assertions() {
-    // GIVEN
-    Object value = new short[][] { { 0, 1 }, { 2, 3 } };
-    // WHEN
-    Short2DArrayAssert result = SHORT_2D_ARRAY.createAssert(value);
-    // THEN
-    result.hasDimensions(2, 2);
-  }
-
-  @Test
-  void date_factory_createAssert_should_create_date_assertions() {
-    // GIVEN
-    Object value = new Date();
-    // WHEN
-    AbstractDateAssert<?> result = DATE.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(new Date());
-  }
-
-  @Test
-  void temporal_factory_createAssert_should_create_temporal_assertions() {
-    // GIVEN
-    Object value = ZonedDateTime.now();
-    // WHEN
-    TemporalAssert result = TEMPORAL.createAssert(value);
-    // THEN
-    result.isCloseTo(ZonedDateTime.now(), within(10, ChronoUnit.SECONDS));
-  }
-
-  @Test
-  void zoned_date_time_factory_createAssert_should_create_zoned_date_time_assertions() {
-    // GIVEN
-    Object value = ZonedDateTime.now();
-    // WHEN
-    AbstractZonedDateTimeAssert<?> result = ZONED_DATE_TIME.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(ZonedDateTime.now());
-  }
-
-  @Test
-  void local_date_time_factory_createAssert_should_create_local_date_time_assertions() {
-    // GIVEN
-    Object value = LocalDateTime.now();
-    // WHEN
-    AbstractLocalDateTimeAssert<?> result = LOCAL_DATE_TIME.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(LocalDateTime.now());
-  }
-
-  @Test
-  void offset_date_time_factory_createAssert_should_create_offset_date_time_assertions() {
-    // GIVEN
-    Object value = OffsetDateTime.now();
-    // WHEN
-    AbstractOffsetDateTimeAssert<?> result = OFFSET_DATE_TIME.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(OffsetDateTime.now());
-  }
-
-  @Test
-  void offset_time_factory_createAssert_should_create_offset_time_assertions() {
-    // GIVEN
-    Object value = OffsetTime.now();
-    // WHEN
-    AbstractOffsetTimeAssert<?> result = OFFSET_TIME.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(OffsetTime.now());
-  }
-
-  @Test
-  void local_time_factory_createAssert_should_create_local_time_assertions() {
-    // GIVEN
-    Object value = LocalTime.now();
-    // WHEN
-    AbstractLocalTimeAssert<?> result = LOCAL_TIME.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(LocalTime.now());
-  }
-
-  @Test
-  void local_date_factory_createAssert_should_create_local_date_assertions() {
-    // GIVEN
-    Object value = LocalDate.now();
-    // WHEN
-    AbstractLocalDateAssert<?> result = LOCAL_DATE.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(LocalDate.now());
-  }
-
-  @Test
-  void year_month_factory_createAssert_should_create_year_month_assertions() {
-    // GIVEN
-    Object value = YearMonth.now();
-    // WHEN
-    AbstractYearMonthAssert<?> result = YEAR_MONTH.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(YearMonth.now());
-  }
-
-  @Test
-  void instant_factory_createAssert_should_create_instant_assertions() {
-    // GIVEN
-    Object value = Instant.now();
-    // WHEN
-    AbstractInstantAssert<?> result = INSTANT.createAssert(value);
-    // THEN
-    result.isBeforeOrEqualTo(Instant.now());
-  }
-
-  @Test
-  void duration_factory_createAssert_should_create_duration_assertions() {
-    // GIVEN
-    Object value = Duration.ofHours(10);
-    // WHEN
-    AbstractDurationAssert<?> result = DURATION.createAssert(value);
-    // THEN
-    result.isPositive();
-  }
-
-  @Test
-  void period_factory_createAssert_should_create_period_assertions() {
-    // GIVEN
-    Object value = Period.of(1, 1, 1);
-    // WHEN
-    AbstractPeriodAssert<?> result = PERIOD.createAssert(value);
-    // THEN
-    result.hasDays(1);
-  }
-
-  @Test
-  void atomic_boolean_factory_createAssert_should_create_atomic_boolean_assertions() {
-    // GIVEN
-    Object value = new AtomicBoolean();
-    // WHEN
-    AtomicBooleanAssert result = ATOMIC_BOOLEAN.createAssert(value);
-    // THEN
-    result.isFalse();
-  }
-
-  @Test
-  void atomic_integer_factory_createAssert_should_create_atomic_integer_assertions() {
-    // GIVEN
-    Object value = new AtomicInteger();
-    // WHEN
-    AtomicIntegerAssert result = ATOMIC_INTEGER.createAssert(value);
-    // THEN
-    result.hasValue(0);
-  }
-
-  @Test
-  void atomic_integer_array_factory_createAssert_should_create_atomic_integer_array_assertions() {
-    // GIVEN
-    Object value = new AtomicIntegerArray(new int[] { 0, 1 });
-    // WHEN
-    AtomicIntegerArrayAssert result = ATOMIC_INTEGER_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void atomic_integer_field_updater_factory_createAssert_should_create_atomic_integer_field_updater_assertions() {
-    // GIVEN
-    Object value = AtomicIntegerFieldUpdater.newUpdater(VolatileFieldContainer.class, "intField");
-    // WHEN
-    AtomicIntegerFieldUpdaterAssert<Object> result = ATOMIC_INTEGER_FIELD_UPDATER.createAssert(value);
-    // THEN
-    result.hasValue(0, new VolatileFieldContainer());
-  }
-
-  @Test
-  void atomic_integer_field_updater_typed_factory_createAssert_should_create_atomic_integer_field_updater_typed_assertions() {
-    // GIVEN
-    Object value = AtomicIntegerFieldUpdater.newUpdater(VolatileFieldContainer.class, "intField");
-    // WHEN
-    AtomicIntegerFieldUpdaterAssert<VolatileFieldContainer> result = atomicIntegerFieldUpdater(VolatileFieldContainer.class).createAssert(value);
-    // THEN
-    result.hasValue(0, new VolatileFieldContainer());
-  }
-
-  @Test
-  void long_adder_factory_createAssert_should_create_long_adder_assertions() {
-    // GIVEN
-    Object value = new LongAdder();
-    // WHEN
-    LongAdderAssert result = LONG_ADDER.createAssert(value);
-    // THEN
-    result.hasValue(0L);
-  }
-
-  @Test
-  void atomic_long_factory_createAssert_should_create_atomic_long_assertions() {
-    // GIVEN
-    Object value = new AtomicLong();
-    // WHEN
-    AtomicLongAssert result = ATOMIC_LONG.createAssert(value);
-    // THEN
-    result.hasValue(0L);
-  }
-
-  @Test
-  void atomic_long_array_factory_createAssert_should_create_atomic_long_array_assertions() {
-    // GIVEN
-    Object value = new AtomicLongArray(new long[] { 0L, 1L });
-    // WHEN
-    AtomicLongArrayAssert result = ATOMIC_LONG_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0L, 1L);
-  }
-
-  @Test
-  void atomic_long_field_updater_factory_createAssert_should_create_atomic_long_field_updater_assertions() {
-    // GIVEN
-    Object value = AtomicLongFieldUpdater.newUpdater(VolatileFieldContainer.class, "longField");
-    // WHEN
-    AtomicLongFieldUpdaterAssert<Object> result = ATOMIC_LONG_FIELD_UPDATER.createAssert(value);
-    // THEN
-    result.hasValue(0L, new VolatileFieldContainer());
-  }
-
-  @Test
-  void atomic_long_field_updater_typed_factory_createAssert_should_create_atomic_long_field_updater_typed_assertions() {
-    // GIVEN
-    Object value = AtomicLongFieldUpdater.newUpdater(VolatileFieldContainer.class, "longField");
-    // WHEN
-    AtomicLongFieldUpdaterAssert<VolatileFieldContainer> result = atomicLongFieldUpdater(VolatileFieldContainer.class).createAssert(value);
-    // THEN
-    result.hasValue(0L, new VolatileFieldContainer());
-  }
-
-  @Test
-  void atomic_reference_factory_createAssert_should_create_atomic_reference_assertions() {
-    // GIVEN
-    Object value = new AtomicReference<>();
-    // WHEN
-    AtomicReferenceAssert<Object> result = ATOMIC_REFERENCE.createAssert(value);
-    // THEN
-    result.hasValue(null);
-  }
-
-  @Test
-  void atomic_reference_typed_factory_createAssert_should_create_atomic_reference_typed_assertions() {
-    // GIVEN
-    Object value = new AtomicReference<>(0);
-    // WHEN
-    AtomicReferenceAssert<Integer> result = atomicReference(Integer.class).createAssert(value);
-    // THEN
-    result.hasValue(0);
-  }
-
-  @Test
-  void atomic_reference_array_factory_createAssert_should_create_atomic_reference_array_assertions() {
-    // GIVEN
-    Object value = new AtomicReferenceArray<>(new Object[] { 0, "" });
-    // WHEN
-    AtomicReferenceArrayAssert<Object> result = ATOMIC_REFERENCE_ARRAY.createAssert(value);
-    // THEN
-    result.containsExactly(0, "");
-  }
-
-  @Test
-  void atomic_reference_array_typed_factory_createAssert_should_create_atomic_reference_array_typed_assertions() {
-    // GIVEN
-    Object value = new AtomicReferenceArray<>(new Integer[] { 0, 1 });
-    // WHEN
-    AtomicReferenceArrayAssert<Integer> result = atomicReferenceArray(Integer.class).createAssert(value);
-    // THEN
-    result.containsExactly(0, 1);
-  }
-
-  @Test
-  void atomic_reference_field_updater_factory_createAssert_should_create_atomic_reference_field_updater_assertions() {
-    // GIVEN
-    Object value = AtomicReferenceFieldUpdater.newUpdater(VolatileFieldContainer.class, String.class, "stringField");
-    // WHEN
-    AtomicReferenceFieldUpdaterAssert<Object, Object> result = ATOMIC_REFERENCE_FIELD_UPDATER.createAssert(value);
-    // THEN
-    result.hasValue(null, new VolatileFieldContainer());
-  }
-
-  @Test
-  void atomic_reference_field_updater_typed_factory_createAssert_should_create_atomic_reference_field_updater_typed_assertions() {
-    // GIVEN
-    Object value = AtomicReferenceFieldUpdater.newUpdater(VolatileFieldContainer.class, String.class, "stringField");
-    // WHEN
-    AtomicReferenceFieldUpdaterAssert<String, VolatileFieldContainer> result = atomicReferenceFieldUpdater(String.class,
-                                                                                                           VolatileFieldContainer.class).createAssert(value);
-    // THEN
-    result.hasValue(null, new VolatileFieldContainer());
-  }
-
-  @Test
-  void atomic_markable_reference_factory_createAssert_should_create_atomic_markable_reference_assertions() {
-    // GIVEN
-    Object value = new AtomicMarkableReference<>(null, false);
-    // WHEN
-    AtomicMarkableReferenceAssert<Object> result = ATOMIC_MARKABLE_REFERENCE.createAssert(value);
-    // THEN
-    result.hasReference(null);
-  }
-
-  @Test
-  void atomic_markable_reference_typed_factory_createAssert_should_create_atomic_markable_reference_typed_assertions() {
-    // GIVEN
-    Object value = new AtomicMarkableReference<>(0, false);
-    // WHEN
-    AtomicMarkableReferenceAssert<Integer> result = atomicMarkableReference(Integer.class).createAssert(value);
-    // THEN
-    result.hasReference(0);
-  }
-
-  @Test
-  void atomic_stamped_reference_factory_createAssert_should_create_atomic_stamped_reference_assertions() {
-    // GIVEN
-    Object value = new AtomicStampedReference<>(null, 0);
-    // WHEN
-    AtomicStampedReferenceAssert<Object> result = ATOMIC_STAMPED_REFERENCE.createAssert(value);
-    // THEN
-    result.hasReference(null);
-  }
-
-  @Test
-  void atomic_stamped_reference_typed_factory_createAssert_should_create_atomic_stamped_reference_typed_assertions() {
-    // GIVEN
-    Object value = new AtomicStampedReference<>(0, 0);
-    // WHEN
-    AtomicStampedReferenceAssert<Integer> result = atomicStampedReference(Integer.class).createAssert(value);
-    // THEN
-    result.hasReference(0);
-  }
-
-  @Test
-  void throwable_factory_createAssert_should_create_throwable_assertions() {
-    // GIVEN
-    Object value = new RuntimeException("message");
-    // WHEN
-    AbstractThrowableAssert<?, ? extends Throwable> result = THROWABLE.createAssert(value);
-    // THEN
-    result.hasMessage("message");
-  }
-
-  @Test
-  void throwable_typed_factory_createAssert_should_create_throwable_typed_assertions() {
-    // GIVEN
-    Object value = new RuntimeException("message");
-    // WHEN
-    AbstractThrowableAssert<?, RuntimeException> result = throwable(RuntimeException.class).createAssert(value);
-    // THEN
-    result.hasMessage("message");
-  }
-
-  @Test
-  void char_sequence_factory_createAssert_should_create_char_sequence_assertions() {
-    // GIVEN
-    Object value = "string";
-    // WHEN
-    AbstractCharSequenceAssert<?, ? extends CharSequence> result = CHAR_SEQUENCE.createAssert(value);
-    // THEN
-    result.startsWith("str");
-  }
-
-  @Test
-  void string_builder_factory_createAssert_should_create_char_sequence_assertions() {
-    // GIVEN
-    Object value = new StringBuilder("string");
-    // WHEN
-    AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUILDER.createAssert(value);
-    // THEN
-    result.startsWith("str");
-  }
-
-  @Test
-  void string_buffer_factory_createAssert_should_create_char_sequence_assertions() {
-    // GIVEN
-    Object value = new StringBuffer("string");
-    // WHEN
-    AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUFFER.createAssert(value);
-    // THEN
-    result.startsWith("str");
-  }
-
-  @Test
-  void string_factory_createAssert_should_create_string_assertions() {
-    // GIVEN
-    Object value = "string";
-    // WHEN
-    AbstractStringAssert<?> result = STRING.createAssert(value);
-    // THEN
-    result.startsWith("str");
-  }
-
-  @Test
-  void iterable_factory_createAssert_should_create_iterable_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    IterableAssert<Object> result = ITERABLE.createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void iterable_typed_factory_createAssert_should_create_iterable_typed_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    IterableAssert<String> result = iterable(String.class).createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void iterator_factory_createAssert_should_create_iterator_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie").iterator();
-    // WHEN
-    IteratorAssert<Object> result = ITERATOR.createAssert(value);
-    // THEN
-    result.hasNext();
-  }
-
-  @Test
-  void iterator_typed_factory_createAssert_should_create_iterator_typed_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie").iterator();
-    // WHEN
-    IteratorAssert<String> result = iterator(String.class).createAssert(value);
-    // THEN
-    result.hasNext();
-  }
-
-  @Test
-  void collection_factory_createAssert_should_create_collection_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = COLLECTION.createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void collection_typed_factory_createAssert_should_create_collection_typed_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = collection(String.class).createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void set_factory_createAssert_should_create_collection_assertions() {
-    // GIVEN
-    Object value = Sets.set("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = SET.createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void set_typed_factory_createAssert_should_create_collection_typed_assertions() {
-    // GIVEN
-    Object value = Sets.set("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = set(String.class).createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void list_factory_createAssert_should_create_list_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    ListAssert<Object> result = LIST.createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void list_factory_createAssert_with_ValueProvider_should_create_list_assertions() {
-    // GIVEN
-    ValueProvider<List<Object>> valueProvider = mockThatDelegatesTo(type -> Lists.list("Homer", "Marge", "Bart", "Lisa",
-                                                                                       "Maggie"));
-    // WHEN
-    ListAssert<Object> result = LIST.createAssert(valueProvider);
-    // THEN
-    result.contains("Bart", "Lisa");
-    verify(valueProvider).apply(parameterizedType(List.class, Object.class));
-  }
-
-  @Test
-  void list_typed_factory_createAssert_should_create_typed_list_assertions() {
-    // GIVEN
-    Object value = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
-    // WHEN
-    ListAssert<String> result = list(String.class).createAssert(value);
-    // THEN
-    result.contains("Bart", "Lisa");
-  }
-
-  @Test
-  void list_typed_factory_createAssert_with_ValueProvider_should_create_typed_list_assertions() {
-    // GIVEN
-    ValueProvider<List<String>> valueProvider = mockThatDelegatesTo(type -> Lists.list("Homer", "Marge", "Bart", "Lisa",
-                                                                                       "Maggie"));
-    // WHEN
-    ListAssert<String> result = list(String.class).createAssert(valueProvider);
-    // THEN
-    result.contains("Bart", "Lisa");
-    verify(valueProvider).apply(parameterizedType(List.class, classes(String.class)));
-  }
-
-  @Test
-  void stream_factory_createAssert_should_create_list_assertions() {
-    // GIVEN
-    Object value = Stream.of(1, 2, 3);
-    // WHEN
-    ListAssert<Object> result = STREAM.createAssert(value);
-    // THEN
-    result.containsExactly(1, 2, 3);
-  }
-
-  @Test
-  void stream_typed_factory_createAssert_should_create_typed_list_typed_assertions() {
-    // GIVEN
-    Object value = Stream.of(1, 2, 3);
-    // WHEN
-    ListAssert<Integer> result = stream(Integer.class).createAssert(value);
-    // THEN
-    result.containsExactly(1, 2, 3);
-  }
-
-  @Test
-  void double_stream_factory_createAssert_should_create_double_list_assertions() {
-    // GIVEN
-    Object value = DoubleStream.of(1.0, 2.0, 3.0);
-    // WHEN
-    ListAssert<Double> result = DOUBLE_STREAM.createAssert(value);
-    // THEN
-    result.containsExactly(1.0, 2.0, 3.0);
-  }
-
-  @Test
-  void long_stream_factory_createAssert_should_create_long_list_assertions() {
-    // GIVEN
-    Object value = LongStream.of(1L, 2L, 3L);
-    // WHEN
-    ListAssert<Long> result = LONG_STREAM.createAssert(value);
-    // THEN
-    result.containsExactly(1L, 2L, 3L);
-  }
-
-  @Test
-  void int_stream_factory_createAssert_should_create_int_list_assertions() {
-    // GIVEN
-    Object value = IntStream.of(1, 2, 3);
-    // WHEN
-    ListAssert<Integer> result = INT_STREAM.createAssert(value);
-    // THEN
-    result.containsExactly(1, 2, 3);
-  }
-
-  @Test
-  void path_factory_createAssert_should_create_path_assertions() {
-    // GIVEN
-    Object value = Paths.get("random-file-which-does-not-exist");
-    // WHEN
-    AbstractPathAssert<?> result = PATH.createAssert(value);
-    // THEN
-    result.doesNotExist();
-  }
-
-  @Test
-  void spliterator_factory_createAssert_should_create_spliterator_assertions() {
-    // GIVEN
-    Object value = Stream.of(1, 2).spliterator();
-    // WHEN
-    SpliteratorAssert<Object> result = SPLITERATOR.createAssert(value);
-    // THEN
-    result.hasCharacteristics(Spliterator.SIZED);
-  }
-
-  @Test
-  void map_factory_createAssert_should_create_map_assertions() {
-    // GIVEN
-    Object value = mapOf(entry("key", "value"));
-    // WHEN
-    MapAssert<Object, Object> result = MAP.createAssert(value);
-    // THEN
-    result.containsExactly(entry("key", "value"));
-  }
-
-  @Test
-  void map_typed_factory_createAssert_should_create_map_typed_assertions() {
-    // GIVEN
-    Object value = mapOf(entry("key", "value"));
-    // WHEN
-    MapAssert<String, String> result = map(String.class, String.class).createAssert(value);
-    // THEN
-    result.containsExactly(entry("key", "value"));
-  }
-
-  @Test
-  void comparable_factory_createAssert_should_create_comparable_assertions() {
-    // GIVEN
-    Object value = 0;
-    // WHEN
-    AbstractComparableAssert<?, Integer> result = comparable(Integer.class).createAssert(value);
-    // THEN
-    result.isEqualByComparingTo(0);
-  }
-
-  @SuppressWarnings("unused")
-  private static class VolatileFieldContainer {
-
-    volatile int intField;
-    volatile long longField;
-    volatile String stringField;
-
-  }
-
-  @ParameterizedTest
-  @MethodSource({
-      "nonParameterizedFactories",
-      "parameterizedFactories"
-  })
-  void getRawClass(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
-    // WHEN
-    Class<?> result = underTest.getRawClass();
-    // THEN
-    then(result).isEqualTo(rawClass);
-  }
-
-  @ParameterizedTest
-  @MethodSource("nonParameterizedFactories")
-  void createAssert_with_ValueProvider_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest,
-                                                                       Class<?> rawClass) {
-    // GIVEN
-    ValueProvider<?> valueProvider = mock();
-    // WHEN
-    underTest.createAssert(valueProvider);
-    // THEN
-    verify(valueProvider).apply(rawClass);
-  }
-
-  @ParameterizedTest
-  @MethodSource("nonParameterizedFactories")
-  void getType_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
-    // WHEN
-    Type type = underTest.getType();
-    // THEN
-    then(type).isEqualTo(rawClass);
-  }
-
-  @ParameterizedTest
-  @MethodSource("parameterizedFactories")
-  void getType_for_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass, Class<?>[] typeArguments) {
-    // WHEN
-    Type type = underTest.getType();
-    // THEN
-    then(type).asInstanceOf(type(ParameterizedType.class))
-              .returns(typeArguments, from(ParameterizedType::getActualTypeArguments))
-              .returns(rawClass, from(ParameterizedType::getRawType))
-              .returns(null, from(ParameterizedType::getOwnerType));
-  }
-
-  static Stream<Arguments> nonParameterizedFactories() {
-    return Stream.of(arguments(ARRAY, Object[].class),
-                     arguments(ARRAY_2D, Object[][].class),
-                     arguments(ATOMIC_BOOLEAN, AtomicBoolean.class),
-                     arguments(ATOMIC_INTEGER, AtomicInteger.class),
-                     arguments(ATOMIC_INTEGER_ARRAY, AtomicIntegerArray.class),
-                     arguments(ATOMIC_LONG, AtomicLong.class),
-                     arguments(ATOMIC_LONG_ARRAY, AtomicLongArray.class),
-                     arguments(BIG_DECIMAL, BigDecimal.class),
-                     arguments(BIG_INTEGER, BigInteger.class),
-                     arguments(BOOLEAN, Boolean.class),
-                     arguments(BOOLEAN_2D_ARRAY, boolean[][].class),
-                     arguments(BOOLEAN_ARRAY, boolean[].class),
-                     arguments(BYTE, Byte.class),
-                     arguments(BYTE_2D_ARRAY, byte[][].class),
-                     arguments(BYTE_ARRAY, byte[].class),
-                     arguments(CHAR_2D_ARRAY, char[][].class),
-                     arguments(CHAR_ARRAY, char[].class),
-                     arguments(CHAR_SEQUENCE, CharSequence.class),
-                     arguments(CHARACTER, Character.class),
-                     arguments(CLASS, Class.class),
-                     arguments(DATE, Date.class),
-                     arguments(DOUBLE, Double.class),
-                     arguments(DOUBLE_2D_ARRAY, double[][].class),
-                     arguments(DOUBLE_ARRAY, double[].class),
-                     arguments(DOUBLE_PREDICATE, DoublePredicate.class),
-                     arguments(DOUBLE_STREAM, DoubleStream.class),
-                     arguments(DURATION, Duration.class),
-                     arguments(FILE, File.class),
-                     arguments(FLOAT, Float.class),
-                     arguments(FLOAT_2D_ARRAY, float[][].class),
-                     arguments(FLOAT_ARRAY, float[].class),
-                     arguments(INPUT_STREAM, InputStream.class),
-                     arguments(INSTANT, Instant.class),
-                     arguments(INT_2D_ARRAY, int[][].class),
-                     arguments(INT_ARRAY, int[].class),
-                     arguments(INT_PREDICATE, IntPredicate.class),
-                     arguments(INT_STREAM, IntStream.class),
-                     arguments(INTEGER, Integer.class),
-                     arguments(LOCAL_DATE, LocalDate.class),
-                     arguments(LOCAL_DATE_TIME, LocalDateTime.class),
-                     arguments(LOCAL_TIME, LocalTime.class),
-                     arguments(LONG, Long.class),
-                     arguments(LONG_2D_ARRAY, long[][].class),
-                     arguments(LONG_ADDER, LongAdder.class),
-                     arguments(LONG_ARRAY, long[].class),
-                     arguments(LONG_PREDICATE, LongPredicate.class),
-                     arguments(LONG_STREAM, LongStream.class),
-                     arguments(MATCHER, Matcher.class),
-                     arguments(OFFSET_DATE_TIME, OffsetDateTime.class),
-                     arguments(OFFSET_TIME, OffsetTime.class),
-                     arguments(OPTIONAL_DOUBLE, OptionalDouble.class),
-                     arguments(OPTIONAL_INT, OptionalInt.class),
-                     arguments(OPTIONAL_LONG, OptionalLong.class),
-                     arguments(PATH, Path.class),
-                     arguments(PERIOD, Period.class),
-                     arguments(SHORT, Short.class),
-                     arguments(SHORT_2D_ARRAY, short[][].class),
-                     arguments(SHORT_ARRAY, short[].class),
-                     arguments(STRING, String.class),
-                     arguments(STRING_BUFFER, StringBuffer.class),
-                     arguments(STRING_BUILDER, StringBuilder.class),
-                     arguments(TEMPORAL, Temporal.class),
-                     arguments(THROWABLE, Throwable.class),
-                     arguments(URI_TYPE, URI.class),
-                     arguments(URL_TYPE, URL.class),
-                     arguments(YEAR_MONTH, YearMonth.class),
-                     arguments(ZONED_DATE_TIME, ZonedDateTime.class),
-                     arguments(array(String[].class), String[].class),
-                     arguments(array2D(String[][].class), String[][].class),
-                     arguments(comparable(Integer.class), Integer.class),
-                     arguments(throwable(RuntimeException.class), RuntimeException.class),
-                     arguments(type(String.class), String.class));
-  }
-
-  static Stream<Arguments> parameterizedFactories() {
-    return Stream.of(arguments(ATOMIC_INTEGER_FIELD_UPDATER, AtomicIntegerFieldUpdater.class, classes(Object.class)),
-                     arguments(ATOMIC_LONG_FIELD_UPDATER, AtomicLongFieldUpdater.class, classes(Object.class)),
-                     arguments(ATOMIC_MARKABLE_REFERENCE, AtomicMarkableReference.class, classes(Object.class)),
-                     arguments(ATOMIC_REFERENCE, AtomicReference.class, classes(Object.class)),
-                     arguments(ATOMIC_REFERENCE_ARRAY, AtomicReferenceArray.class, classes(Object.class)),
-                     arguments(ATOMIC_REFERENCE_FIELD_UPDATER, AtomicReferenceFieldUpdater.class,
-                               classes(Object.class, Object.class)),
-                     arguments(ATOMIC_STAMPED_REFERENCE, AtomicStampedReference.class, classes(Object.class)),
-                     arguments(COLLECTION, Collection.class, classes(Object.class)),
-                     arguments(COMPLETABLE_FUTURE, CompletableFuture.class, classes(Object.class)),
-                     arguments(COMPLETION_STAGE, CompletionStage.class, classes(Object.class)),
-                     arguments(FUTURE, Future.class, classes(Object.class)),
-                     arguments(ITERABLE, Iterable.class, classes(Object.class)),
-                     arguments(ITERATOR, Iterator.class, classes(Object.class)),
-                     arguments(LIST, List.class, classes(Object.class)),
-                     arguments(MAP, Map.class, classes(Object.class, Object.class)),
-                     arguments(OPTIONAL, Optional.class, classes(Object.class)),
-                     arguments(PREDICATE, Predicate.class, classes(Object.class)),
-                     arguments(SET, Set.class, classes(Object.class)),
-                     arguments(SPLITERATOR, Spliterator.class, classes(Object.class)),
-                     arguments(STREAM, Stream.class, classes(Object.class)),
-                     arguments(atomicIntegerFieldUpdater(VolatileFieldContainer.class), AtomicIntegerFieldUpdater.class,
-                               classes(VolatileFieldContainer.class)),
-                     arguments(atomicLongFieldUpdater(VolatileFieldContainer.class), AtomicLongFieldUpdater.class,
-                               classes(VolatileFieldContainer.class)),
-                     arguments(atomicMarkableReference(Integer.class), AtomicMarkableReference.class, classes(Integer.class)),
-                     arguments(atomicReference(Integer.class), AtomicReference.class, classes(Integer.class)),
-                     arguments(atomicReferenceArray(Integer.class), AtomicReferenceArray.class, classes(Integer.class)),
-                     arguments(atomicReferenceFieldUpdater(String.class, VolatileFieldContainer.class),
-                               AtomicReferenceFieldUpdater.class,
-                               classes(String.class, VolatileFieldContainer.class)),
-                     arguments(atomicStampedReference(Integer.class), AtomicStampedReference.class, classes(Integer.class)),
-                     arguments(collection(String.class), Collection.class, classes(String.class)),
-                     arguments(completableFuture(String.class), CompletableFuture.class, classes(String.class)),
-                     arguments(completionStage(String.class), CompletionStage.class, classes(String.class)),
-                     arguments(future(String.class), Future.class, classes(String.class)),
-                     arguments(iterable(String.class), Iterable.class, classes(String.class)),
-                     arguments(iterator(String.class), Iterator.class, classes(String.class)),
-                     arguments(list(String.class), List.class, classes(String.class)),
-                     arguments(map(String.class, String.class), Map.class, classes(String.class, String.class)),
-                     arguments(optional(String.class), Optional.class, classes(String.class)),
-                     arguments(predicate(String.class), Predicate.class, classes(String.class)),
-                     arguments(set(String.class), Set.class, classes(String.class)),
-                     arguments(spliterator(String.class), Spliterator.class, classes(String.class)),
-                     arguments(stream(String.class), Stream.class, classes(String.class)));
-  }
-
-  private static Class<?>[] classes(Class<?>... classes) {
-    return classes;
+  @Nested
+  class Predicate_Factory {
+
+    private final Object actual = (Predicate<Object>) Objects::isNull;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = PREDICATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Predicate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      PredicateAssert<Object> result = PREDICATE.createAssert(actual);
+      // THEN
+      result.accepts((Object) null);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      PredicateAssert<Object> result = PREDICATE.createAssert(valueProvider);
+      // THEN
+      result.accepts((Object) null);
+      verify(valueProvider).apply(parameterizedType(Predicate.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Predicate_Typed_Factory {
+
+    private final Object actual = (Predicate<String>) Strings::isNullOrEmpty;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = PREDICATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Predicate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      PredicateAssert<String> result = predicate(String.class).createAssert(actual);
+      // THEN
+      result.accepts("");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      PredicateAssert<String> result = predicate(String.class).createAssert(valueProvider);
+      // THEN
+      result.accepts("");
+      verify(valueProvider).apply(parameterizedType(Predicate.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class IntPredicate_Factory {
+
+    private final Object actual = (IntPredicate) i -> i == 0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INT_PREDICATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(IntPredicate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      IntPredicateAssert result = INT_PREDICATE.createAssert(actual);
+      // THEN
+      result.accepts(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      IntPredicateAssert result = INT_PREDICATE.createAssert(valueProvider);
+      // THEN
+      result.accepts(0);
+      verify(valueProvider).apply(IntPredicate.class);
+    }
+
+  }
+
+  @Nested
+  class LongPredicate_Factory {
+
+    private final Object actual = (LongPredicate) l -> l == 0L;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG_PREDICATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(LongPredicate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      LongPredicateAssert result = LONG_PREDICATE.createAssert(actual);
+      // THEN
+      result.accepts(0L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      LongPredicateAssert result = LONG_PREDICATE.createAssert(valueProvider);
+      // THEN
+      result.accepts(0L);
+      verify(valueProvider).apply(LongPredicate.class);
+    }
+
+  }
+
+  @Nested
+  class DoublePredicate_Factory {
+
+    private final Object actual = (DoublePredicate) d -> d == 0.0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DOUBLE_PREDICATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(DoublePredicate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      DoublePredicateAssert result = DOUBLE_PREDICATE.createAssert(actual);
+      // THEN
+      result.accepts(0.0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      DoublePredicateAssert result = DOUBLE_PREDICATE.createAssert(valueProvider);
+      // THEN
+      result.accepts(0.0);
+      verify(valueProvider).apply(DoublePredicate.class);
+    }
+
+  }
+
+  @Nested
+  class CompletableFuture_Factory {
+
+    private final Object actual = completedFuture("done");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = COMPLETABLE_FUTURE.getRawClass();
+      // THEN
+      then(result).isEqualTo(CompletableFuture.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      CompletableFutureAssert<Object> result = COMPLETABLE_FUTURE.createAssert(actual);
+      // THEN
+      result.isDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      CompletableFutureAssert<Object> result = COMPLETABLE_FUTURE.createAssert(valueProvider);
+      // THEN
+      result.isDone();
+      verify(valueProvider).apply(parameterizedType(CompletableFuture.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class CompletableFuture_Typed_Factory {
+
+    private final Object actual = completedFuture("done");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = completableFuture(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(CompletableFuture.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      CompletableFutureAssert<String> result = completableFuture(String.class).createAssert(actual);
+      // THEN
+      result.isDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      CompletableFutureAssert<String> result = completableFuture(String.class).createAssert(valueProvider);
+      // THEN
+      result.isDone();
+      verify(valueProvider).apply(parameterizedType(CompletableFuture.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class CompletionStage_Factory {
+
+    private final Object actual = completedFuture("done");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = COMPLETION_STAGE.getRawClass();
+      // THEN
+      then(result).isEqualTo(CompletionStage.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      CompletableFutureAssert<Object> result = COMPLETION_STAGE.createAssert(actual);
+      // THEN
+      result.isDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      CompletableFutureAssert<Object> result = COMPLETION_STAGE.createAssert(valueProvider);
+      // THEN
+      result.isDone();
+      verify(valueProvider).apply(parameterizedType(CompletionStage.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class CompletionStage_Typed_Factory {
+
+    private final Object actual = completedFuture("done");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = COMPLETION_STAGE.getRawClass();
+      // THEN
+      then(result).isEqualTo(CompletionStage.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      CompletableFutureAssert<String> result = completionStage(String.class).createAssert(actual);
+      // THEN
+      result.isDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      CompletableFutureAssert<String> result = completionStage(String.class).createAssert(valueProvider);
+      // THEN
+      result.isDone();
+      verify(valueProvider).apply(parameterizedType(CompletionStage.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Optional_Factory {
+
+    private final Object actual = Optional.of("something");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OPTIONAL.getRawClass();
+      // THEN
+      then(result).isEqualTo(Optional.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      OptionalAssert<Object> result = OPTIONAL.createAssert(actual);
+      // THEN
+      result.isPresent();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      OptionalAssert<Object> result = OPTIONAL.createAssert(valueProvider);
+      // THEN
+      result.isPresent();
+      verify(valueProvider).apply(parameterizedType(Optional.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Optional_Typed_Factory {
+
+    private final Object actual = Optional.of("something");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = optional(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Optional.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      OptionalAssert<String> result = optional(String.class).createAssert(actual);
+      // THEN
+      result.isPresent();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      OptionalAssert<String> result = optional(String.class).createAssert(valueProvider);
+      // THEN
+      result.isPresent();
+      verify(valueProvider).apply(parameterizedType(Optional.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class OptionalDouble_Factory {
+
+    private final Object actual = OptionalDouble.of(0.0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OPTIONAL_DOUBLE.getRawClass();
+      // THEN
+      then(result).isEqualTo(OptionalDouble.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      OptionalDoubleAssert result = OPTIONAL_DOUBLE.createAssert(actual);
+      // THEN
+      result.isPresent();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      OptionalDoubleAssert result = OPTIONAL_DOUBLE.createAssert(valueProvider);
+      // THEN
+      result.isPresent();
+      verify(valueProvider).apply(OptionalDouble.class);
+    }
+
+  }
+
+  @Nested
+  class OptionalInt_Factory {
+
+    private final Object actual = OptionalInt.of(0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OPTIONAL_INT.getRawClass();
+      // THEN
+      then(result).isEqualTo(OptionalInt.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      OptionalIntAssert result = OPTIONAL_INT.createAssert(actual);
+      // THEN
+      result.isPresent();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      OptionalIntAssert result = OPTIONAL_INT.createAssert(valueProvider);
+      // THEN
+      result.isPresent();
+      verify(valueProvider).apply(OptionalInt.class);
+    }
+
+  }
+
+  @Nested
+  class OptionalLong_Factory {
+
+    private final Object actual = OptionalLong.of(0L);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OPTIONAL_LONG.getRawClass();
+      // THEN
+      then(result).isEqualTo(OptionalLong.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      OptionalLongAssert result = OPTIONAL_LONG.createAssert(actual);
+      // THEN
+      result.isPresent();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      OptionalLongAssert result = OPTIONAL_LONG.createAssert(valueProvider);
+      // THEN
+      result.isPresent();
+      verify(valueProvider).apply(OptionalLong.class);
+    }
+
+  }
+
+  @Nested
+  class Matcher_Factory {
+
+    private final Object actual = Pattern.compile("a*").matcher("aaa");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = MATCHER.getRawClass();
+      // THEN
+      then(result).isEqualTo(Matcher.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      MatcherAssert result = MATCHER.createAssert(actual);
+      // THEN
+      result.matches();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      MatcherAssert result = MATCHER.createAssert(valueProvider);
+      // THEN
+      result.matches();
+      verify(valueProvider).apply(Matcher.class);
+    }
+
+  }
+
+  @Nested
+  class BigDecimal_Factory {
+
+    private final Object actual = BigDecimal.valueOf(0.0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BIG_DECIMAL.getRawClass();
+      // THEN
+      then(result).isEqualTo(BigDecimal.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractBigDecimalAssert<?> result = BIG_DECIMAL.createAssert(actual);
+      // THEN
+      result.isEqualTo("0.0");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractBigDecimalAssert<?> result = BIG_DECIMAL.createAssert(valueProvider);
+      // THEN
+      result.isEqualTo("0.0");
+      verify(valueProvider).apply(BigDecimal.class);
+    }
+
+  }
+
+  @Nested
+  class BigInteger_Factory {
+
+    private final Object actual = BigInteger.valueOf(0L);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BIG_INTEGER.getRawClass();
+      // THEN
+      then(result).isEqualTo(BigInteger.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractBigIntegerAssert<?> result = BIG_INTEGER.createAssert(actual);
+      // THEN
+      result.isEqualTo(0L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractBigIntegerAssert<?> result = BIG_INTEGER.createAssert(valueProvider);
+      // THEN
+      result.isEqualTo(0L);
+      verify(valueProvider).apply(BigInteger.class);
+    }
+
+  }
+
+  @Nested
+  class URI_Factory {
+
+    private final Object actual = URI.create("http://localhost");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = URI_TYPE.getRawClass();
+      // THEN
+      then(result).isEqualTo(URI.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractUriAssert<?> result = URI_TYPE.createAssert(actual);
+      // THEN
+      result.hasHost("localhost");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractUriAssert<?> result = URI_TYPE.createAssert(valueProvider);
+      // THEN
+      result.hasHost("localhost");
+      verify(valueProvider).apply(URI.class);
+    }
+
+  }
+
+  @Nested
+  class URL_Factory {
+
+    private final Object actual = new URL("http://localhost");
+
+    URL_Factory() throws MalformedURLException {}
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = URL_TYPE.getRawClass();
+      // THEN
+      then(result).isEqualTo(URL.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractUrlAssert<?> result = URL_TYPE.createAssert(actual);
+      // THEN
+      result.hasHost("localhost");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractUrlAssert<?> result = URL_TYPE.createAssert(valueProvider);
+      // THEN
+      result.hasHost("localhost");
+      verify(valueProvider).apply(URL.class);
+    }
+
+  }
+
+  @Nested
+  class Boolean_Factory {
+
+    private final Object actual = true;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BOOLEAN.getRawClass();
+      // THEN
+      then(result).isEqualTo(Boolean.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractBooleanAssert<?> result = BOOLEAN.createAssert(actual);
+      // THEN
+      result.isTrue();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractBooleanAssert<?> result = BOOLEAN.createAssert(valueProvider);
+      // THEN
+      result.isTrue();
+      verify(valueProvider).apply(Boolean.class);
+    }
+
+  }
+
+  @Nested
+  class Boolean_Array_Factory {
+
+    private final Object actual = new boolean[] { true, false };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BOOLEAN_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(boolean[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractBooleanArrayAssert<?> result = BOOLEAN_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(true, false);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractBooleanArrayAssert<?> result = BOOLEAN_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(true, false);
+      verify(valueProvider).apply(boolean[].class);
+    }
+
+  }
+
+  @Nested
+  class Boolean_2D_Array_Factory {
+
+    private final Object actual = new boolean[][] { { true, false }, { false, true } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BOOLEAN_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(boolean[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Boolean2DArrayAssert result = BOOLEAN_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Boolean2DArrayAssert result = BOOLEAN_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(boolean[][].class);
+    }
+
+  }
+
+  @Nested
+  class Byte_Factory {
+
+    private final Object actual = (byte) 0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BYTE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Byte.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractByteAssert<?> result = BYTE.createAssert(actual);
+      // THEN
+      result.isEqualTo((byte) 0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractByteAssert<?> result = BYTE.createAssert(valueProvider);
+      // THEN
+      result.isEqualTo((byte) 0);
+      verify(valueProvider).apply(Byte.class);
+    }
+
+  }
+
+  @Nested
+  class Byte_Array_Factory {
+
+    private final Object actual = new byte[] { 0, 1 };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BYTE_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(byte[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractByteArrayAssert<?> result = BYTE_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0, 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractByteArrayAssert<?> result = BYTE_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, 1);
+      verify(valueProvider).apply(byte[].class);
+    }
+
+  }
+
+  @Nested
+  class Byte_2D_Array_Factory {
+
+    private final Object actual = new byte[][] { { 0, 1 }, { 2, 3 } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = BYTE_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(byte[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Byte2DArrayAssert result = BYTE_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Byte2DArrayAssert result = BYTE_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(byte[][].class);
+    }
+
+  }
+
+  @Nested
+  class Character_Factory {
+
+    private final Object actual = 'a';
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = CHARACTER.getRawClass();
+      // THEN
+      then(result).isEqualTo(Character.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCharacterAssert<?> result = CHARACTER.createAssert(actual);
+      // THEN
+      result.isLowerCase();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCharacterAssert<?> result = CHARACTER.createAssert(valueProvider);
+      // THEN
+      result.isLowerCase();
+      verify(valueProvider).apply(Character.class);
+    }
+
+  }
+
+  @Nested
+  class Char_Array_Factory {
+
+    private final Object actual = new char[] { 'a', 'b' };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = CHAR_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(char[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCharArrayAssert<?> result = CHAR_ARRAY.createAssert(actual);
+      // THEN
+      result.doesNotHaveDuplicates();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCharArrayAssert<?> result = CHAR_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.doesNotHaveDuplicates();
+      verify(valueProvider).apply(char[].class);
+    }
+
+  }
+
+  @Nested
+  class Char_2D_Array_Factory {
+
+    private final Object actual = new char[][] { { 'a', 'b' }, { 'c', 'd' } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = CHAR_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(char[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Char2DArrayAssert result = CHAR_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Char2DArrayAssert result = CHAR_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(char[][].class);
+    }
+
+  }
+
+  @Nested
+  class Class_Factory {
+
+    private final Object actual = Function.class;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = CLASS.getRawClass();
+      // THEN
+      then(result).isEqualTo(Class.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ClassAssert result = CLASS.createAssert(actual);
+      // THEN
+      result.hasAnnotations(FunctionalInterface.class);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ClassAssert result = CLASS.createAssert(valueProvider);
+      // THEN
+      result.hasAnnotations(FunctionalInterface.class);
+      verify(valueProvider).apply(Class.class);
+    }
+
+  }
+
+  @Nested
+  class Double_Factory {
+
+    private final Object actual = 0.0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DOUBLE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Double.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractDoubleAssert<?> result = DOUBLE.createAssert(actual);
+      // THEN
+      result.isZero();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractDoubleAssert<?> result = DOUBLE.createAssert(valueProvider);
+      // THEN
+      result.isZero();
+      verify(valueProvider).apply(Double.class);
+    }
+
+  }
+
+  @Nested
+  class Double_Array_Factory {
+
+    private final Object actual = new double[] { 0.0, 1.0 };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DOUBLE_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(double[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractDoubleArrayAssert<?> result = DOUBLE_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0.0, 1.0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractDoubleArrayAssert<?> result = DOUBLE_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0.0, 1.0);
+      verify(valueProvider).apply(double[].class);
+    }
+
+  }
+
+  @Nested
+  class Double_2D_Array_Factory {
+
+    private final Object actual = new double[][] { { 0.0, 1.0 }, { 2.0, 3.0 } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DOUBLE_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(double[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Double2DArrayAssert result = DOUBLE_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Double2DArrayAssert result = DOUBLE_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(double[][].class);
+    }
+
+  }
+
+  @Nested
+  class File_Factory {
+
+    private final Object actual = new File("non-existing-file");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = FILE.getRawClass();
+      // THEN
+      then(result).isEqualTo(File.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractFileAssert<?> result = FILE.createAssert(actual);
+      // THEN
+      result.doesNotExist();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractFileAssert<?> result = FILE.createAssert(valueProvider);
+      // THEN
+      result.doesNotExist();
+      verify(valueProvider).apply(File.class);
+    }
+
+  }
+
+  @Nested
+  class Future_Factory {
+
+    private final Object actual = mock(Future.class);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = FUTURE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Future.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      FutureAssert<Object> result = FUTURE.createAssert(actual);
+      // THEN
+      result.isNotDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      FutureAssert<Object> result = FUTURE.createAssert(valueProvider);
+      // THEN
+      result.isNotDone();
+      verify(valueProvider).apply(parameterizedType(Future.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Future_Typed_Factory {
+
+    private final Object actual = mock(Future.class);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = future(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Future.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      FutureAssert<String> result = future(String.class).createAssert(actual);
+      // THEN
+      result.isNotDone();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      FutureAssert<String> result = future(String.class).createAssert(valueProvider);
+      // THEN
+      result.isNotDone();
+      verify(valueProvider).apply(parameterizedType(Future.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class InputStream_Factory {
+
+    private final Object actual = new ByteArrayInputStream("stream".getBytes());
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INPUT_STREAM.getRawClass();
+      // THEN
+      then(result).isEqualTo(InputStream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractInputStreamAssert<?, ?> result = INPUT_STREAM.createAssert(actual);
+      // THEN
+      result.hasContent("stream");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractInputStreamAssert<?, ?> result = INPUT_STREAM.createAssert(valueProvider);
+      // THEN
+      result.hasContent("stream");
+      verify(valueProvider).apply(InputStream.class);
+    }
+
+  }
+
+  @Nested
+  class Float_Factory {
+
+    private final Object actual = 0.0f;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = FLOAT.getRawClass();
+      // THEN
+      then(result).isEqualTo(Float.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractFloatAssert<?> result = FLOAT.createAssert(actual);
+      // THEN
+      result.isZero();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractFloatAssert<?> result = FLOAT.createAssert(valueProvider);
+      // THEN
+      result.isZero();
+      verify(valueProvider).apply(Float.class);
+    }
+
+  }
+
+  @Nested
+  class Float_Array_Factory {
+
+    private final Object actual = new float[] { 0.0f, 1.0f };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = FLOAT_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(float[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractFloatArrayAssert<?> result = FLOAT_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0.0f, 1.0f);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractFloatArrayAssert<?> result = FLOAT_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0.0f, 1.0f);
+      verify(valueProvider).apply(float[].class);
+    }
+
+  }
+
+  @Nested
+  class Float_2D_Array_Factory {
+
+    private final Object actual = new float[][] { { 0.0f, 1.0f }, { 2.0f, 3.0f } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = FLOAT_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(float[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Float2DArrayAssert result = FLOAT_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Float2DArrayAssert result = FLOAT_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(float[][].class);
+    }
+
+  }
+
+  @Nested
+  class Integer_Factory {
+
+    private final Object actual = 0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INTEGER.getRawClass();
+      // THEN
+      then(result).isEqualTo(Integer.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractIntegerAssert<?> result = INTEGER.createAssert(actual);
+      // THEN
+      result.isZero();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractIntegerAssert<?> result = INTEGER.createAssert(valueProvider);
+      // THEN
+      result.isZero();
+      verify(valueProvider).apply(Integer.class);
+    }
+
+  }
+
+  @Nested
+  class Int_Array_Factory {
+
+    private final Object actual = new int[] { 0, 1 };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INT_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(int[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractIntArrayAssert<?> result = INT_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0, 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractIntArrayAssert<?> result = INT_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, 1);
+      verify(valueProvider).apply(int[].class);
+    }
+
+  }
+
+  @Nested
+  class Int_2D_Array_Factory {
+
+    private final Object actual = new int[][] { { 0, 1 }, { 2, 3 } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INT_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(int[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Int2DArrayAssert result = INT_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Int2DArrayAssert result = INT_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(int[][].class);
+    }
+
+  }
+
+  @Nested
+  class Long_Factory {
+
+    private final Object actual = 0L;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG.getRawClass();
+      // THEN
+      then(result).isEqualTo(Long.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractLongAssert<?> result = LONG.createAssert(actual);
+      // THEN
+      result.isZero();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractLongAssert<?> result = LONG.createAssert(valueProvider);
+      // THEN
+      result.isZero();
+      verify(valueProvider).apply(Long.class);
+    }
+
+  }
+
+  @Nested
+  class Long_Array_Factory {
+
+    private final Object actual = new long[] { 0L, 1L };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(long[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractLongArrayAssert<?> result = LONG_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0L, 1L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractLongArrayAssert<?> result = LONG_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0L, 1L);
+      verify(valueProvider).apply(long[].class);
+    }
+
+  }
+
+  @Nested
+  class Long_2D_Array_Factory {
+
+    private final Object actual = new long[][] { { 0L, 1L }, { 2L, 3L } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(long[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Long2DArrayAssert result = LONG_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Long2DArrayAssert result = LONG_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(long[][].class);
+    }
+
+  }
+
+  @Nested
+  class Type_Factory {
+
+    private final Object actual = "string";
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = type(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(String.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ObjectAssert<String> result = type(String.class).createAssert(actual);
+      // THEN
+      result.extracting(String::isEmpty).isEqualTo(false);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ObjectAssert<String> result = type(String.class).createAssert(valueProvider);
+      // THEN
+      result.extracting(String::isEmpty).isEqualTo(false);
+      verify(valueProvider).apply(String.class);
+    }
+
+  }
+
+  @Nested
+  class Array_Factory {
+
+    private final Object actual = new Object[] { 0, "" };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(Object[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ObjectArrayAssert<Object> result = ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0, "");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ObjectArrayAssert<Object> result = ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, "");
+      verify(valueProvider).apply(Object[].class);
+    }
+
+  }
+
+  @Nested
+  class Array_Typed_Factory {
+
+    private final Object actual = new Integer[] { 0, 1 };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = array(Integer[].class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Integer[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ObjectArrayAssert<Integer> result = array(Integer[].class).createAssert(actual);
+      // THEN
+      result.containsExactly(0, 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ObjectArrayAssert<Integer> result = array(Integer[].class).createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, 1);
+      verify(valueProvider).apply(Integer[].class);
+    }
+
+  }
+
+  @Nested
+  class Array_2D_Factory {
+
+    private final Object actual = new Object[][] { { 0, "" }, { 3.0, 'b' } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ARRAY_2D.getRawClass();
+      // THEN
+      then(result).isEqualTo(Object[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Object2DArrayAssert<Object> result = ARRAY_2D.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Object2DArrayAssert<Object> result = ARRAY_2D.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(Object[][].class);
+    }
+
+  }
+
+  @Nested
+  class Array_2D_Typed_Factory {
+
+    private final Object actual = new Integer[][] { { 0, 1 }, { 2, 3 } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = array2D(Integer[][].class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Integer[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Object2DArrayAssert<Integer> result = array2D(Integer[][].class).createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Object2DArrayAssert<Integer> result = array2D(Integer[][].class).createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(Integer[][].class);
+    }
+
+  }
+
+  @Nested
+  class Short_Factory {
+
+    private final Object actual = (short) 0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = SHORT.getRawClass();
+      // THEN
+      then(result).isEqualTo(Short.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractShortAssert<?> result = SHORT.createAssert(actual);
+      // THEN
+      result.isZero();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractShortAssert<?> result = SHORT.createAssert(valueProvider);
+      // THEN
+      result.isZero();
+      verify(valueProvider).apply(Short.class);
+    }
+
+  }
+
+  @Nested
+  class Short_Array_Factory {
+
+    private final Object actual = new short[] { 0, 1 };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = SHORT_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(short[].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractShortArrayAssert<?> result = SHORT_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly((short) 0, (short) 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractShortArrayAssert<?> result = SHORT_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly((short) 0, (short) 1);
+      verify(valueProvider).apply(short[].class);
+    }
+
+  }
+
+  @Nested
+  class Short_2D_Array_Factory {
+
+    private final Object actual = new short[][] { { 0, 1 }, { 2, 3 } };
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = SHORT_2D_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(short[][].class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      Short2DArrayAssert result = SHORT_2D_ARRAY.createAssert(actual);
+      // THEN
+      result.hasDimensions(2, 2);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      Short2DArrayAssert result = SHORT_2D_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.hasDimensions(2, 2);
+      verify(valueProvider).apply(short[][].class);
+    }
+
+  }
+
+  @Nested
+  class Date_Factory {
+
+    private final Object actual = new Date();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Date.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractDateAssert<?> result = DATE.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(new Date());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractDateAssert<?> result = DATE.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(new Date());
+      verify(valueProvider).apply(Date.class);
+    }
+
+  }
+
+  @Nested
+  class Temporal_Factory {
+
+    private final Object actual = ZonedDateTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = TEMPORAL.getRawClass();
+      // THEN
+      then(result).isEqualTo(Temporal.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      TemporalAssert result = TEMPORAL.createAssert(actual);
+      // THEN
+      result.isCloseTo(ZonedDateTime.now(), within(10, SECONDS));
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      TemporalAssert result = TEMPORAL.createAssert(valueProvider);
+      // THEN
+      result.isCloseTo(ZonedDateTime.now(), within(10, SECONDS));
+      verify(valueProvider).apply(Temporal.class);
+    }
+
+  }
+
+  @Nested
+  class ZonedDateTime_Factory {
+
+    private final Object actual = ZonedDateTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ZONED_DATE_TIME.getRawClass();
+      // THEN
+      then(result).isEqualTo(ZonedDateTime.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractZonedDateTimeAssert<?> result = ZONED_DATE_TIME.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(ZonedDateTime.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractZonedDateTimeAssert<?> result = ZONED_DATE_TIME.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(ZonedDateTime.now());
+      verify(valueProvider).apply(ZonedDateTime.class);
+    }
+
+  }
+
+  @Nested
+  class LocalDateTime_Factory {
+
+    private final Object actual = LocalDateTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LOCAL_DATE_TIME.getRawClass();
+      // THEN
+      then(result).isEqualTo(LocalDateTime.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractLocalDateTimeAssert<?> result = LOCAL_DATE_TIME.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(LocalDateTime.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractLocalDateTimeAssert<?> result = LOCAL_DATE_TIME.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(LocalDateTime.now());
+      verify(valueProvider).apply(LocalDateTime.class);
+    }
+
+  }
+
+  @Nested
+  class OffsetDateTime_Factory {
+
+    private final Object actual = OffsetDateTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OFFSET_DATE_TIME.getRawClass();
+      // THEN
+      then(result).isEqualTo(OffsetDateTime.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractOffsetDateTimeAssert<?> result = OFFSET_DATE_TIME.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(OffsetDateTime.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractOffsetDateTimeAssert<?> result = OFFSET_DATE_TIME.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(OffsetDateTime.now());
+      verify(valueProvider).apply(OffsetDateTime.class);
+    }
+
+  }
+
+  @Nested
+  class OffsetTime_Factory {
+
+    private final Object actual = OffsetTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = OFFSET_TIME.getRawClass();
+      // THEN
+      then(result).isEqualTo(OffsetTime.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractOffsetTimeAssert<?> result = OFFSET_TIME.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(OffsetTime.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractOffsetTimeAssert<?> result = OFFSET_TIME.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(OffsetTime.now());
+      verify(valueProvider).apply(OffsetTime.class);
+    }
+
+  }
+
+  @Nested
+  class LocalTime_Factory {
+
+    private final Object actual = LocalTime.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LOCAL_TIME.getRawClass();
+      // THEN
+      then(result).isEqualTo(LocalTime.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractLocalTimeAssert<?> result = LOCAL_TIME.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(LocalTime.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractLocalTimeAssert<?> result = LOCAL_TIME.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(LocalTime.now());
+      verify(valueProvider).apply(LocalTime.class);
+    }
+
+  }
+
+  @Nested
+  class LocalDate_Factory {
+
+    private final Object actual = LocalDate.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LOCAL_DATE.getRawClass();
+      // THEN
+      then(result).isEqualTo(LocalDate.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractLocalDateAssert<?> result = LOCAL_DATE.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(LocalDate.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractLocalDateAssert<?> result = LOCAL_DATE.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(LocalDate.now());
+      verify(valueProvider).apply(LocalDate.class);
+    }
+
+  }
+
+  @Nested
+  class YearMonth_Factory {
+
+    private final Object actual = YearMonth.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = YEAR_MONTH.getRawClass();
+      // THEN
+      then(result).isEqualTo(YearMonth.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractYearMonthAssert<?> result = YEAR_MONTH.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(YearMonth.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractYearMonthAssert<?> result = YEAR_MONTH.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(YearMonth.now());
+      verify(valueProvider).apply(YearMonth.class);
+    }
+
+  }
+
+  @Nested
+  class Instant_Factory {
+
+    private final Object actual = Instant.now();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INSTANT.getRawClass();
+      // THEN
+      then(result).isEqualTo(Instant.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractInstantAssert<?> result = INSTANT.createAssert(actual);
+      // THEN
+      result.isBeforeOrEqualTo(Instant.now());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractInstantAssert<?> result = INSTANT.createAssert(valueProvider);
+      // THEN
+      result.isBeforeOrEqualTo(Instant.now());
+      verify(valueProvider).apply(Instant.class);
+    }
+
+  }
+
+  @Nested
+  class Duration_Factory {
+
+    private final Object actual = Duration.ofHours(10);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DURATION.getRawClass();
+      // THEN
+      then(result).isEqualTo(Duration.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractDurationAssert<?> result = DURATION.createAssert(actual);
+      // THEN
+      result.hasHours(10);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractDurationAssert<?> result = DURATION.createAssert(valueProvider);
+      // THEN
+      result.hasHours(10);
+      verify(valueProvider).apply(Duration.class);
+    }
+
+  }
+
+  @Nested
+  class Period_Factory {
+
+    private final Object actual = Period.ofYears(1);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = PERIOD.getRawClass();
+      // THEN
+      then(result).isEqualTo(Period.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractPeriodAssert<?> result = PERIOD.createAssert(actual);
+      // THEN
+      result.hasYears(1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractPeriodAssert<?> result = PERIOD.createAssert(valueProvider);
+      // THEN
+      result.hasYears(1);
+      verify(valueProvider).apply(Period.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicBoolean_Factory {
+
+    private final Object actual = new AtomicBoolean();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_BOOLEAN.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicBoolean.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicBooleanAssert result = ATOMIC_BOOLEAN.createAssert(actual);
+      // THEN
+      result.isFalse();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicBooleanAssert result = ATOMIC_BOOLEAN.createAssert(valueProvider);
+      // THEN
+      result.isFalse();
+      verify(valueProvider).apply(AtomicBoolean.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicInteger_Factory {
+
+    private final Object actual = new AtomicInteger();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_INTEGER.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicInteger.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicIntegerAssert result = ATOMIC_INTEGER.createAssert(actual);
+      // THEN
+      result.hasValue(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicIntegerAssert result = ATOMIC_INTEGER.createAssert(valueProvider);
+      // THEN
+      result.hasValue(0);
+      verify(valueProvider).apply(AtomicInteger.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicIntegerArray_Factory {
+
+    private final Object actual = new AtomicIntegerArray(new int[] { 0, 1 });
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_INTEGER_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicIntegerArray.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicIntegerArrayAssert result = ATOMIC_INTEGER_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0, 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicIntegerArrayAssert result = ATOMIC_INTEGER_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, 1);
+      verify(valueProvider).apply(AtomicIntegerArray.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicIntegerFieldUpdater_Factory {
+
+    private final Object actual = AtomicIntegerFieldUpdater.newUpdater(Container.class, "intField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_INTEGER_FIELD_UPDATER.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicIntegerFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicIntegerFieldUpdaterAssert<Object> result = ATOMIC_INTEGER_FIELD_UPDATER.createAssert(actual);
+      // THEN
+      result.hasValue(0, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicIntegerFieldUpdaterAssert<Object> result = ATOMIC_INTEGER_FIELD_UPDATER.createAssert(valueProvider);
+      // THEN
+      result.hasValue(0, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicIntegerFieldUpdater.class, Object.class));
+    }
+
+    private class Container {
+
+      volatile int intField;
+
+    }
+
+  }
+
+  @Nested
+  class AtomicIntegerFieldUpdater_Typed_Factory {
+
+    private final Object actual = AtomicIntegerFieldUpdater.newUpdater(Container.class, "intField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = atomicIntegerFieldUpdater(Container.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicIntegerFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicIntegerFieldUpdaterAssert<Container> result = atomicIntegerFieldUpdater(Container.class).createAssert(actual);
+      // THEN
+      result.hasValue(0, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicIntegerFieldUpdaterAssert<Container> result = atomicIntegerFieldUpdater(Container.class).createAssert(valueProvider);
+      // THEN
+      result.hasValue(0, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicIntegerFieldUpdater.class, Container.class));
+    }
+
+    private class Container {
+
+      volatile int intField;
+
+    }
+
+  }
+
+  @Nested
+  class LongAdder_Factory {
+
+    private final Object actual = new LongAdder();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG_ADDER.getRawClass();
+      // THEN
+      then(result).isEqualTo(LongAdder.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      LongAdderAssert result = LONG_ADDER.createAssert(actual);
+      // THEN
+      result.hasValue(0L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      LongAdderAssert result = LONG_ADDER.createAssert(valueProvider);
+      // THEN
+      result.hasValue(0L);
+      verify(valueProvider).apply(LongAdder.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicLong_Factory {
+
+    private final Object actual = new AtomicLong();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_LONG.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicLong.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicLongAssert result = ATOMIC_LONG.createAssert(actual);
+      // THEN
+      result.hasValue(0L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicLongAssert result = ATOMIC_LONG.createAssert(valueProvider);
+      // THEN
+      result.hasValue(0L);
+      verify(valueProvider).apply(AtomicLong.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicLongArray_Factory {
+
+    private final Object actual = new AtomicLongArray(new long[] { 0L, 1L });
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_LONG_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicLongArray.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicLongArrayAssert result = ATOMIC_LONG_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0L, 1L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicLongArrayAssert result = ATOMIC_LONG_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0L, 1L);
+      verify(valueProvider).apply(AtomicLongArray.class);
+    }
+
+  }
+
+  @Nested
+  class AtomicLongFieldUpdater_Factory {
+
+    private final Object actual = AtomicLongFieldUpdater.newUpdater(Container.class, "longField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_LONG_FIELD_UPDATER.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicLongFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicLongFieldUpdaterAssert<Object> result = ATOMIC_LONG_FIELD_UPDATER.createAssert(actual);
+      // THEN
+      result.hasValue(0L, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicLongFieldUpdaterAssert<Object> result = ATOMIC_LONG_FIELD_UPDATER.createAssert(valueProvider);
+      // THEN
+      result.hasValue(0L, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicLongFieldUpdater.class, Object.class));
+    }
+
+    private class Container {
+
+      volatile long longField;
+
+    }
+
+  }
+
+  @Nested
+  class AtomicLongFieldUpdater_Typed_Factory {
+
+    private final Object actual = AtomicLongFieldUpdater.newUpdater(Container.class, "longField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = atomicLongFieldUpdater(Container.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicLongFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicLongFieldUpdaterAssert<Container> result = atomicLongFieldUpdater(Container.class).createAssert(actual);
+      // THEN
+      result.hasValue(0L, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicLongFieldUpdaterAssert<Container> result = atomicLongFieldUpdater(Container.class).createAssert(valueProvider);
+      // THEN
+      result.hasValue(0L, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicLongFieldUpdater.class, Container.class));
+    }
+
+    private class Container {
+
+      volatile long longField;
+
+    }
+
+  }
+
+  @Nested
+  class AtomicReference_Factory {
+
+    private final Object actual = new AtomicReference<>();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_REFERENCE.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceAssert<Object> result = ATOMIC_REFERENCE.createAssert(actual);
+      // THEN
+      result.hasValue(null);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceAssert<Object> result = ATOMIC_REFERENCE.createAssert(valueProvider);
+      // THEN
+      result.hasValue(null);
+      verify(valueProvider).apply(parameterizedType(AtomicReference.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicReference_Typed_Factory {
+
+    private final Object actual = new AtomicReference<>(0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = atomicReference(Integer.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceAssert<Integer> result = atomicReference(Integer.class).createAssert(actual);
+      // THEN
+      result.hasValue(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceAssert<Integer> result = atomicReference(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.hasValue(0);
+      verify(valueProvider).apply(parameterizedType(AtomicReference.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicReferenceArray_Factory {
+
+    private final Object actual = new AtomicReferenceArray<>(new Object[] { 0, "" });
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_REFERENCE_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReferenceArray.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceArrayAssert<Object> result = ATOMIC_REFERENCE_ARRAY.createAssert(actual);
+      // THEN
+      result.containsExactly(0, "");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceArrayAssert<Object> result = ATOMIC_REFERENCE_ARRAY.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, "");
+      verify(valueProvider).apply(parameterizedType(AtomicReferenceArray.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicReferenceArray_Typed_Factory {
+
+    private final Object actual = new AtomicReferenceArray<>(new Integer[] { 0, 1 });
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_REFERENCE_ARRAY.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReferenceArray.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceArrayAssert<Integer> result = atomicReferenceArray(Integer.class).createAssert(actual);
+      // THEN
+      result.containsExactly(0, 1);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceArrayAssert<Integer> result = atomicReferenceArray(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.containsExactly(0, 1);
+      verify(valueProvider).apply(parameterizedType(AtomicReferenceArray.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicReferenceFieldUpdater_Factory {
+
+    private final Object actual = AtomicReferenceFieldUpdater.newUpdater(Container.class, String.class, "stringField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_REFERENCE_FIELD_UPDATER.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReferenceFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceFieldUpdaterAssert<Object, Object> result = ATOMIC_REFERENCE_FIELD_UPDATER.createAssert(actual);
+      // THEN
+      result.hasValue(null, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceFieldUpdaterAssert<Object, Object> result = ATOMIC_REFERENCE_FIELD_UPDATER.createAssert(valueProvider);
+      // THEN
+      result.hasValue(null, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicReferenceFieldUpdater.class, Object.class, Object.class));
+    }
+
+    private class Container {
+
+      volatile String stringField;
+
+    }
+
+  }
+
+  @Nested
+  class AtomicReferenceFieldUpdater_Typed_Factory {
+
+    private final Object actual = AtomicReferenceFieldUpdater.newUpdater(Container.class, String.class, "stringField");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = atomicReferenceFieldUpdater(String.class, Container.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicReferenceFieldUpdater.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicReferenceFieldUpdaterAssert<String, Container> result = atomicReferenceFieldUpdater(String.class,
+                                                                                                Container.class).createAssert(actual);
+      // THEN
+      result.hasValue(null, new Container());
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicReferenceFieldUpdaterAssert<String, Container> result = atomicReferenceFieldUpdater(String.class,
+                                                                                                Container.class).createAssert(valueProvider);
+      // THEN
+      result.hasValue(null, new Container());
+      verify(valueProvider).apply(parameterizedType(AtomicReferenceFieldUpdater.class, String.class,
+                                                    Container.class));
+    }
+
+    private class Container {
+
+      volatile String stringField;
+
+    }
+
+  }
+
+  @Nested
+  class AtomicMarkableReference_Factory {
+
+    private final Object actual = new AtomicMarkableReference<>(null, false);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_MARKABLE_REFERENCE.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicMarkableReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicMarkableReferenceAssert<Object> result = ATOMIC_MARKABLE_REFERENCE.createAssert(actual);
+      // THEN
+      result.hasReference(null);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicMarkableReferenceAssert<Object> result = ATOMIC_MARKABLE_REFERENCE.createAssert(valueProvider);
+      // THEN
+      result.hasReference(null);
+      verify(valueProvider).apply(parameterizedType(AtomicMarkableReference.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicMarkableReference_Typed_Factory {
+
+    private final Object actual = new AtomicMarkableReference<>(0, false);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = atomicMarkableReference(Integer.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicMarkableReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicMarkableReferenceAssert<Integer> result = atomicMarkableReference(Integer.class).createAssert(actual);
+      // THEN
+      result.hasReference(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicMarkableReferenceAssert<Integer> result = atomicMarkableReference(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.hasReference(0);
+      verify(valueProvider).apply(parameterizedType(AtomicMarkableReference.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicStampedReference_Factory {
+
+    private final Object actual = new AtomicStampedReference<>(null, 0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_STAMPED_REFERENCE.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicStampedReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicStampedReferenceAssert<Object> result = ATOMIC_STAMPED_REFERENCE.createAssert(actual);
+      // THEN
+      result.hasReference(null);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicStampedReferenceAssert<Object> result = ATOMIC_STAMPED_REFERENCE.createAssert(valueProvider);
+      // THEN
+      result.hasReference(null);
+      verify(valueProvider).apply(parameterizedType(AtomicStampedReference.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class AtomicStampedReference_Typed_Factory {
+
+    private final Object actual = new AtomicStampedReference<>(0, 0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ATOMIC_STAMPED_REFERENCE.getRawClass();
+      // THEN
+      then(result).isEqualTo(AtomicStampedReference.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AtomicStampedReferenceAssert<Integer> result = atomicStampedReference(Integer.class).createAssert(actual);
+      // THEN
+      result.hasReference(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AtomicStampedReferenceAssert<Integer> result = atomicStampedReference(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.hasReference(0);
+      verify(valueProvider).apply(parameterizedType(AtomicStampedReference.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class Throwable_Factory {
+
+    private final Object actual = new RuntimeException("message");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = THROWABLE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Throwable.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractThrowableAssert<?, Throwable> result = THROWABLE.createAssert(actual);
+      // THEN
+      result.hasMessage("message");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractThrowableAssert<?, Throwable> result = THROWABLE.createAssert(valueProvider);
+      // THEN
+      result.hasMessage("message");
+      verify(valueProvider).apply(Throwable.class);
+    }
+
+  }
+
+  @Nested
+  class Throwable_Typed_Factory {
+
+    private final Object actual = new RuntimeException("message");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = throwable(RuntimeException.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(RuntimeException.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractThrowableAssert<?, RuntimeException> result = throwable(RuntimeException.class).createAssert(actual);
+      // THEN
+      result.hasMessage("message");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractThrowableAssert<?, RuntimeException> result = throwable(RuntimeException.class).createAssert(valueProvider);
+      // THEN
+      result.hasMessage("message");
+      verify(valueProvider).apply(RuntimeException.class);
+    }
+
+  }
+
+  @Nested
+  class CharSequence_Factory {
+
+    private final Object actual = "string";
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = CHAR_SEQUENCE.getRawClass();
+      // THEN
+      then(result).isEqualTo(CharSequence.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = CHAR_SEQUENCE.createAssert(actual);
+      // THEN
+      result.startsWith("str");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = CHAR_SEQUENCE.createAssert(valueProvider);
+      // THEN
+      result.startsWith("str");
+      verify(valueProvider).apply(CharSequence.class);
+    }
+
+  }
+
+  @Nested
+  class StringBuilder_Factory {
+
+    private final Object actual = new StringBuilder("string");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = STRING_BUILDER.getRawClass();
+      // THEN
+      then(result).isEqualTo(StringBuilder.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUILDER.createAssert(actual);
+      // THEN
+      result.startsWith("str");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUILDER.createAssert(valueProvider);
+      // THEN
+      result.startsWith("str");
+      verify(valueProvider).apply(StringBuilder.class);
+    }
+
+  }
+
+  @Nested
+  class StringBuffer_Factory {
+
+    private final Object actual = new StringBuffer("string");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = STRING_BUFFER.getRawClass();
+      // THEN
+      then(result).isEqualTo(StringBuffer.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUFFER.createAssert(actual);
+      // THEN
+      result.startsWith("str");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCharSequenceAssert<?, ? extends CharSequence> result = STRING_BUFFER.createAssert(valueProvider);
+      // THEN
+      result.startsWith("str");
+      verify(valueProvider).apply(StringBuffer.class);
+    }
+
+  }
+
+  @Nested
+  class String_Factory {
+
+    private final Object actual = "string";
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = STRING.getRawClass();
+      // THEN
+      then(result).isEqualTo(String.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractStringAssert<?> result = STRING.createAssert(actual);
+      // THEN
+      result.startsWith("str");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractStringAssert<?> result = STRING.createAssert(valueProvider);
+      // THEN
+      result.startsWith("str");
+      verify(valueProvider).apply(String.class);
+    }
+
+  }
+
+  @Nested
+  class Iterable_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ITERABLE.getRawClass();
+      // THEN
+      then(result).isEqualTo(Iterable.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      IterableAssert<Object> result = ITERABLE.createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      IterableAssert<Object> result = ITERABLE.createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Iterable.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Iterable_Typed_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = iterable(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Iterable.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      IterableAssert<String> result = iterable(String.class).createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      IterableAssert<String> result = iterable(String.class).createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Iterable.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Iterator_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie").iterator();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = ITERATOR.getRawClass();
+      // THEN
+      then(result).isEqualTo(Iterator.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      IteratorAssert<Object> result = ITERATOR.createAssert(actual);
+      // THEN
+      result.hasNext();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      IteratorAssert<Object> result = ITERATOR.createAssert(valueProvider);
+      // THEN
+      result.hasNext();
+      verify(valueProvider).apply(parameterizedType(Iterator.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Iterator_Typed_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie").iterator();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = iterator(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Iterator.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      IteratorAssert<String> result = iterator(String.class).createAssert(actual);
+      // THEN
+      result.hasNext();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      IteratorAssert<String> result = iterator(String.class).createAssert(valueProvider);
+      // THEN
+      result.hasNext();
+      verify(valueProvider).apply(parameterizedType(Iterator.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Collection_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = COLLECTION.getRawClass();
+      // THEN
+      then(result).isEqualTo(Collection.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = COLLECTION.createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = COLLECTION.createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Collection.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Collection_Typed_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = collection(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Collection.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = collection(String.class).createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = collection(String.class).createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Collection.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Set_Factory {
+
+    private final Object actual = Sets.set("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = SET.getRawClass();
+      // THEN
+      then(result).isEqualTo(Set.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = SET.createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCollectionAssert<?, Collection<?>, Object, ObjectAssert<Object>> result = SET.createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Set.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Set_Typed_Factory {
+
+    private final Object actual = Sets.set("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = set(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Set.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = set(String.class).createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> result = set(String.class).createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(Set.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class List_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LIST.getRawClass();
+      // THEN
+      then(result).isEqualTo(List.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Object> result = LIST.createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Object> result = LIST.createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(List.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class List_Typed_Factory {
+
+    private final Object actual = Lists.list("Homer", "Marge", "Bart", "Lisa", "Maggie");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = list(String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(List.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<String> result = list(String.class).createAssert(actual);
+      // THEN
+      result.contains("Bart", "Lisa");
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<String> result = list(String.class).createAssert(valueProvider);
+      // THEN
+      result.contains("Bart", "Lisa");
+      verify(valueProvider).apply(parameterizedType(List.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Stream_Factory {
+
+    private final Object actual = Stream.of(1, 2, 3);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = STREAM.getRawClass();
+      // THEN
+      then(result).isEqualTo(Stream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Object> result = STREAM.createAssert(actual);
+      // THEN
+      result.containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Object> result = STREAM.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(1, 2, 3);
+      verify(valueProvider).apply(parameterizedType(Stream.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Stream_Typed_Factory {
+
+    private final Object actual = Stream.of(1, 2, 3);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = stream(Integer.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Stream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Integer> result = stream(Integer.class).createAssert(actual);
+      // THEN
+      result.containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Integer> result = stream(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.containsExactly(1, 2, 3);
+      verify(valueProvider).apply(parameterizedType(Stream.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class DoubleStream_Factory {
+
+    private final Object actual = DoubleStream.of(1.0, 2.0, 3.0);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = DOUBLE_STREAM.getRawClass();
+      // THEN
+      then(result).isEqualTo(DoubleStream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Double> result = DOUBLE_STREAM.createAssert(actual);
+      // THEN
+      result.containsExactly(1.0, 2.0, 3.0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Double> result = DOUBLE_STREAM.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(1.0, 2.0, 3.0);
+      verify(valueProvider).apply(DoubleStream.class);
+    }
+
+  }
+
+  @Nested
+  class LongStream_Factory {
+
+    private final Object actual = LongStream.of(1L, 2L, 3L);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = LONG_STREAM.getRawClass();
+      // THEN
+      then(result).isEqualTo(LongStream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Long> result = LONG_STREAM.createAssert(actual);
+      // THEN
+      result.containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Long> result = LONG_STREAM.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(1L, 2L, 3L);
+      verify(valueProvider).apply(LongStream.class);
+    }
+
+  }
+
+  @Nested
+  class IntStream_Factory {
+
+    private final Object actual = IntStream.of(1, 2, 3);
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = INT_STREAM.getRawClass();
+      // THEN
+      then(result).isEqualTo(IntStream.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      ListAssert<Integer> result = INT_STREAM.createAssert(actual);
+      // THEN
+      result.containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      ListAssert<Integer> result = INT_STREAM.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(1, 2, 3);
+      verify(valueProvider).apply(IntStream.class);
+    }
+
+  }
+
+  @Nested
+  class Path_Factory {
+
+    private final Object actual = Paths.get("non-existing");
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = PATH.getRawClass();
+      // THEN
+      then(result).isEqualTo(Path.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractPathAssert<?> result = PATH.createAssert(actual);
+      // THEN
+      result.doesNotExist();
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractPathAssert<?> result = PATH.createAssert(valueProvider);
+      // THEN
+      result.doesNotExist();
+      verify(valueProvider).apply(Path.class);
+    }
+
+  }
+
+  @Nested
+  class Spliterator_Factory {
+
+    private final Object actual = Stream.of(1, 2).spliterator();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = SPLITERATOR.getRawClass();
+      // THEN
+      then(result).isEqualTo(Spliterator.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      SpliteratorAssert<Object> result = SPLITERATOR.createAssert(actual);
+      // THEN
+      result.hasCharacteristics(Spliterator.SIZED);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      SpliteratorAssert<Object> result = SPLITERATOR.createAssert(valueProvider);
+      // THEN
+      result.hasCharacteristics(Spliterator.SIZED);
+      verify(valueProvider).apply(parameterizedType(Spliterator.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Spliterator_Typed_Factory {
+
+    private final Object actual = Stream.of(1, 2).spliterator();
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = spliterator(Integer.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Spliterator.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      SpliteratorAssert<Integer> result = spliterator(Integer.class).createAssert(actual);
+      // THEN
+      result.hasCharacteristics(Spliterator.SIZED);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      SpliteratorAssert<Integer> result = spliterator(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.hasCharacteristics(Spliterator.SIZED);
+      verify(valueProvider).apply(parameterizedType(Spliterator.class, Integer.class));
+    }
+
+  }
+
+  @Nested
+  class Map_Factory {
+
+    private final Object actual = mapOf(entry("key", "value"));
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = MAP.getRawClass();
+      // THEN
+      then(result).isEqualTo(Map.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      MapAssert<Object, Object> result = MAP.createAssert(actual);
+      // THEN
+      result.containsExactly(entry("key", "value"));
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      MapAssert<Object, Object> result = MAP.createAssert(valueProvider);
+      // THEN
+      result.containsExactly(entry("key", "value"));
+      verify(valueProvider).apply(parameterizedType(Map.class, Object.class, Object.class));
+    }
+
+  }
+
+  @Nested
+  class Map_Typed_Factory {
+
+    private final Object actual = mapOf(entry("key", "value"));
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = map(String.class, String.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Map.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      MapAssert<String, String> result = map(String.class, String.class).createAssert(actual);
+      // THEN
+      result.containsExactly(entry("key", "value"));
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      MapAssert<String, String> result = map(String.class, String.class).createAssert(valueProvider);
+      // THEN
+      result.containsExactly(entry("key", "value"));
+      verify(valueProvider).apply(parameterizedType(Map.class, String.class, String.class));
+    }
+
+  }
+
+  @Nested
+  class Comparable_Factory {
+
+    private final Object actual = 0;
+
+    @Test
+    void getRawClass() {
+      // WHEN
+      Class<?> result = comparable(Integer.class).getRawClass();
+      // THEN
+      then(result).isEqualTo(Integer.class);
+    }
+
+    @Test
+    void createAssert() {
+      // WHEN
+      AbstractComparableAssert<?, Integer> result = comparable(Integer.class).createAssert(actual);
+      // THEN
+      result.isEqualByComparingTo(0);
+    }
+
+    @Test
+    void createAssert_with_ValueProvider() {
+      // GIVEN
+      ValueProvider<?> valueProvider = mockThatDelegatesTo(type -> actual);
+      // WHEN
+      AbstractComparableAssert<?, Integer> result = comparable(Integer.class).createAssert(valueProvider);
+      // THEN
+      result.isEqualByComparingTo(0);
+      verify(valueProvider).apply(Integer.class);
+    }
+
   }
 
   @SuppressWarnings("unchecked")
   @SafeVarargs
   private static <T> T mockThatDelegatesTo(T delegate, T... reified) {
     if (reified.length > 0) {
-      throw new IllegalArgumentException("Please don't pass any values here. Java will detect class automagically.");
+      throw new IllegalArgumentException("NioJava will detect class automagically.");
     }
-    return mock((Class<T>) reified.getClass().getComponentType(), AdditionalAnswers.delegatesTo(delegate));
+    return mock((Class<T>) reified.getClass().getComponentType(), delegatesTo(delegate));
   }
 
   private static ParameterizedType parameterizedType(Class<?> rawClass, Class<?>... typeArguments) {
     return argThat(argument -> {
-      then(argument).returns(typeArguments, from(ParameterizedType::getActualTypeArguments))
-                    .returns(rawClass, from(ParameterizedType::getRawType))
-                    .returns(null, from(ParameterizedType::getOwnerType));
+      assertThat(argument).returns(typeArguments, from(ParameterizedType::getActualTypeArguments))
+                          .returns(rawClass, from(ParameterizedType::getRawType))
+                          .returns(null, from(ParameterizedType::getOwnerType));
       return true;
     });
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -1321,18 +1321,18 @@ class InstanceOfAssertFactoriesTest {
   @MethodSource("nonParameterizedFactories")
   void getType_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
     // WHEN
-    Optional<Type> type = underTest.getType();
+    Type type = underTest.getType();
     // THEN
-    then(type).hasValue(rawClass);
+    then(type).isEqualTo(rawClass);
   }
 
   @ParameterizedTest
   @MethodSource("parameterizedFactories")
   void getType_for_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass, Class<?>[] typeArguments) {
     // WHEN
-    Optional<Type> type = underTest.getType();
+    Type type = underTest.getType();
     // THEN
-    then(type).get(type(ParameterizedType.class))
+    then(type).asInstanceOf(type(ParameterizedType.class))
               .returns(typeArguments, from(ParameterizedType::getActualTypeArguments))
               .returns(rawClass, from(ParameterizedType::getRawType))
               .returns(null, from(ParameterizedType::getOwnerType));

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -99,9 +99,11 @@ import static org.assertj.core.api.InstanceOfAssertFactories.STREAM;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUFFER;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING_BUILDER;
+import static org.assertj.core.api.InstanceOfAssertFactories.TEMPORAL;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URI_TYPE;
 import static org.assertj.core.api.InstanceOfAssertFactories.URL_TYPE;
+import static org.assertj.core.api.InstanceOfAssertFactories.YEAR_MONTH;
 import static org.assertj.core.api.InstanceOfAssertFactories.ZONED_DATE_TIME;
 import static org.assertj.core.api.InstanceOfAssertFactories.array;
 import static org.assertj.core.api.InstanceOfAssertFactories.array2D;
@@ -131,6 +133,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -155,6 +158,7 @@ import java.time.Period;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -195,6 +199,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import org.assertj.core.api.AssertFactory.ValueProvider;
 import org.assertj.core.util.Lists;
 import org.assertj.core.util.Sets;
 import org.assertj.core.util.Strings;
@@ -1342,6 +1347,17 @@ class InstanceOfAssertFactoriesTest {
 
   @ParameterizedTest
   @MethodSource("nonParameterizedFactories")
+  void createAssert_with_ValueProvider_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
+    // GIVEN
+    ValueProvider<?> valueProvider = mock();
+    // WHEN
+    underTest.createAssert(valueProvider);
+    // THEN
+    verify(valueProvider).apply(rawClass);
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonParameterizedFactories")
   void getType_for_non_parameterized_factories(InstanceOfAssertFactory<?, ?> underTest, Class<?> rawClass) {
     // WHEN
     Type type = underTest.getType();
@@ -1423,9 +1439,11 @@ class InstanceOfAssertFactoriesTest {
                      arguments(STRING, String.class),
                      arguments(STRING_BUFFER, StringBuffer.class),
                      arguments(STRING_BUILDER, StringBuilder.class),
+                     arguments(TEMPORAL, Temporal.class),
                      arguments(THROWABLE, Throwable.class),
                      arguments(URI_TYPE, URI.class),
                      arguments(URL_TYPE, URL.class),
+                     arguments(YEAR_MONTH, YearMonth.class),
                      arguments(ZONED_DATE_TIME, ZonedDateTime.class),
                      arguments(array(String[].class), String[].class),
                      arguments(array2D(String[][].class), String[][].class),

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoriesTest.java
@@ -4137,7 +4137,7 @@ class InstanceOfAssertFactoriesTest {
   @SafeVarargs
   private static <T> T mockThatDelegatesTo(T delegate, T... reified) {
     if (reified.length > 0) {
-      throw new IllegalArgumentException("NioJava will detect class automagically.");
+      throw new IllegalArgumentException("Leave the vararg parameter empty. That is used to detect the class instance automagically.");
     }
     return mock((Class<T>) reified.getClass().getComponentType(), delegatesTo(delegate));
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -78,9 +79,9 @@ class InstanceOfAssertFactoryTest {
     @Test
     void getType_should_return_given_class() {
       // WHEN
-      Type result = underTest.getType();
+      Optional<Type> result = underTest.getType();
       // THEN
-      then(result).isEqualTo(Integer.class);
+      then(result).hasValue(Integer.class);
     }
 
     @Test
@@ -168,9 +169,9 @@ class InstanceOfAssertFactoryTest {
     @Test
     void getType_should_return_synthetic_ParameterizedType() {
       // WHEN
-      Type result = underTest.getType();
+      Optional<Type> result = underTest.getType();
       // THEN
-      then(result).asInstanceOf(type(ParameterizedType.class))
+      then(result).get(type(ParameterizedType.class))
                   .returns(new Class[] { Integer.class }, from(ParameterizedType::getActualTypeArguments))
                   .returns(List.class, from(ParameterizedType::getRawType))
                   .returns(null, from(ParameterizedType::getOwnerType))
@@ -214,7 +215,7 @@ class InstanceOfAssertFactoryTest {
       // WHEN
       String result = underTest.toString();
       // THEN
-      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().getTypeName());
+      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().get().getTypeName());
     }
 
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -13,6 +13,7 @@
 package org.assertj.core.api;
 
 import static java.lang.Class.forName;
+import static java.lang.reflect.Modifier.isPrivate;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.from;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -20,7 +21,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.mockito.BDDMockito.willReturn;
 
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
@@ -231,7 +231,7 @@ class InstanceOfAssertFactoryTest {
       // WHEN
       int modifiers = underTest.getModifiers();
       // THEN
-      then(Modifier.isPrivate(modifiers)).isTrue();
+      then(isPrivate(modifiers)).isTrue();
     }
 
     @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -12,12 +12,19 @@
  */
 package org.assertj.core.api;
 
+import static java.lang.Class.forName;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.from;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.mockito.BDDMockito.willReturn;
 
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -25,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * @author Stefano Cordio
@@ -41,24 +50,24 @@ class InstanceOfAssertFactoryTest {
     private InstanceOfAssertFactory<Integer, AbstractAssert<?, ?>> underTest;
 
     @Mock
-    private AssertFactory<Integer, AbstractAssert<?, ?>> assertFactory;
+    private AssertFactory<Integer, AbstractAssert<?, ?>> delegate;
 
     @BeforeEach
     void setUp() {
-      underTest = new InstanceOfAssertFactory<>(Integer.class, assertFactory);
+      underTest = new InstanceOfAssertFactory<>(Integer.class, delegate);
     }
 
     @Test
-    void constructor_should_fail_if_no_type_is_given() {
+    void constructor_should_fail_if_type_is_null() {
       // WHEN
-      Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(null, assertFactory));
+      Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(null, delegate));
       // THEN
       then(thrown).isInstanceOf(NullPointerException.class)
                   .hasMessage(shouldNotBeNull("type").create());
     }
 
     @Test
-    void constructor_should_fail_if_no_assert_factory_is_given() {
+    void constructor_should_fail_if_assert_factory_is_null() {
       // WHEN
       Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(Object.class, null));
       // THEN
@@ -69,16 +78,13 @@ class InstanceOfAssertFactoryTest {
     @Test
     void getType_should_return_given_class() {
       // WHEN
-      Type result = this.underTest.getType();
+      Type result = underTest.getType();
       // THEN
       then(result).isEqualTo(Integer.class);
     }
 
     @Test
     void getRawClass_should_return_given_class() {
-      // GIVEN
-      InstanceOfAssertFactory<Integer, AbstractAssert<?, ?>> underTest = new InstanceOfAssertFactory<>(Integer.class,
-                                                                                                       assertFactory);
       // WHEN
       Class<Integer> result = underTest.getRawClass();
       // THEN
@@ -89,7 +95,7 @@ class InstanceOfAssertFactoryTest {
     void createAssert_should_return_assert_factory_result_if_actual_is_an_instance_of_given_type() {
       // GIVEN
       int value = 0;
-      willReturn(abstractAssert).given(assertFactory).createAssert(value);
+      willReturn(abstractAssert).given(delegate).createAssert(value);
       // WHEN
       Assert<?, ?> result = underTest.createAssert(value);
       // THEN
@@ -119,6 +125,121 @@ class InstanceOfAssertFactoryTest {
 
   @Nested
   class With_Class_and_Type_array {
+
+    @SuppressWarnings("rawtypes")
+    private InstanceOfAssertFactory<List, AbstractAssert<?, ?>> underTest;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private AssertFactory<List, AbstractAssert<?, ?>> delegate;
+
+    @BeforeEach
+    void setUp() {
+      underTest = new InstanceOfAssertFactory<>(List.class, new Class[] { Integer.class }, delegate);
+    }
+
+    @Test
+    void constructor_should_fail_if_rawClass_is_null() {
+      // WHEN
+      Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(null, new Class[] { Integer.class }, delegate));
+      // THEN
+      then(thrown).isInstanceOf(NullPointerException.class)
+                  .hasMessage(shouldNotBeNull("rawClass").create());
+    }
+
+    @Test
+    void constructor_should_fail_if_typeArguments_is_null() {
+      // WHEN
+      Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(List.class, null, delegate));
+      // THEN
+      then(thrown).isInstanceOf(NullPointerException.class)
+                  .hasMessage(shouldNotBeNull("typeArguments").create());
+    }
+
+    @Test
+    void constructor_should_fail_if_delegate_is_null() {
+      // WHEN
+      Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(List.class, new Class[] { Integer.class }, null));
+      // THEN
+      then(thrown).isInstanceOf(NullPointerException.class)
+                  .hasMessage(shouldNotBeNull("delegate").create());
+    }
+
+    @Test
+    void getType_should_return_synthetic_ParameterizedType() {
+      // WHEN
+      Type result = underTest.getType();
+      // THEN
+      then(result).asInstanceOf(type(ParameterizedType.class))
+                  .returns(new Class[] { Integer.class }, from(ParameterizedType::getActualTypeArguments))
+                  .returns(List.class, from(ParameterizedType::getRawType))
+                  .returns(null, from(ParameterizedType::getOwnerType))
+                  .returns("java.util.List<java.lang.Integer>", from(ParameterizedType::getTypeName))
+                  .returns("java.util.List<java.lang.Integer>", from(ParameterizedType::toString));
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    void getRawClass_should_return_given_raw_class() {
+      // WHEN
+      Class<List> result = underTest.getRawClass();
+      // THEN
+      then(result).isEqualTo(List.class);
+    }
+
+    @Test
+    void createAssert_should_return_assert_factory_result_if_actual_is_an_instance_of_given_type() {
+      // GIVEN
+      List<Integer> list = Collections.emptyList();
+      willReturn(abstractAssert).given(delegate).createAssert(list);
+      // WHEN
+      Assert<?, ?> result = underTest.createAssert(list);
+      // THEN
+      then(result).isSameAs(abstractAssert);
+    }
+
+    @Test
+    void createAssert_should_throw_assertion_error_if_actual_is_not_an_instance_of_given_type() {
+      // GIVEN
+      String value = "string";
+      // WHEN
+      Throwable throwable = catchThrowable(() -> underTest.createAssert(value));
+      // THEN
+      then(throwable).isInstanceOf(ClassCastException.class)
+                     .hasMessage("Cannot cast %s to %s", value.getClass().getName(), underTest.getRawClass().getName());
+    }
+
+    @Test
+    void toString_should_return_expected_value() {
+      // WHEN
+      String result = underTest.toString();
+      // THEN
+      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().getTypeName());
+    }
+
+  }
+
+  @Nested
+  class SyntheticParameterizedTypeTest {
+
+    private final Class<?> underTest = forName(InstanceOfAssertFactory.class.getName() + "$SyntheticParameterizedType");
+
+    SyntheticParameterizedTypeTest() throws ClassNotFoundException {}
+
+    @Test
+    void class_should_be_private() {
+      // WHEN
+      int modifiers = underTest.getModifiers();
+      // THEN
+      then(Modifier.isPrivate(modifiers)).isTrue();
+    }
+
+    @Test
+    void should_honor_equals_contract() {
+      EqualsVerifier.forClass(underTest)
+                    .withNonnullFields("rawClass", "typeArguments")
+                    .verify();
+    }
 
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -15,14 +15,10 @@ package org.assertj.core.api;
 import static java.lang.Class.forName;
 import static java.lang.reflect.Modifier.isPrivate;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.BDDAssertions.from;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.mockito.BDDMockito.willReturn;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 
@@ -67,20 +63,12 @@ class InstanceOfAssertFactoryTest {
     }
 
     @Test
-    void constructor_should_fail_if_assert_factory_is_null() {
+    void constructor_should_fail_if_delegate_is_null() {
       // WHEN
       Throwable thrown = catchThrowable(() -> new InstanceOfAssertFactory<>(Object.class, null));
       // THEN
       then(thrown).isInstanceOf(NullPointerException.class)
                   .hasMessage(shouldNotBeNull("delegate").create());
-    }
-
-    @Test
-    void getType_should_return_given_class() {
-      // WHEN
-      Type result = underTest.getType();
-      // THEN
-      then(result).isEqualTo(Integer.class);
     }
 
     @Test
@@ -165,19 +153,6 @@ class InstanceOfAssertFactoryTest {
                   .hasMessage(shouldNotBeNull("delegate").create());
     }
 
-    @Test
-    void getType_should_return_synthetic_ParameterizedType() {
-      // WHEN
-      Type result = underTest.getType();
-      // THEN
-      then(result).asInstanceOf(type(ParameterizedType.class))
-                  .returns(new Class[] { Integer.class }, from(ParameterizedType::getActualTypeArguments))
-                  .returns(List.class, from(ParameterizedType::getRawType))
-                  .returns(null, from(ParameterizedType::getOwnerType))
-                  .returns("java.util.List<java.lang.Integer>", from(ParameterizedType::getTypeName))
-                  .returns("java.util.List<java.lang.Integer>", from(ParameterizedType::toString));
-    }
-
     @SuppressWarnings("rawtypes")
     @Test
     void getRawClass_should_return_given_raw_class() {
@@ -214,7 +189,7 @@ class InstanceOfAssertFactoryTest {
       // WHEN
       String result = underTest.toString();
       // THEN
-      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().getTypeName());
+      then(result).isEqualTo("InstanceOfAssertFactory for %s<%s>", List.class.getTypeName(), Integer.class.getTypeName());
     }
 
   }
@@ -227,7 +202,7 @@ class InstanceOfAssertFactoryTest {
     SyntheticParameterizedTypeTest() throws ClassNotFoundException {}
 
     @Test
-    void class_should_be_private() {
+    void should_be_private() {
       // WHEN
       int modifiers = underTest.getModifiers();
       // THEN

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -13,7 +13,6 @@
 package org.assertj.core.api;
 
 import static java.lang.Class.forName;
-import static java.lang.reflect.Modifier.isPrivate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.from;
@@ -261,14 +260,13 @@ class InstanceOfAssertFactoryTest {
 
     @Test
     void should_be_private() {
-      // WHEN
-      int modifiers = underTest.getModifiers();
-      // THEN
-      then(isPrivate(modifiers)).isTrue();
+      // WHEN/THEN
+      assertThat(underTest).isPrivate();
     }
 
     @Test
     void should_honor_equals_contract() {
+      // WHEN/THEN
       EqualsVerifier.forClass(underTest)
                     .withNonnullFields("rawClass", "typeArguments")
                     .verify();

--- a/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/InstanceOfAssertFactoryTest.java
@@ -25,7 +25,6 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -79,9 +78,9 @@ class InstanceOfAssertFactoryTest {
     @Test
     void getType_should_return_given_class() {
       // WHEN
-      Optional<Type> result = underTest.getType();
+      Type result = underTest.getType();
       // THEN
-      then(result).hasValue(Integer.class);
+      then(result).isEqualTo(Integer.class);
     }
 
     @Test
@@ -169,9 +168,9 @@ class InstanceOfAssertFactoryTest {
     @Test
     void getType_should_return_synthetic_ParameterizedType() {
       // WHEN
-      Optional<Type> result = underTest.getType();
+      Type result = underTest.getType();
       // THEN
-      then(result).get(type(ParameterizedType.class))
+      then(result).asInstanceOf(type(ParameterizedType.class))
                   .returns(new Class[] { Integer.class }, from(ParameterizedType::getActualTypeArguments))
                   .returns(List.class, from(ParameterizedType::getRawType))
                   .returns(null, from(ParameterizedType::getOwnerType))
@@ -215,7 +214,7 @@ class InstanceOfAssertFactoryTest {
       // WHEN
       String result = underTest.toString();
       // THEN
-      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().get().getTypeName());
+      then(result).isEqualTo("InstanceOfAssertFactory for %s", underTest.getType().getTypeName());
     }
 
   }


### PR DESCRIPTION
Closes #3368.

Open points:

- [x] Proper test coverage for the new `InstanceOfAssertFactory` constructor
- [x] Proper test coverage for the new `createAssert(ValueProvider)` of `InstanceOfAssertFactory`
- [x] Proper test coverage for all the existing `InstanceOfAssertFactories` instances and related `createAssert(ValueProvider)` behavior.
- [x] Integration tests based on `DefaultConversionService` from `spring-core`