### PR TITLE
Allow ComparingNormalizedFields instances to be reused across different assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingNormalizedFields.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingNormalizedFields.java
@@ -40,7 +40,7 @@ public abstract class ComparingNormalizedFields implements RecursiveComparisonIn
   private static final String NO_FIELD_FOUND = "Unable to find field in %s, fields tried: %s and %s";
 
   // original field name <-> normalized field name by node
-  private final Map<Object, Map<String, String>> originalFieldNamesByNormalizedFieldNameByNode = new IdentityHashMap<>();
+  private final Map<Class<?>, Map<String, String>> originalFieldNamesByNormalizedFieldNameByNode = new ConcurrentHashMap<>();
 
   // use ConcurrentHashMap in case this strategy instance is used in a multi-thread context
   private final Map<Class<?>, Set<String>> fieldNamesPerClass = new ConcurrentHashMap<>();
@@ -95,10 +95,10 @@ public abstract class ComparingNormalizedFields implements RecursiveComparisonIn
    */
   private String normalize(Object node, String fieldName) {
     String normalizedFieldName = normalizeFieldName(fieldName);
-    if (!originalFieldNamesByNormalizedFieldNameByNode.containsKey(node)) {
-      originalFieldNamesByNormalizedFieldNameByNode.put(node, new HashMap<>());
+    if (!originalFieldNamesByNormalizedFieldNameByNode.containsKey(node.getClass())) {
+      originalFieldNamesByNormalizedFieldNameByNode.put(node.getClass(), new HashMap<>());
     }
-    originalFieldNamesByNormalizedFieldNameByNode.get(node).put(normalizedFieldName, fieldName);
+    originalFieldNamesByNormalizedFieldNameByNode.get(node.getClass()).put(normalizedFieldName, fieldName);
     return normalizedFieldName;
   }
 
@@ -143,8 +143,8 @@ public abstract class ComparingNormalizedFields implements RecursiveComparisonIn
   private String getOriginalFieldName(String fieldName, Object instance) {
     // call getChildrenNodeNamesOf to populate originalFieldNamesByNormalizedFieldNameByNode, the recursive comparison
     // should already do this if this is used outside then getChildNodeValue would fail
-    if (!originalFieldNamesByNormalizedFieldNameByNode.containsKey(instance)) getChildrenNodeNamesOf(instance);
-    return originalFieldNamesByNormalizedFieldNameByNode.get(instance).get(fieldName);
+    if (!originalFieldNamesByNormalizedFieldNameByNode.containsKey(instance.getClass())) getChildrenNodeNamesOf(instance);
+    return originalFieldNamesByNormalizedFieldNameByNode.get(instance.getClass()).get(fieldName);
   }
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test.java
@@ -339,6 +339,8 @@ class RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test
 
   static class ComparingLowercaseNormalizedFields extends ComparingNormalizedFields {
 
+    static final ComparingLowercaseNormalizedFields INSTANCE = new ComparingLowercaseNormalizedFields();
+
     @Override
     public String normalizeFieldName(String name) {
       return name.toLowerCase();
@@ -353,11 +355,27 @@ class RecursiveComparisonAssert_isEqualTo_withIntrospectionStrategy_Test
     AnimalDto foxDto = new AnimalDto("fox");
     // WHEN/THEN
     then(fox).usingRecursiveComparison()
-             .withIntrospectionStrategy(new ComparingLowercaseNormalizedFields())
+             .withIntrospectionStrategy(ComparingLowercaseNormalizedFields.INSTANCE)
              .isEqualTo(foxDto);
     then(foxDto).usingRecursiveComparison()
-                .withIntrospectionStrategy(new ComparingLowercaseNormalizedFields())
+                .withIntrospectionStrategy(ComparingLowercaseNormalizedFields.INSTANCE)
                 .isEqualTo(fox);
+  }
+
+  @Test
+  void should_pass_with_lowercase_compared_fields_several_times() {
+    // GIVEN
+    Animal fox1 = new Animal("fox");
+    AnimalDto foxDto1 = new AnimalDto("fox");
+    Animal fox2 = new Animal("fox");
+    AnimalDto foxDto2 = new AnimalDto("fox");
+    // WHEN/THEN
+    then(fox1).usingRecursiveComparison()
+              .withIntrospectionStrategy(ComparingLowercaseNormalizedFields.INSTANCE)
+              .isEqualTo(foxDto1);
+    then(fox2).usingRecursiveComparison()
+              .withIntrospectionStrategy(ComparingLowercaseNormalizedFields.INSTANCE)
+              .isEqualTo(foxDto2);
   }
 
   static class Animal {


### PR DESCRIPTION
Hi, team!

After upgrading to 3.25.3 I see that `ComparingNormalizedFields` `RecursiveComparisonIntrospectionStrategy` can't be between different assertions (see my example). I digged into the code and found that the change was introduced in commit 0d5b789c, related to some performance improvements. The root cause is that `originalFieldNamesByNormalizedFieldNameByNode` is an identity hash map, although `fieldNamesPerClass` is keyed by class values. So, I found a fix for that, which I present here. I'm not sure that it's 100% correct, but I didn't find any failing tests. Hope you may find this helpful.

```java
package test;

import org.assertj.core.api.Assertions;
import org.assertj.core.api.recursive.comparison.ComparingNormalizedFields;
import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
import org.junit.jupiter.api.Test;

class AssertjBugTest {

  @Test
  void test() {
    Assertions.assertThat(new Actual(0))
        .usingRecursiveComparison(
            RecursiveComparisonConfiguration.builder()
                .withIntrospectionStrategy(SomeIntrospectionStrategy.INSTANCE)
                .build())
        .isEqualTo(new Expected(0));
    Assertions.assertThat(new Actual(0))
        .usingRecursiveComparison(
            RecursiveComparisonConfiguration.builder()
                .withIntrospectionStrategy(SomeIntrospectionStrategy.INSTANCE)
                .build())
        .isEqualTo(new Expected(0));
  }

  record Actual(int a) {}

  record Expected(int A) {}
}

class SomeIntrospectionStrategy extends ComparingNormalizedFields {

  static final SomeIntrospectionStrategy INSTANCE = new SomeIntrospectionStrategy();

  @Override
  protected String normalizeFieldName(String fieldName) {
    return fieldName.toLowerCase();
  }
}
```

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
