### PR TITLE
Add `asBase64UrlDecoded()` to `AbstractStringAssert`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -1344,6 +1344,24 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
   }
 
   /**
+   * Encodes the actual array into a Base64 URL string, the encoded string becoming the new object under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat("AssertJ".getBytes()).asBase64UrlEncoded().isEqualTo(&quot;QXNzZXJ0Sg&quot;);</code></pre>
+   *
+   * @return a new {@link StringAssert} instance whose string under test is the result of the encoding.
+   * @throws AssertionError if the actual value is {@code null}.
+   *
+   * @since 3.27.0
+   */
+  @CheckReturnValue
+  public AbstractStringAssert<?> asBase64UrlEncoded() {
+    objects.assertNotNull(info, actual);
+    return new StringAssert(Base64.getUrlEncoder().encodeToString(actual)).withAssertionState(myself);
+  }
+
+  /**
    * @deprecated use {@link #asBase64Encoded()} instead.
    * <p>
    * Encodes the actual array into a Base64 string, the encoded string becoming the new object under test.

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -309,6 +309,55 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
   }
 
   /**
+   * Verifies that the actual value is a valid Base64 URL encoded string.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat(&quot;QXNzZXJ0SiA_==&quot;).isBase64Url();
+   *
+   * // assertion succeeds even without padding as it is optional by specification
+   * assertThat(&quot;QXNzZXJ0SiA_&quot;).isBase64Url();
+   *
+   * // assertion fails as it has invalid Base64 URL characters
+   * assertThat(&quot;inv@lid&quot;).isBase64Url();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not a valid Base64 URL encoded string.
+   *
+   * @since 3.27.0
+   */
+  public SELF isBase64Url() {
+    strings.assertIsBase64Url(info, actual);
+    return myself;
+  }
+
+  /**
+   * Decodes the actual value as a Base64 URL encoded string, the decoded bytes becoming the new array under test.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // assertion succeeds
+   * assertThat(&quot;QXNzZXJ0SiA_==&quot;).asBase64UrlDecoded().containsExactly("AssertJ ?".getBytes());
+   *
+   * // assertion succeeds even without padding as it is optional by specification
+   * assertThat(&quot;QXNzZXJ0SiA_&quot;).asBase64UrlDecoded().containsExactly("AssertJ ?".getBytes());
+   *
+   * // assertion fails as it has invalid Base64 URL characters
+   * assertThat(&quot;inv@lid&quot;).asBase64UrlDecoded();</code></pre>
+   *
+   * @return a new {@link ByteArrayAssert} instance whose array under test is the result of the decoding.
+   * @throws AssertionError if the actual value is {@code null}.
+   * @throws AssertionError if the actual value is not a valid Base64 URL encoded string.
+   *
+   * @since 3.27.0
+   */
+  @CheckReturnValue
+  public AbstractByteArrayAssert<?> asBase64UrlDecoded() {
+    isBase64Url();
+    return new ByteArrayAssert(Base64.getUrlDecoder().decode(actual)).withAssertionState(myself);
+  }
+
+  /**
    * Use the given custom comparator instead of relying on {@link String} natural comparator for the incoming assertions.
    * <p>
    * The custom comparator is bound to an assertion instance, meaning that if a new assertion instance is created

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeBase64Url.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeBase64Url.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+/**
+ * Creates an error message that indicates an assertion that verifies that a string is a valid Base64 URL encoded string failed.
+ */
+public class ShouldBeBase64Url extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeBase64Url}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeBase64Url(String actual) {
+    return new ShouldBeBase64Url(actual);
+  }
+
+  private ShouldBeBase64Url(String actual) {
+    super("%nExpecting %s to be a valid Base64 URL encoded string", actual);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -24,6 +24,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.error.ShouldBeBase64.shouldBeBase64;
+import static org.assertj.core.error.ShouldBeBase64Url.shouldBeBase64Url;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEqual.shouldBeEqual;
 import static org.assertj.core.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
@@ -818,6 +819,15 @@ public class Strings {
       Base64.getDecoder().decode(actual);
     } catch (IllegalArgumentException e) {
       throw failures.failure(info, shouldBeBase64(actual));
+    }
+  }
+
+  public void assertIsBase64Url(AssertionInfo info, String actual) {
+    assertNotNull(info, actual);
+    try {
+      Base64.getUrlDecoder().decode(actual);
+    } catch (IllegalArgumentException e) {
+      throw failures.failure(info, shouldBeBase64Url(actual));
     }
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asBase64UrlEncoded_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asBase64UrlEncoded_Test.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.bytearray;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.ByteArrayAssert;
+import org.assertj.core.api.ByteArrayAssertBaseTest;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.verify;
+
+class ByteArrayAssert_asBase64UrlEncoded_Test extends ByteArrayAssertBaseTest implements NavigationMethodBaseTest<ByteArrayAssert> {
+
+  @Override
+  protected ByteArrayAssert invoke_api_method() {
+    assertions.asBase64UrlEncoded();
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotNull(getInfo(assertions), getActual(assertions));
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Override
+  public ByteArrayAssert getAssertion() {
+    return assertions;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(ByteArrayAssert assertion) {
+    return assertion.asBase64UrlEncoded();
+  }
+
+  @Test
+  void should_return_string_assertion() {
+    // WHEN
+    AbstractAssert<?, ?> result = assertions.asBase64UrlEncoded();
+    // THEN
+    then(result).isInstanceOf(AbstractStringAssert.class);
+  }
+
+
+  @Test
+  void should_produce_valid_base64url() {
+    // GIVEN
+    byte[] bytes = "AssertJ ?".getBytes(StandardCharsets.UTF_8);
+
+    // WHEN/THEN
+    assertThat(bytes)
+      .asBase64UrlEncoded()
+      .isEqualTo("QXNzZXJ0SiA_");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asBase64UrlDecoded_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_asBase64UrlDecoded_Test.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractByteArrayAssert;
+import org.assertj.core.api.NavigationMethodBaseTest;
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.verify;
+
+class StringAssert_asBase64UrlDecoded_Test extends StringAssertBaseTest implements NavigationMethodBaseTest<StringAssert> {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    assertions.asBase64UrlDecoded();
+    return null;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertIsBase64Url(getInfo(assertions), getActual(assertions));
+  }
+
+  @Override
+  public void should_return_this() {
+    // Test disabled as the assertion does not return this.
+  }
+
+  @Override
+  public StringAssert getAssertion() {
+    return assertions;
+  }
+
+  @Override
+  public AbstractAssert<?, ?> invoke_navigation_method(StringAssert assertion) {
+    return assertion.asBase64UrlDecoded();
+  }
+
+  @Test
+  void should_return_byte_array_assertion() {
+    // WHEN
+    AbstractAssert<?, ?> result = assertions.asBase64UrlDecoded();
+    // THEN
+    then(result).isInstanceOf(AbstractByteArrayAssert.class);
+  }
+
+  @Test
+  void should_accept_valid_base64url() {
+    // GIVEN
+    String base64url = "QXNzZXJ0SiA_";
+
+    // WHEN/THEN
+    assertThat(base64url)
+      .isBase64Url()
+      .asBase64UrlDecoded()
+      .isEqualTo("AssertJ ?".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void should_reject_invalid_base64url() {
+    // GIVEN
+    String base64url = "hello";
+
+    // WHEN/THEN
+    assertThatThrownBy(() -> assertThat(base64url).asBase64UrlDecoded())
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("Expecting \"hello\" to be a valid Base64 URL encoded string");
+  }
+
+  @Test
+  void should_reject_regular_base64() {
+    // GIVEN
+    String base64 = "c3ViamVjdHM/X2Q9MQ==";
+
+    // WHEN/THEN
+    assertThatThrownBy(() -> assertThat(base64).asBase64UrlDecoded())
+      .isInstanceOf(AssertionError.class)
+      .hasMessageContaining("Expecting \"c3ViamVjdHM/X2Q9MQ==\" to be a valid Base64 URL encoded string");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_isBase64Url_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/string_/StringAssert_isBase64Url_Test.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.string_;
+
+import org.assertj.core.api.StringAssert;
+import org.assertj.core.api.StringAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+class StringAssert_isBase64Url_Test extends StringAssertBaseTest {
+
+  @Override
+  protected StringAssert invoke_api_method() {
+    return assertions.isBase64Url();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertIsBase64Url(getInfo(assertions), getActual(assertions));
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #3069 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
