### PR TITLE
Replace simple date format by date time formatter

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -3335,18 +3336,18 @@ public class Assertions implements InstanceOfAssertFactories {
    * <p>
    * Defaults date format are:
    * <ul>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSSX</code></li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link java.sql.Timestamp} String representation support)</li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ssX</code></li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss</code></li>
-   * <li><code>yyyy-MM-dd</code></li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME ISO_OFFSET_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME ISO_LOCAL_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE ISO_LOCAL_DATE}</li>
+   * <li>{@link Timestamp} format as supported by {@link Timestamp#valueOf(String)}</li>
    * </ul>
    * <p>
    * Example of valid string date representations:
    * <ul>
+   * <li><code>2003-04-26T03:01:02.758+00:00</code></li>
    * <li><code>2003-04-26T03:01:02.999</code></li>
    * <li><code>2003-04-26 03:01:02.999</code></li>
+   * <li><code>2003-04-26T03:01:02+00:00</code></li>
    * <li><code>2003-04-26T13:01:02</code></li>
    * <li><code>2003-04-26</code></li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -2010,16 +2011,18 @@ public class AssertionsForClassTypes {
    * <p>
    * Defaults date format are:
    * <ul>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link java.sql.Timestamp} String representation support)</li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss</code></li>
-   * <li><code>yyyy-MM-dd</code></li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME ISO_OFFSET_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME ISO_LOCAL_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE ISO_LOCAL_DATE}</li>
+   * <li>{@link Timestamp} format as supported by {@link Timestamp#valueOf(String)}</li>
    * </ul>
    * <p>
-   * Example of valid string date representations:
+   * Examples of valid string date representations:
    * <ul>
+   * <li><code>2003-04-26T03:01:02.758+00:00</code></li>
    * <li><code>2003-04-26T03:01:02.999</code></li>
    * <li><code>2003-04-26 03:01:02.999</code></li>
+   * <li><code>2003-04-26T03:01:02+00:00</code></li>
    * <li><code>2003-04-26T13:01:02</code></li>
    * <li><code>2003-04-26</code></li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -3854,18 +3855,18 @@ public class BDDAssertions extends Assertions {
    * <p>
    * Defaults date format are:
    * <ul>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSSX</code></li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link java.sql.Timestamp} String representation support)</li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ssX</code></li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss</code></li>
-   * <li><code>yyyy-MM-dd</code></li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME ISO_OFFSET_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME ISO_LOCAL_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE ISO_LOCAL_DATE}</li>
+   * <li>{@link Timestamp} format as supported by {@link Timestamp#valueOf(String)}</li>
    * </ul>
    * <p>
-   * Example of valid string date representations:
+   * Examples of valid string date representations:
    * <ul>
+   * <li><code>2003-04-26T03:01:02.758+00:00</code></li>
    * <li><code>2003-04-26T03:01:02.999</code></li>
    * <li><code>2003-04-26 03:01:02.999</code></li>
+   * <li><code>2003-04-26T03:01:02+00:00</code></li>
    * <li><code>2003-04-26T13:01:02</code></li>
    * <li><code>2003-04-26</code></li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.util.Collection;
 import java.util.Date;
@@ -2567,16 +2568,18 @@ public class Java6Assertions {
    * <p>
    * Defaults date format are:
    * <ul>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link java.sql.Timestamp} String representation support)</li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss</code></li>
