### PR TITLE
Added assertion for completable future for it to complete within peri…

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
@@ -15,6 +15,8 @@ package org.assertj.core.api.future;
 import static java.lang.String.format;
 
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -69,5 +71,19 @@ abstract class AbstractFutureTest {
                   ex,
                   () -> format("Thread %s [%s] threw an exception", thread.getName(), thread.getId()));
     }
+  }
+
+  protected static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
+    CompletableFuture<U> completableFuture = new CompletableFuture<>();
+    service.submit(() -> {
+      Thread.sleep(sleepDuration);
+      completableFuture.complete(value);
+      return null;
+    });
+    return completableFuture;
+  }
+
+  protected static <U> CompletableFuture<U> completedFutureAfter(U value, Duration sleepDuration, ExecutorService service) {
+    return completedFutureAfter(value, sleepDuration.toMillis(), service);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_Test.java
@@ -110,15 +110,4 @@ class CompletableFutureAssert_succeedsWithin_Test extends AbstractFutureTest {
     then(assertionError).hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed with the following stack trace:%njava.lang.RuntimeException: boom%%s%%n"))
                         .hasMessageContaining("to be completed within 1L Millis.");
   }
-
-  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
-    CompletableFuture<U> completableFuture = new CompletableFuture<>();
-    service.submit(() -> {
-      Thread.sleep(sleepDuration);
-      completableFuture.complete(value);
-      return null;
-    });
-    return completableFuture;
-  }
-
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_duration_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_duration_Test.java
@@ -24,8 +24,6 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -112,16 +110,6 @@ class CompletableFutureAssert_succeedsWithin_duration_Test extends AbstractFutur
     // THEN
     then(assertionError).hasMessageStartingWith(format("%nExpecting%n  <CompletableFuture[Failed with the following stack trace:%njava.lang.RuntimeException: boom%%s%%n"))
                         .hasMessageContaining("to be completed within 0.001S.");
-  }
-
-  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
-    CompletableFuture<U> completableFuture = new CompletableFuture<>();
-    service.submit(() -> {
-      Thread.sleep(sleepDuration);
-      completableFuture.complete(value);
-      return null;
-    });
-    return completableFuture;
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_willCompleteWithValueMatching_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_willCompleteWithValueMatching_Test.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.future;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.util.AssertionsUtil;
+import org.junit.jupiter.api.Test;
+
+public class CompletableFutureAssert_willCompleteWithValueMatching_Test extends AbstractFutureTest {
+
+  @Test
+  void should_pass_on_already_completed_future_with_matching_result() {
+
+    // GIVEN
+    CompletableFuture<String> future = CompletableFuture.completedFuture("string");
+
+    // WHEN/THEN
+    Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofSeconds(1L), s -> s.length() == 6);
+  }
+
+  @Test
+  void should_fail_on_already_exceptionally_completed_future() {
+
+    // GIVEN
+    CompletableFuture<String> future = new CompletableFuture<>();
+    future.completeExceptionally(new Exception());
+
+    // WHEN
+    ThrowingCallable t = () -> Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofSeconds(1L),
+                                                                                           s -> s.length() == 5);
+
+    // THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(t);
+  }
+
+  @Test
+  void should_fail_on_already_completed_future_with_non_matching_result() {
+
+    // GIVEN
+    CompletableFuture<String> future = CompletableFuture.completedFuture("string");
+
+    // WHEN
+    ThrowingCallable t = () -> Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofSeconds(1L),
+                                                                                           s -> s.length() == 5);
+
+    // THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(t);
+  }
+
+  @Test
+  void should_fail_on_pending_future_that_will_not_complete_in_provided_period() {
+
+    // GIVEN
+    CompletableFuture<String> future = completedFutureAfter("string", Duration.ofSeconds(1), executorService);
+
+    // WHEN
+    ThrowingCallable t = () -> Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofMillis(10),
+                                                                                           s -> s.length() == 6);
+
+    // THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(t);
+  }
+
+  @Test
+  void should_fail_on_pending_future_that_will_complete_in_provided_period_but_with_wrong_value() {
+
+    // GIVEN
+    CompletableFuture<String> future = completedFutureAfter("string", Duration.ofMillis(10), executorService);
+
+    // WHEN
+    ThrowingCallable t = () -> Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofMillis(100),
+                                                                                           s -> s.length() == 5);
+
+    // THEN
+    AssertionsUtil.assertThatAssertionErrorIsThrownBy(t);
+  }
+
+  @Test
+  void should_pass_on_pending_future_that_will_complete_in_provided_period_with_satisfying_value() {
+
+    // GIVEN
+    CompletableFuture<String> future = completedFutureAfter("string", Duration.ofMillis(10), executorService);
+
+    // WHEN/THEN
+    Assertions.assertThat(future).willCompleteWithValueMatching(Duration.ofMillis(100), s -> s.length() == 6);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_Test.java
@@ -98,15 +98,4 @@ class FutureAssert_succeedsWithin_Test extends AbstractFutureTest {
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
-
-  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
-    CompletableFuture<U> completableFuture = new CompletableFuture<>();
-    service.submit(() -> {
-      Thread.sleep(sleepDuration);
-      completableFuture.complete(value);
-      return null;
-    });
-    return completableFuture;
-  }
-
 }


### PR DESCRIPTION
Added a new `willCompleteWithValueMatching` method to `AbstractCompletableFutureAssert` to check that `CompletableFuture` will complete within the given period with value matching given `Predicate`. Found this kind of assertion very handy in my project.