### PR TITLE
Add doesNot[Start/End]WithWhitespace methods to AbstractCharSequenceAssert

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -2182,11 +2182,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   private void assertDoesNotStartWithWhitespace(CharSequence actual) {
-    isNotNull();
-    isNotEmpty();
-    char first = actual.charAt(0);
-
-    if (Character.isWhitespace(first)) throwAssertionError(shouldNotStartWithWhitespace(actual));
+    if (Character.isWhitespace(actual.codePoints().findFirst().getAsInt())) throwAssertionError(shouldNotStartWithWhitespace(actual));
   }
 
   /**
@@ -2216,12 +2212,8 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   private void assertDoesNotEndWithWhitespace(CharSequence actual) {
-    isNotNull();
-    isNotEmpty();
-    int length = actual.length();
-    char last = actual.charAt(length - 1);
 
-    if (Character.isWhitespace(last)) throwAssertionError(shouldNotEndWithWhitespace(actual));
+    if (Character.isWhitespace(actual.codePoints().reduce((v1, v2) -> v2).getAsInt())) throwAssertionError(shouldNotEndWithWhitespace(actual));
   }
 
   private static boolean isBlank(CharSequence actual) {

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -28,6 +28,8 @@ import static org.assertj.core.error.ShouldContainOnlyWhitespaces.shouldContainO
 import static org.assertj.core.error.ShouldNotBeBlank.shouldNotBeBlank;
 import static org.assertj.core.error.ShouldNotContainAnyWhitespaces.shouldNotContainAnyWhitespaces;
 import static org.assertj.core.error.ShouldNotContainOnlyWhitespaces.shouldNotContainOnlyWhitespaces;
+import static org.assertj.core.error.ShouldNotEndWithWhitespace.shouldNotEndWithWhitespace;
+import static org.assertj.core.error.ShouldNotStartWithWhitespace.shouldNotStartWithWhitespace;
 import static org.assertj.core.internal.Strings.doCommonCheckForCharSequence;
 import static org.assertj.core.internal.Strings.removeAllWhitespaces;
 import static org.assertj.core.util.IterableUtil.toArray;
@@ -2151,6 +2153,73 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
     isNotNull();
     if (!Pattern.matches("\\p{Graph}+", actual)) throwAssertionError(shouldBeVisible(actual));
     return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is visible by checking it against the {@code \p{Graph}+} regex pattern
+   * POSIX character classes (US-ASCII only).
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(&quot;2&quot;).isVisible();
+   * assertThat(&quot;a&quot;).isVisible();
+   * assertThat(&quot;.&quot;).isVisible();
+   *
+   * // assertions will fail
+   * assertThat(&quot;\t&quot;).isVisible();
+   * assertThat(&quot;\n&quot;).isVisible();
+   * assertThat(&quot;&quot;).isVisible();
+   * assertThat(&quot; &quot;).isVisible();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not visible.
+   * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>
+   */
+  public SELF doesNotStartWithWhitespace() {
+    assertDoesNotStartWithWhitespace(actual);
+    return myself;
+  }
+
+  private void assertDoesNotStartWithWhitespace(CharSequence actual) {
+    char first = actual.charAt(0);
+
+    if (first == ' ') {
+      throwAssertionError(shouldNotStartWithWhitespace(actual));
+    }
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} is visible by checking it against the {@code \p{Graph}+} regex pattern
+   * POSIX character classes (US-ASCII only).
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(&quot;2&quot;).isVisible();
+   * assertThat(&quot;a&quot;).isVisible();
+   * assertThat(&quot;.&quot;).isVisible();
+   *
+   * // assertions will fail
+   * assertThat(&quot;\t&quot;).isVisible();
+   * assertThat(&quot;\n&quot;).isVisible();
+   * assertThat(&quot;&quot;).isVisible();
+   * assertThat(&quot; &quot;).isVisible();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code CharSequence} is not visible.
+   * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>
+   */
+  public SELF doesNotEndWithWhitespace() {
+    assertDoesNotEndWithWhitespace(actual);
+    return myself;
+  }
+
+  private void assertDoesNotEndWithWhitespace(CharSequence actual) {
+    int length = actual.length();
+    char last = actual.charAt(length - 1);
+
+    if (last == ' ') {
+      throwAssertionError(shouldNotEndWithWhitespace(actual));
+    }
   }
 
   private static boolean isBlank(CharSequence actual) {

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -65,6 +65,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Mikhail Mazursky
  * @author Nicolas Francois
  * @author Daniel Weber
+ * @author Lim Wonjae
  */
 public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequenceAssert<SELF, ACTUAL>, ACTUAL extends CharSequence>
     extends AbstractAssert<SELF, ACTUAL> implements EnumerableAssert<SELF, Character> {
@@ -2156,24 +2157,26 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} is visible by checking it against the {@code \p{Graph}+} regex pattern
-   * POSIX character classes (US-ASCII only).
+   * Verifies that the actual {@code CharSequence} does not start with whitespace.
    * <p>
    * Example:
-   * <pre><code class='java'> // assertions will pass
-   * assertThat(&quot;2&quot;).isVisible();
-   * assertThat(&quot;a&quot;).isVisible();
-   * assertThat(&quot;.&quot;).isVisible();
+   * <pre><code class='java'>
+   * // assertions will pass
+   * assertThat(&quot;abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc  &quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;\t\t abc&quot;).doesNotStartWithWhitespace();
    *
    * // assertions will fail
-   * assertThat(&quot;\t&quot;).isVisible();
-   * assertThat(&quot;\n&quot;).isVisible();
-   * assertThat(&quot;&quot;).isVisible();
-   * assertThat(&quot; &quot;).isVisible();</code></pre>
+   * assertThat(&quot;  abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;  abc  &quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc \r\n&quot;).doesNotStartWithWhitespace();
+   * </code></pre>
    *
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual {@code CharSequence} is not visible.
-   * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>
+   * @throws AssertionError if the actual {@code CharSequence} starts with whitespace.
+   * @see  Character#isWhitespace(char) to know what are the whitespaces.
+   *
+   * @since 3.26.0
    */
   public SELF doesNotStartWithWhitespace() {
     assertDoesNotStartWithWhitespace(actual);
@@ -2181,32 +2184,36 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   private void assertDoesNotStartWithWhitespace(CharSequence actual) {
+    isNotNull();
+    isNotEmpty();
     char first = actual.charAt(0);
 
-    if (first == ' ') {
+    if (Character.isWhitespace(first)) {
       throwAssertionError(shouldNotStartWithWhitespace(actual));
     }
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} is visible by checking it against the {@code \p{Graph}+} regex pattern
-   * POSIX character classes (US-ASCII only).
+   * Verifies that the actual {@code CharSequence} does not end with whitespace.
    * <p>
    * Example:
-   * <pre><code class='java'> // assertions will pass
-   * assertThat(&quot;2&quot;).isVisible();
-   * assertThat(&quot;a&quot;).isVisible();
-   * assertThat(&quot;.&quot;).isVisible();
+   * <pre><code class='java'>
+   * // assertions will pass
+   * assertThat(&quot;abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;  abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc \t\t&quot;).doesNotStartWithWhitespace();
    *
    * // assertions will fail
-   * assertThat(&quot;\t&quot;).isVisible();
-   * assertThat(&quot;\n&quot;).isVisible();
-   * assertThat(&quot;&quot;).isVisible();
-   * assertThat(&quot; &quot;).isVisible();</code></pre>
+   * assertThat(&quot;abc  &quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;  abc  &quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;\r\n abc&quot;).doesNotStartWithWhitespace();
+   * </code></pre>
    *
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual {@code CharSequence} is not visible.
-   * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">java.util.regex.Pattern</a>
+   * @throws AssertionError if the actual {@code CharSequence} ends with whitespace.
+   * @see  Character#isWhitespace(char) to know what are the whitespaces.
+   *
+   * @since 3.26.0
    */
   public SELF doesNotEndWithWhitespace() {
     assertDoesNotEndWithWhitespace(actual);
@@ -2214,12 +2221,12 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   private void assertDoesNotEndWithWhitespace(CharSequence actual) {
+    isNotNull();
+    isNotEmpty();
     int length = actual.length();
     char last = actual.charAt(length - 1);
 
-    if (last == ' ') {
-      throwAssertionError(shouldNotEndWithWhitespace(actual));
-    }
+    if (Character.isWhitespace(last)) throwAssertionError(shouldNotEndWithWhitespace(actual));
   }
 
   private static boolean isBlank(CharSequence actual) {

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -65,7 +65,6 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Mikhail Mazursky
  * @author Nicolas Francois
  * @author Daniel Weber
- * @author Lim Wonjae
  */
 public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequenceAssert<SELF, ACTUAL>, ACTUAL extends CharSequence>
     extends AbstractAssert<SELF, ACTUAL> implements EnumerableAssert<SELF, Character> {
@@ -2164,18 +2163,17 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * // assertions will pass
    * assertThat(&quot;abc&quot;).doesNotStartWithWhitespace();
    * assertThat(&quot;abc  &quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;\t\t abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc\t\t&quot;).doesNotStartWithWhitespace();
    *
    * // assertions will fail
    * assertThat(&quot;  abc&quot;).doesNotStartWithWhitespace();
    * assertThat(&quot;  abc  &quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;abc \r\n&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;\r\nabc&quot;).doesNotStartWithWhitespace();
    * </code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code CharSequence} starts with whitespace.
    * @see  Character#isWhitespace(char) to know what are the whitespaces.
-   *
    * @since 3.26.0
    */
   public SELF doesNotStartWithWhitespace() {
@@ -2188,9 +2186,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
     isNotEmpty();
     char first = actual.charAt(0);
 
-    if (Character.isWhitespace(first)) {
-      throwAssertionError(shouldNotStartWithWhitespace(actual));
-    }
+    if (Character.isWhitespace(first)) throwAssertionError(shouldNotStartWithWhitespace(actual));
   }
 
   /**
@@ -2199,20 +2195,19 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    * Example:
    * <pre><code class='java'>
    * // assertions will pass
-   * assertThat(&quot;abc&quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;  abc&quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;abc \t\t&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc&quot;).doesNotEndWithWhitespace();
+   * assertThat(&quot;  abc&quot;).doesNotEndWithWhitespace();
+   * assertThat(&quot;\t\tabc&quot;).doesNotEndWithWhitespace();
    *
    * // assertions will fail
-   * assertThat(&quot;abc  &quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;  abc  &quot;).doesNotStartWithWhitespace();
-   * assertThat(&quot;\r\n abc&quot;).doesNotStartWithWhitespace();
+   * assertThat(&quot;abc  &quot;).doesNotEndWithWhitespace();
+   * assertThat(&quot;  abc  &quot;).doesNotEndWithWhitespace();
+   * assertThat(&quot;abc\r\n&quot;).doesNotEndWithWhitespace();
    * </code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code CharSequence} ends with whitespace.
    * @see  Character#isWhitespace(char) to know what are the whitespaces.
-   *
    * @since 3.26.0
    */
   public SELF doesNotEndWithWhitespace() {

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
@@ -14,7 +14,7 @@ package org.assertj.core.error;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a {@link CharSequence}
- * does not contain whitespace characters.
+ * does not end with whitespace characters.
  */
 public class ShouldNotEndWithWhitespace extends BasicErrorMessageFactory {
 

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
@@ -1,0 +1,23 @@
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@link CharSequence}
+ * does not contain whitespace characters.
+ */
+public class ShouldNotEndWithWhitespace extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotStartWithWhitespace}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotEndWithWhitespace(CharSequence actual) {
+    return new ShouldNotEndWithWhitespace(actual);
+  }
+
+  private ShouldNotEndWithWhitespace(Object actual) {
+    super("%n" +
+          "Expecting string not to end with whitespace but found one, string was:%n" +
+          "  %s", actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotEndWithWhitespace.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
 package org.assertj.core.error;
 
 /**
@@ -7,7 +19,7 @@ package org.assertj.core.error;
 public class ShouldNotEndWithWhitespace extends BasicErrorMessageFactory {
 
   /**
-   * Creates a new <code>{@link ShouldNotStartWithWhitespace}</code>.
+   * Creates a new <code>{@link ShouldNotEndWithWhitespace}</code>.
    * @param actual the actual value in the failed assertion.
    * @return the created {@code ErrorMessageFactory}.
    */

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
 package org.assertj.core.error;
 
 /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
@@ -1,0 +1,23 @@
+package org.assertj.core.error;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@link CharSequence}
+ * does not contain whitespace characters.
+ */
+public class ShouldNotStartWithWhitespace extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotStartWithWhitespace}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotStartWithWhitespace(CharSequence actual) {
+    return new ShouldNotStartWithWhitespace(actual);
+  }
+
+  private ShouldNotStartWithWhitespace(Object actual) {
+    super("%n" +
+          "Expecting string not to start with whitespace but found one, string was:%n" +
+          "  %s", actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotStartWithWhitespace.java
@@ -14,7 +14,7 @@ package org.assertj.core.error;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a {@link CharSequence}
- * does not contain whitespace characters.
+ * does not start with whitespace characters.
  */
 public class ShouldNotStartWithWhitespace extends BasicErrorMessageFactory {
 

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotEndWithWhitespace.shouldNotEndWithWhitespace;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+/**
+ * @author Lim Wonjae
+ */
+public class CharSequenceAssert_doesNotEndWithWhitespace_Test {
+
+  @ParameterizedTest
+  @ValueSource(strings =  {"abc", "  ?", "  ab", "\t\t\""})
+  protected void should_pass_if_actual_does_not_end_with_whitespace(String actual) {
+    assertThat(actual).doesNotEndWithWhitespace();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings =  {"abc ", "abc\t", "abc\n", "abc\r"})
+  protected void should_fail_if_actual_ends_with_whitespace(String actual) {
+    //When
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).doesNotEndWithWhitespace());
+    //Then
+    BDDAssertions.then(assertionError).hasMessage(shouldNotEndWithWhitespace(actual).create());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
@@ -23,7 +23,7 @@ import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 /**
  * @author Lim Wonjae
  */
-public class CharSequenceAssert_doesNotEndWithWhitespace_Test {
+class CharSequenceAssert_doesNotEndWithWhitespace_Test {
 
   @ParameterizedTest
   @ValueSource(strings =  {"abc", "  ?", "  ab", "\t\t\""})

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithWhitespace_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.core.api.charsequence;
 
-import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotEndWithWhitespace.shouldNotEndWithWhitespace;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
@@ -28,6 +28,7 @@ public class CharSequenceAssert_doesNotEndWithWhitespace_Test {
   @ParameterizedTest
   @ValueSource(strings =  {"abc", "  ?", "  ab", "\t\t\""})
   protected void should_pass_if_actual_does_not_end_with_whitespace(String actual) {
+    //When + Then
     assertThat(actual).doesNotEndWithWhitespace();
   }
 
@@ -37,7 +38,7 @@ public class CharSequenceAssert_doesNotEndWithWhitespace_Test {
     //When
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).doesNotEndWithWhitespace());
     //Then
-    BDDAssertions.then(assertionError).hasMessage(shouldNotEndWithWhitespace(actual).create());
+    then(assertionError).hasMessage(shouldNotEndWithWhitespace(actual).create());
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotStartWithWhitespace.shouldNotStartWithWhitespace;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+/**
+ * @author Lim Wonjae
+ */
+public class CharSequenceAssert_doesNotStartWithWhitespace_Test {
+
+  @ParameterizedTest
+  @ValueSource(strings =  {"abc", "?  ", "ab  ", "\"\t\t"})
+  protected void should_pass_if_actual_does_not_start_with_whitespace(String actual) {
+    assertThat(actual).doesNotStartWithWhitespace();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings =  {" abc", "\tabc ", "\nabc", "\rabc"})
+  protected void should_fail_if_actual_starts_with_whitespace(String actual) {
+    //When
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).doesNotStartWithWhitespace());
+    //Then
+    BDDAssertions.then(assertionError).hasMessage(shouldNotStartWithWhitespace(actual).create());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
@@ -23,7 +23,7 @@ import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 /**
  * @author Lim Wonjae
  */
-public class CharSequenceAssert_doesNotStartWithWhitespace_Test {
+class CharSequenceAssert_doesNotStartWithWhitespace_Test {
 
   @ParameterizedTest
   @ValueSource(strings =  {"abc", "?  ", "ab  ", "\"\t\t"})

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithWhitespace_Test.java
@@ -12,11 +12,11 @@
  */
 package org.assertj.core.api.charsequence;
 
-import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotStartWithWhitespace.shouldNotStartWithWhitespace;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
@@ -28,6 +28,7 @@ public class CharSequenceAssert_doesNotStartWithWhitespace_Test {
   @ParameterizedTest
   @ValueSource(strings =  {"abc", "?  ", "ab  ", "\"\t\t"})
   protected void should_pass_if_actual_does_not_start_with_whitespace(String actual) {
+    //When + Then
     assertThat(actual).doesNotStartWithWhitespace();
   }
 
@@ -37,7 +38,7 @@ public class CharSequenceAssert_doesNotStartWithWhitespace_Test {
     //When
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).doesNotStartWithWhitespace());
     //Then
-    BDDAssertions.then(assertionError).hasMessage(shouldNotStartWithWhitespace(actual).create());
+    then(assertionError).hasMessage(shouldNotStartWithWhitespace(actual).create());
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotEndWithWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotEndWithWhitespace_create_Test.java
@@ -22,7 +22,7 @@ import static org.assertj.core.error.ShouldNotEndWithWhitespace.shouldNotEndWith
 /**
  * author: Lim Wonjae
  */
-public class ShouldNotEndWithWhitespace_create_Test {
+class ShouldNotEndWithWhitespace_create_Test {
 
   @Test
   void should_create_error_message() {

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotEndWithWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotEndWithWhitespace_create_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotEndWithWhitespace.shouldNotEndWithWhitespace;
+
+/**
+ * author: Lim Wonjae
+ */
+public class ShouldNotEndWithWhitespace_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    //Given
+    ErrorMessageFactory factory = shouldNotEndWithWhitespace("abc");
+
+    //When
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    //Then
+    then(message).isEqualTo(String.format("[Test] " + "%n" +
+      "Expecting string not to end with whitespace but found one, string was:%n" +
+      "  \"%s\"", "abc"));
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotStartWithWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotStartWithWhitespace_create_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotStartWithWhitespace.shouldNotStartWithWhitespace;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.Test;
+
+/**
+ * author: Lim Wonjae
+ */
+public class ShouldNotStartWithWhitespace_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    //Given
+    ErrorMessageFactory factory = shouldNotStartWithWhitespace("abc");
+
+    //When
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+
+    //Then
+    then(message).isEqualTo(String.format("[Test] " + "%n" +
+      "Expecting string not to start with whitespace but found one, string was:%n" +
+      "  \"%s\"", "abc"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotStartWithWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotStartWithWhitespace_create_Test.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 /**
  * author: Lim Wonjae
  */
-public class ShouldNotStartWithWhitespace_create_Test {
+class ShouldNotStartWithWhitespace_create_Test {
 
   @Test
   void should_create_error_message() {


### PR DESCRIPTION
#### Check List:
* Fixes #3433 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)