### PR TITLE
Throwable assertion support for `hasMessageNormalizingNewlines(String)`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -326,6 +326,32 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   }
 
   /**
+   * Verifies that the message of the actual (@code Throwable) is equal to the given one
+   * after normalizing new line characters (i.e. '\r\n' == '\n').
+   * <p>
+   * Example:
+   * <pre><code class='java'> Throwable invalidArgException = new IllegalArgumentException("Error:\r\ninvalid input");
+   * Throwable throwable = new Throwable(invalidArgException);
+   *
+   * // This assertion succeeds:
+   * assertThat(throwable).hasMessageNormalizingNewlines("Error:\r\ninvalid input");
+   * assertThat(throwable).hasMessageNormalizingNewlines("Error:\ninvalid input");
+   *
+   * // These assertions fail:
+   * assertThat(throwable).hasMessageNormalizingNewlines("Error:\ninvalid input\n");
+   * assertThat(null).hasMessageNormalizingNewlines("Error:\r\ninvalid input");</code></pre>
+   *
+   * @param message the expected message.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} is not equal to the given one after normalizing new lines.
+   */
+  public SELF hasMessageNormalizingNewlines(String message) {
+    throwables.assertHasMessageNormalizingNewlines(info, actual, message);
+    return myself;
+  }
+
+  /**
    * Verifies that the message of the actual {@code Throwable} contains the given description, after being formatted using
    * the {@link String#format} method.
    * <p>

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -343,7 +343,7 @@ public class Strings {
                              normalizedExpected);
   }
 
-  private static String normalizeNewlines(CharSequence charSequence) {
+  public static String normalizeNewlines(CharSequence charSequence) {
     return charSequence != null ? charSequence.toString().replace("\r\n", "\n") : null;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Throwables.java
@@ -36,6 +36,7 @@ import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsEmpty;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 import static org.assertj.core.internal.CommonValidations.checkTypeIsNotNull;
+import static org.assertj.core.internal.Strings.normalizeNewlines;
 import static org.assertj.core.util.Throwables.getRootCause;
 
 import java.util.LinkedHashSet;
@@ -222,6 +223,23 @@ public class Throwables {
     assertNotNull(info, actual);
     if (actual.getMessage() != null && actual.getMessage().contains(description)) return;
     throw failures.failure(info, shouldContain(actual, description));
+  }
+
+  /**
+   * Asserts that the given actual {@code Throwable} message is equal to the given one
+   * after normalizing new line characters (i.e. '\r\n' == '\n').
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Throwable}.
+   * @param expectedMessage the expected message.
+   * @throws AssertionError if the actual {@code Throwable} is {@code null}.
+   * @throws AssertionError if the message of the actual {@code Throwable} is not equal to the given one after normalizing new lines.
+   */
+  public void assertHasMessageNormalizingNewlines(AssertionInfo info, Throwable actual, String expectedMessage) {
+    assertNotNull(info, actual);
+    if (actual.getMessage() != null && normalizeNewlines(actual.getMessage()).equals(normalizeNewlines(expectedMessage))) return;
+
+    throw failures.failure(info, shouldHaveMessage(actual, expectedMessage), actual.getMessage(), expectedMessage);
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageNormalizingNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableAssert_hasMessageNormalizingNewlines_Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.throwable;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+class ThrowableAssert_hasMessageNormalizingNewlines_Test extends ThrowableAssertBaseTest {
+
+  @Override
+  protected ThrowableAssert<Throwable> invoke_api_method() {
+    return assertions.hasMessageNormalizingNewlines("throwable\r\nmessage");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(throwables).assertHasMessageNormalizingNewlines(getInfo(assertions), getActual(assertions), "throwable\r\nmessage");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNormalizingNewlines_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNormalizingNewlines_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.internal.throwables;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Throwables;
+import org.assertj.core.internal.ThrowablesBaseTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.error.ShouldHaveMessage.shouldHaveMessage;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link Throwables#assertHasMessageNormalizingNewlines(AssertionInfo, Throwable, String)}.
+ */
+class Throwables_assertHasMessageNormalizingNewlines_Test extends ThrowablesBaseTest {
+
+  @BeforeAll
+  public static void setUpOnce() {
+    actual = new NullPointerException("Throwable\r\nmessage");
+  }
+
+  @Test
+  void should_pass_if_actual_has_expected_message_normalizing_new_lines() {
+    throwables.assertHasMessageNormalizingNewlines(someInfo(), actual, "Throwable\nmessage");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    Throwable actual = null;
+    // THEN
+    assertThatAssertionErrorIsThrownBy(() -> throwables.assertHasMessageNormalizingNewlines(info, actual, "message"))
+                                                                                                                     .withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_has_not_expected_message_normalizing_new_lines() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    String expectedMessage = "expected message";
+    // WHEN
+    expectAssertionError(() -> throwables.assertHasMessageNormalizingNewlines(info, actual, expectedMessage));
+    // THEN
+    verify(failures).failure(info, shouldHaveMessage(actual, expectedMessage), "Throwable\r\nmessage", expectedMessage);
+  }
+}


### PR DESCRIPTION
I propose adding `hasMessageNormalizingNewlines(String)` method for asserting `Throwable` messages.

Currently, this can be done using workarounds, e.g.

```java
Throwable ex = catchThrowable(() -> someMethod());
      
assertThat(ex.getMessage()).isEqualToNormalizingNewlines("multiline\nmessage");
```


#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
