### PR TITLE
#3458 isUnmodifiable assertion for Iterator instances

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIteratorAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIteratorAssert.java
@@ -14,8 +14,11 @@ package org.assertj.core.api;
 
 import java.util.Iterator;
 
+import org.assertj.core.annotations.Beta;
 import org.assertj.core.internal.Iterators;
 import org.assertj.core.util.VisibleForTesting;
+
+import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
 
 /**
  * <p>Base class for all implementations of assertions for {@link Iterator}s.</p>
@@ -93,4 +96,50 @@ public abstract class AbstractIteratorAssert<SELF extends AbstractIteratorAssert
     return new IterableAssert<>(IterableAssert.toIterable(actual));
   }
 
+  /**
+   * Verifies that the actual iterator is unmodifiable, i.e., throws an {@link UnsupportedOperationException} with
+   * any attempt to remove from the iterator.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(List.of().iterator()).isUnmodifiable();
+   * assertThat(Set.of().iterator()).isUnmodifiable();
+   *
+   * // assertions will fail
+   * assertThat(new ArrayList&lt;&gt;().iterator()).isUnmodifiable();
+   * assertThat(new HashSet&lt;&gt;().iterator()).isUnmodifiable();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual iterator is modifiable.
+   * @since 3.27.0
+   */
+  @Beta
+  public SELF isUnmodifiable() {
+    isNotNull();
+    assertIsUnmodifiable();
+    return myself;
+  }
+
+  private void assertIsUnmodifiable() {
+    switch (actual.getClass().getName()) {
+    case "java.util.Collections$EmptyIterator":
+    case "java.util.Collections$EmptyListIterator":
+      // immutable by contract, although not all methods throw UnsupportedOperationException
+      return;
+    }
+
+    expectUnsupportedOperationException(() -> actual.remove(), "Iterator.remove()");
+  }
+
+  // Same as AbstractCollectionAssert#expectUnsupportedOperationException
+  private void expectUnsupportedOperationException(Runnable runnable, String method) {
+    try {
+      runnable.run();
+      throwAssertionError(shouldBeUnmodifiable(method));
+    } catch (UnsupportedOperationException e) {
+      // happy path
+    } catch (RuntimeException e) {
+      throwAssertionError(shouldBeUnmodifiable(method, e));
+    }
+  }
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIteratorAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIteratorAssert.java
@@ -12,13 +12,13 @@
  */
 package org.assertj.core.api;
 
+import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
+
 import java.util.Iterator;
 
 import org.assertj.core.annotations.Beta;
 import org.assertj.core.internal.Iterators;
 import org.assertj.core.util.VisibleForTesting;
-
-import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
 
 /**
  * <p>Base class for all implementations of assertions for {@link Iterator}s.</p>
@@ -111,7 +111,7 @@ public abstract class AbstractIteratorAssert<SELF extends AbstractIteratorAssert
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual iterator is modifiable.
-   * @since 3.27.0
+   * @since 3.26.0
    */
   @Beta
   public SELF isUnmodifiable() {
@@ -128,7 +128,7 @@ public abstract class AbstractIteratorAssert<SELF extends AbstractIteratorAssert
       return;
     }
 
-    expectUnsupportedOperationException(() -> actual.remove(), "Iterator.remove()");
+    expectUnsupportedOperationException(actual::remove, "Iterator.remove()");
   }
 
   // Same as AbstractCollectionAssert#expectUnsupportedOperationException

--- a/assertj-core/src/test/java/org/assertj/core/api/iterator/IteratorAssert_isUnmodifiable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterator/IteratorAssert_isUnmodifiable_Test.java
@@ -12,10 +12,27 @@
  */
 package org.assertj.core.api.iterator;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Sets;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.newTreeSet;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.stream.Stream;
+
 import org.apache.commons.collections4.collection.UnmodifiableCollection;
 import org.apache.commons.collections4.list.UnmodifiableList;
 import org.apache.commons.collections4.set.UnmodifiableSet;
@@ -27,19 +44,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.*;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
-import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
-import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
-import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Lists.newArrayList;
-import static org.assertj.core.util.Sets.*;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
 
 class IteratorAssert_isUnmodifiable_Test {
 
@@ -81,7 +89,7 @@ class IteratorAssert_isUnmodifiable_Test {
                                shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())));
   }
 
