### PR TITLE
Fix: AbstractOptionalDoubleAssert.hasValue(double) fails with NaN

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalDoubleAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalDoubleAssert.java
@@ -115,7 +115,8 @@ public abstract class AbstractOptionalDoubleAssert<SELF extends AbstractOptional
   }
 
   /**
-   * Verifies that the actual {@link java.util.OptionalDouble} has the value in argument.
+   * Verifies that the actual {@link java.util.OptionalDouble} has the value in argument. The check is consistent
+   * with {@link java.util.OptionalDouble#equals(Object)}
    * <p>
    * Assertion will pass :
    * <pre><code class='java'> assertThat(OptionalDouble.of(8.0)).hasValue(8.0);
@@ -135,7 +136,7 @@ public abstract class AbstractOptionalDoubleAssert<SELF extends AbstractOptional
   public SELF hasValue(double expectedValue) {
     isNotNull();
     if (!actual.isPresent()) throwAssertionError(shouldContain(expectedValue));
-    if (expectedValue != actual.getAsDouble())
+    if (Double.compare(expectedValue, actual.getAsDouble()) != 0)
       throw Failures.instance().failure(info, shouldContain(actual, expectedValue), actual.getAsDouble(), expectedValue);
     return myself;
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/optionaldouble/OptionalDoubleAssert_hasValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/optionaldouble/OptionalDoubleAssert_hasValue_Test.java
@@ -40,6 +40,21 @@ class OptionalDoubleAssert_hasValue_Test {
   }
 
   @Test
+  void should_pass_if_optionalDouble_has_expected_NaN_value() {
+    assertThat(OptionalDouble.of(Double.NaN)).hasValue(Double.NaN);
+  }
+
+  @Test
+  void should_pass_if_optionalDouble_has_expected_positive_infinity_value() {
+    assertThat(OptionalDouble.of(Double.POSITIVE_INFINITY)).hasValue(Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  void should_pass_if_optionalDouble_has_expected_negative_infinity_value() {
+    assertThat(OptionalDouble.of(Double.NEGATIVE_INFINITY)).hasValue(Double.NEGATIVE_INFINITY);
+  }
+
+  @Test
   void should_fail_if_optionalDouble_does_not_have_expected_value() {
     // GIVEN
     OptionalDouble actual = OptionalDouble.of(5.0);


### PR DESCRIPTION
#### Check List:
* Fixes #3401
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
