### PR TITLE
Add `isNotThrownBy()` method as opposite to `isThrownBy()`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
@@ -25,7 +25,7 @@ import org.assertj.core.util.VisibleForTesting;
  * <p>
  * The class itself does not do much, it delegates the work to {@link ThrowableAssertAlternative} after calling {@link #isThrownBy(ThrowingCallable)}.
  *
- * @param <T> type of throwable to be thrown.
+ * @param <T> expected type of throwable to assert.
  * @see NotThrownAssert
  */
 public class ThrowableTypeAssert<T extends Throwable> implements Descriptable<ThrowableTypeAssert<T>> {
@@ -45,7 +45,7 @@ public class ThrowableTypeAssert<T extends Throwable> implements Descriptable<Th
   }
 
   /**
-   * Assert that an exception of type T is thrown by the {@code throwingCallable}
+   * Assert that an exception of type {@link T} is thrown by the {@code throwingCallable}
    * and allow to chain assertions on the thrown exception.
    * <p>
    * Example:
@@ -61,6 +61,25 @@ public class ThrowableTypeAssert<T extends Throwable> implements Descriptable<Th
     @SuppressWarnings("unchecked")
     T castThrowable = (T) throwable;
     return buildThrowableTypeAssert(castThrowable).as(description);
+  }
+
+  /**
+   * Assert that the {@code throwingCallable} does not throw exception or throw an exception which is not type {@link T}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> assertThatExceptionOfType(IllegalArgumentException.class).isNotThrownBy(() -&gt; { throw new IllegalStateException("boom!"); });</code></pre>
+   *
+   * @param throwingCallable code will not throw the exception of expected type
+   */
+  public void isNotThrownBy(final ThrowingCallable throwingCallable) {
+    Throwable throwable = ThrowableAssert.catchThrowable(throwingCallable);
+    if (throwable != null) {
+      checkNotThrowableType(throwable);
+    }
+  }
+
+  protected void checkNotThrowableType(Throwable throwable) {
+    assertThat(throwable).as(description).hasBeenThrown().isNotInstanceOf(expectedThrowableType);
   }
 
   protected void checkThrowableType(Throwable throwable) {

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableTypeAssert_isNotThrownBy_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableTypeAssert_isNotThrownBy_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ThrowableTypeAssert_isNotThrownBy_Test {
+
+  @Test
+  void should_not_fail_if_nothing_is_thrown_by_callable_code() {
+    assertThatExceptionOfType(Throwable.class).isNotThrownBy(() -> {});
+  }
+
+  @Test
+  void should_not_fail_if_expected_exception_is_not_thrown_by_callable_code() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isNotThrownBy(() -> {
+      throw new IllegalStateException();
+    });
+  }
+
+  @Test
+  void should_fail_if_expected_exception_is_thrown_by_callable_code() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> {
+      assertThatExceptionOfType(IllegalArgumentException.class).isNotThrownBy(() -> {
+        throw new IllegalArgumentException();
+      });
+    }).withMessageContaining("not to be an instance of: java.lang.IllegalArgumentException");
+  }
+}


### PR DESCRIPTION
It can be used like:
```java
    assertThatExceptionOfType(IllegalArgumentException.class).isNotThrownBy(() -> {
      // no exception
    });

    assertThatExceptionOfType(IllegalArgumentException.class).isNotThrownBy(() -> {
      throw new IllegalStateException();
    });
```

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