-  // If Iterator.remove() is called Iterator.next(), it doesn't throw exception
+  // No exception thrown if Iterator.remove() is called after Iterator.next()
   private static Stream<Arguments> startedModifiableIterators() {
     Iterator<?> startedIterator = new ArrayList<>(list(1, 2, 3)).iterator();
     startedIterator.next();
@@ -101,8 +109,7 @@ class IteratorAssert_isUnmodifiable_Test {
 
   // Same as CollectionAssert_isUnmodifiable_Test#unmodifiableCollections
   private static Stream<Iterator<?>> unmodifiableIterators() {
-    return Stream.of(
-                     Collections.emptyList(),
+    return Stream.of(Collections.emptyList(),
                      Collections.emptyNavigableSet(),
                      Collections.emptySet(),
                      Collections.emptySortedSet(),
@@ -129,4 +136,5 @@ class IteratorAssert_isUnmodifiable_Test {
                      UnmodifiableSortedSet.unmodifiableSortedSet(newTreeSet("element")))
                  .map(c -> c.iterator());
   }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/iterator/IteratorAssert_isUnmodifiable_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterator/IteratorAssert_isUnmodifiable_Test.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.iterator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Sets;
+import org.apache.commons.collections4.collection.UnmodifiableCollection;
+import org.apache.commons.collections4.list.UnmodifiableList;
+import org.apache.commons.collections4.set.UnmodifiableSet;
+import org.apache.commons.collections4.set.UnmodifiableSortedSet;
+import org.assertj.core.error.ErrorMessageFactory;
+import org.assertj.core.test.jdk11.Jdk11;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeUnmodifiable.shouldBeUnmodifiable;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Sets.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class IteratorAssert_isUnmodifiable_Test {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Iterator<?> actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isUnmodifiable());
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @ParameterizedTest
+  @MethodSource({ "modifiableIterators", "startedModifiableIterators" })
+  void should_fail_if_actual_can_be_modified(Iterator<?> actual, ErrorMessageFactory errorMessageFactory) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isUnmodifiable());
+    // THEN
+    then(assertionError).as(actual.getClass().getName())
+                        .hasMessage(errorMessageFactory.create());
+  }
+
+  // Same as CollectionAssert_isUnmodifiable_Test#modifiableCollections
+  private static Stream<Arguments> modifiableIterators() {
+    return Stream.of(arguments(new ArrayList<>().iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(new LinkedHashSet<>().iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(new LinkedList<>().iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(new HashSet<>().iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(newArrayList(new Object()).iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(newLinkedHashSet(new Object()).iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())),
+                     arguments(newTreeSet("element").iterator(),
+                               shouldBeUnmodifiable("Iterator.remove()", new IllegalStateException())));
+  }
+
+  // If Iterator.remove() is called Iterator.next(), it doesn't throw exception
+  private static Stream<Arguments> startedModifiableIterators() {
+    Iterator<?> startedIterator = new ArrayList<>(list(1, 2, 3)).iterator();
+    startedIterator.next();
+    Iterator<?> endedIterator = new ArrayList<>(list(1)).iterator();
+    endedIterator.next();
+    return Stream.of(arguments(startedIterator, shouldBeUnmodifiable("Iterator.remove()")),
+                     arguments(endedIterator, shouldBeUnmodifiable("Iterator.remove()")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("unmodifiableIterators")
+  void should_pass(Iterator<?> actual) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> assertThat(actual).isUnmodifiable());
+  }
+
+  // Same as CollectionAssert_isUnmodifiable_Test#unmodifiableCollections
+  private static Stream<Iterator<?>> unmodifiableIterators() {
+    return Stream.of(
+                     Collections.emptyList(),
+                     Collections.emptyNavigableSet(),
+                     Collections.emptySet(),
+                     Collections.emptySortedSet(),
+                     Collections.singleton("element"),
+                     Collections.singletonList("element"),
+                     Collections.unmodifiableCollection(list(new Object())),
+                     Collections.unmodifiableList(list(new Object())),
+                     Collections.unmodifiableNavigableSet(newTreeSet("element")),
+                     Collections.unmodifiableSet(set(new Object())),
+                     Collections.unmodifiableSortedSet(newTreeSet("element")),
+                     ImmutableList.of(new Object()),
+                     ImmutableSet.of(new Object()),
+                     ImmutableSortedSet.of("element"),
+                     Jdk11.List.of(),
+                     Jdk11.List.of("element"), // same implementation for 1 or 2 parameters
+                     Jdk11.List.of("element", "element", "element"), // same implementation for 3+ parameters
+                     Jdk11.Set.of(),
+                     Jdk11.Set.of("element"), // same implementation for 1 or 2 parameters
+                     Jdk11.Set.of("element1", "element2", "element3"), // same implementation for 3+ parameters
+                     Sets.unmodifiableNavigableSet(newTreeSet("element")),
+                     UnmodifiableCollection.unmodifiableCollection(list(new Object())),
+                     UnmodifiableList.unmodifiableList(list(new Object())),
+                     UnmodifiableSet.unmodifiableSet(set(new Object())),
+                     UnmodifiableSortedSet.unmodifiableSortedSet(newTreeSet("element")))
+                 .map(c -> c.iterator());
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes: #3458 
* Unit tests: YES
* Javadoc with a code example (on API only): YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.


#### What was done
I can only check if an iterator is unmodifiable by calling `remove()` and checking if the iterator throws `UnsupportedOperationException`. However not all unmodifiable iterators behave like that, see [my comment](https://github.com/assertj/assertj/issues/3458#issuecomment-2111116003) in the ticket. 
That's why I check explicitly for `Collections$EmptyIterator`  and `Collections$EmptyListIterator`.

cc @scordio 