-   * <li><code>yyyy-MM-dd</code></li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME ISO_OFFSET_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME ISO_LOCAL_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE ISO_LOCAL_DATE}</li>
+   * <li>{@link Timestamp} format as supported by {@link Timestamp#valueOf(String)}</li>
    * </ul>
    * <p>
-   * Example of valid string date representations:
+   * Examples of valid string date representations:
    * <ul>
+   * <li><code>2003-04-26T03:01:02.758+00:00</code></li>
    * <li><code>2003-04-26T03:01:02.999</code></li>
    * <li><code>2003-04-26 03:01:02.999</code></li>
+   * <li><code>2003-04-26T03:01:02+00:00</code></li>
    * <li><code>2003-04-26T13:01:02</code></li>
    * <li><code>2003-04-26</code></li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -2578,16 +2579,18 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * <p>
    * Defaults date format are:
    * <ul>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss.SSS</code></li>
-   * <li><code>yyyy-MM-dd HH:mm:ss.SSS</code> (for {@link java.sql.Timestamp} String representation support)</li>
-   * <li><code>yyyy-MM-dd'T'HH:mm:ss</code></li>
-   * <li><code>yyyy-MM-dd</code></li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME ISO_OFFSET_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE_TIME ISO_LOCAL_DATE_TIME}</li>
+   * <li>{@link java.time.format.DateTimeFormatter#ISO_LOCAL_DATE ISO_LOCAL_DATE}</li>
+   * <li>{@link Timestamp} format as supported by {@link Timestamp#valueOf(String)}</li>
    * </ul>
    * <p>
-   * Example of valid string date representations:
+   * Examples of valid string date representations:
    * <ul>
+   * <li><code>2003-04-26T03:01:02.758+00:00</code></li>
    * <li><code>2003-04-26T03:01:02.999</code></li>
    * <li><code>2003-04-26 03:01:02.999</code></li>
+   * <li><code>2003-04-26T03:01:02+00:00</code></li>
    * <li><code>2003-04-26T13:01:02</code></li>
    * <li><code>2003-04-26</code></li>
    * </ul>

--- a/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_Test.java
@@ -124,8 +124,6 @@ class DateAssert_isEqualTo_Test {
 
     Arguments[] should_fail() {
       return new Arguments[] {
-          arguments(Date.from(parse("1970-01-01T00:00:00.000000001Z")),
-                    "1970-01-01T00:00:00.000000001Z"),
           arguments(Timestamp.from(parse("1970-01-01T00:00:00.000000001Z")),
                     "1970-01-01T00:00:00.000000001Z")
       };

--- a/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_with_string_based_date_representation_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_with_string_based_date_representation_Test.java
@@ -24,6 +24,7 @@ import static org.assertj.core.util.DateUtil.parseDatetimeWithMs;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -42,7 +43,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Joel Costigliola
  */
-class DateAssert_with_string_based_date_representation_Test extends DateAssertBaseTest {
+class DateAssert_isEqualTo_with_string_based_date_representation_Test extends DateAssertBaseTest {
 
   @Override
   @AfterEach
@@ -122,6 +123,14 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
     Date date = Date.from(localDateTimeWithMillis.atZone(ZoneId.systemDefault()).toInstant());
     // WHEN/THEN
     then(date).isEqualTo("2003-04-26T13:01:02");
+  }
+
+  @Test
+  public void should_support_nanos() {
+    // GIVEN
+    Date date = Date.from(Instant.parse("1970-01-01T00:00:00.000000001Z"));
+    // WHEN/THEN
+    then(date).isEqualTo("1970-01-01T00:00:00.000000001Z");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_with_string_based_date_representation_Test.java
@@ -15,17 +15,22 @@ package org.assertj.core.api.date;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.registerCustomDateFormat;
 import static org.assertj.core.api.Assertions.useDefaultDateFormatsOnly;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.DateUtil.parseDatetime;
 import static org.assertj.core.util.DateUtil.parseDatetimeWithMs;
 
 import java.sql.Timestamp;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
-import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.DateAssertBaseTest;
 import org.assertj.core.util.DateUtil;
@@ -47,7 +52,6 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
 
   @Test
   void date_assertion_using_default_date_string_representation() {
-
     // datetime with ms is supported
     final Date date1timeWithMS = parseDatetimeWithMs("2003-04-26T03:01:02.999");
     assertThat(date1timeWithMS).isEqualTo("2003-04-26T03:01:02.999");
@@ -56,52 +60,68 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
     assertThat(datetime).isEqualTo("2003-04-26T03:01:02.000");
     assertThat(datetime).isEqualTo("2003-04-26T03:01:02");
     // date is supported
-    final Date date = DateUtil.parse("2003-04-26");
+    Date date = DateUtil.parse("2003-04-26");
     assertThat(date).isEqualTo("2003-04-26");
     assertThat(date).isEqualTo("2003-04-26T00:00:00");
     assertThat(date).isEqualTo("2003-04-26T00:00:00.000");
+
+    // TODO add test with nanos
   }
 
   @Test
-  void date_assertion_should_support_timestamp_string_representation() throws ParseException {
-    Date date = DateUtil.newTimestampDateFormat().parse("2015-05-08 11:30:00.560");
-    String timestampAsString = DateUtil.newTimestampDateFormat().format(new Timestamp(date.getTime()));
-
-    assertThat(date).isEqualTo(timestampAsString);
-  }
-
-  @Test
-  void date_assertion_should_support_date_with_utc_time_zone_string_representation() throws ParseException {
-    SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-    isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    Date date = isoFormat.parse("2003-04-26T00:00:00");
-
-    assertThat(date).isEqualTo("2003-04-26T00:00:00+00:00");
-  }
-
-  @Test
-  void date_assertion_should_support_date_with_ms_and_utc_time_zone_string_representation() throws ParseException {
+  void date_assertion_should_support_local_date_string_representation() {
     // GIVEN
-    SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-    isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    // WHEN
-    Date date = isoFormat.parse("2003-04-26T00:00:00.123");
-    // THEN
-    assertThat(date).isEqualTo("2003-04-26T00:00:00.123+00:00");
+    LocalDate localDate = LocalDate.of(2003, 4, 26);
+    ZoneId systemDefault = ZoneId.systemDefault();
+    Date date = Date.from(localDate.atStartOfDay(systemDefault).toInstant());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26");
   }
 
   @Test
-  void date_assertion_should_support_date_with_utc_time_zone_in_different_time_zone_string_representation() throws ParseException {
-    SimpleDateFormat isoDateFormatUtc = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-    isoDateFormatUtc.setTimeZone(TimeZone.getTimeZone("UTC"));
+  void date_assertion_should_support_timestamp_string_representation() {
+    // GIVEN
+    Date date = new Date(Timestamp.valueOf("2003-04-26 13:01:02.999").getTime());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26 13:01:02.999");
+  }
 
-    SimpleDateFormat isoDateFormatNewYork = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
-    isoDateFormatNewYork.setTimeZone(TimeZone.getTimeZone("America/New_York"));
+  @Test
+  void date_assertion_should_support_date_with_iso_offset_datetime_string_representation() {
+    // GIVEN
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(2003, 4, 26, 13, 1, 2, 0, ZoneOffset.of("+01:00"));
+    Date date = Date.from(offsetDateTime.toInstant());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26T13:01:02+01:00");
+  }
 
-    Date date = isoDateFormatUtc.parse("2003-04-26T00:00:00");
-    String newYorkDate = isoDateFormatNewYork.format(date);
+  @Test
+  void date_assertion_should_support_date_with_iso_offset_datetime_string_representation_with_millis() {
+    // GIVEN
+    int nanos = (int) TimeUnit.MILLISECONDS.toNanos(999);
+    OffsetDateTime isoOffsetDateTime = OffsetDateTime.of(2003, 4, 26, 13, 1, 2, nanos, ZoneOffset.of("+02:00"));
+    Date date = Date.from(isoOffsetDateTime.toInstant());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26T13:01:02.999+02:00");
+  }
 
-    assertThat(date).isEqualTo(newYorkDate);
+  @Test
+  void date_assertion_should_support_date_with_iso_local_datetime_string_representation_with_millis() {
+    // GIVEN
+    int nanos = (int) TimeUnit.MILLISECONDS.toNanos(999);
+    LocalDateTime localDateTimeWithMillis = LocalDateTime.of(2003, 4, 26, 13, 1, 2, nanos);
+    Date date = Date.from(localDateTimeWithMillis.atZone(ZoneId.systemDefault()).toInstant());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26T13:01:02.999");
+  }
+
+  @Test
+  void date_assertion_should_support_date_with_iso_local_datetime_string_representation() {
+    // GIVEN
+    LocalDateTime localDateTimeWithMillis = LocalDateTime.of(2003, 4, 26, 13, 1, 2, 0);
+    Date date = Date.from(localDateTimeWithMillis.atZone(ZoneId.systemDefault()).toInstant());
+    // WHEN/THEN
+    then(date).isEqualTo("2003-04-26T13:01:02");
   }
 
   @Test
@@ -131,18 +151,17 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
     registerCustomDateFormat("yyyy/MM/dd'T'HH:mm:ss");
     // registering again has no effect
     registerCustomDateFormat("yyyy/MM/dd'T'HH:mm:ss");
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(date).withDateFormat("yyyy/MM/dd")
-                                                                                     .isEqualTo("2003 04 26"))
-                                                   .withMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n"
-                                                                       +
-                                                                       "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
-                                                                       "    yyyy/MM/dd,%n" +
-                                                                       "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
-                                                                       "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
-                                                                       "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
-                                                                       "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
-                                                                       "    yyyy-MM-dd'T'HH:mm:ss,%n" +
-                                                                       "    yyyy-MM-dd]"));
+    AssertionError error = expectAssertionError(() -> assertThat(date).withDateFormat("yyyy/MM/dd").isEqualTo("2003 04 26"));
+    assertThat(error).hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n"
+                                        +
+                                        "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
+                                        "    yyyy/MM/dd,%n" +
+                                        "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
+                                        "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
+                                        "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
+                                        "    yyyy-MM-dd'T'HH:mm:ssX,%n" +
+                                        "    yyyy-MM-dd'T'HH:mm:ss,%n" +
+                                        "    yyyy-MM-dd]"));
   }
 
   @Test
@@ -165,11 +184,10 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
 
     // WHEN
     // fail : the registered format does not match the given date
-    Throwable error = catchThrowable(() -> assertThat(date).isEqualTo("2003/04/26"));
+    AssertionError error = expectAssertionError(() -> assertThat(date).isEqualTo("2003/04/26"));
 
     // THEN
-    assertThat(error).isInstanceOf(AssertionError.class)
-                     .hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
+    assertThat(error).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
                                         "   [yyyy/MM/dd'T'HH:mm:ss,%n" +
                                         "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                         "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
@@ -201,11 +219,10 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
 
     // WHEN
     // date with a custom format : failure since the default formats don't match.
-    Throwable error = catchThrowable(() -> assertThat(date).isEqualTo("2003/04/26"));
+    AssertionError error = expectAssertionError(() -> assertThat(date).isEqualTo("2003/04/26"));
 
     // THEN
-    assertThat(error).isInstanceOf(AssertionError.class)
-                     .hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
+    assertThat(error).hasMessage(format("Failed to parse 2003/04/26 with any of these date formats:%n" +
                                         "   [yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                         "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +
                                         "    yyyy-MM-dd HH:mm:ss.SSS,%n" +
@@ -222,11 +239,10 @@ class DateAssert_with_string_based_date_representation_Test extends DateAssertBa
 
     // WHEN
     // but if not format at all matches, it fails.
-    error = catchThrowable(() -> assertThat(date).isEqualTo("2003 04 26"));
+    error = expectAssertionError(() -> assertThat(date).isEqualTo("2003 04 26"));
 
     // THEN
-    assertThat(error).isInstanceOf(AssertionError.class)
-                     .hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n" +
+    assertThat(error).hasMessage(format("Failed to parse 2003 04 26 with any of these date formats:%n" +
                                         "   [yyyy/MM/dd,%n" +
                                         "    yyyy-MM-dd'T'HH:mm:ss.SSSX,%n" +
                                         "    yyyy-MM-dd'T'HH:mm:ss.SSS,%n" +


### PR DESCRIPTION
Fix #3482

The only bit that was not addressed is the lenient parsing, this is why the tests are failing.

At least we are now supporting nanos, ex:
```java
Date date = Date.from(Instant.parse("1970-01-01T00:00:00.000000001Z"));
assertThat(date).isEqualTo("1970-01-01T00:00:00.000000001Z");
```

Not supporting lenient date parsing is breaking change, probably one we can remove in AssertJ 4 since it's not a great idea to accept date like `2001-01-34` anyway. 

