### PR TITLE
Add `isNotEmpty` to `Table` assertions

### DIFF
--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.error.ShouldBeEmpty;
+import org.assertj.core.error.ShouldNotBeEmpty;
 
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
@@ -299,6 +300,30 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     if (!actual.isEmpty()) {
       throw assertionError(ShouldBeEmpty.shouldBeEmpty(actual));
     }
+  }
+
+  /**
+   * Verifies that the actual {@link Table} is not empty.
+   *
+   * <p>
+   * Example :
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   *
+   * assertThat(actual).isNotEmpty();</code></pre>
+   *
+   * @return this {@link TableAssert} for assertion chaining.
+   * @throws AssertionError if the actual {@link Table} is {@code null}.
+   * @throws AssertionError if the actual {@link Table} is empty.
+   */
+  public TableAssert<R, C, V> isNotEmpty() {
+    isNotNull();
+    if (actual.isEmpty()) {
+      throw assertionError(ShouldNotBeEmpty.shouldNotBeEmpty());
+    }
+    return myself;
   }
 
   private void checkExpectedSizeArgument(int expectedSize) {

--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -21,14 +21,12 @@ import static org.assertj.guava.error.TableShouldContainRows.tableShouldContainR
 import static org.assertj.guava.error.TableShouldHaveColumnCount.tableShouldHaveColumnCount;
 import static org.assertj.guava.error.TableShouldHaveRowCount.tableShouldHaveRowCount;
 
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
 import java.util.Set;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.error.ShouldBeEmpty;
 import org.assertj.core.error.ShouldNotBeEmpty;
-
-import com.google.common.collect.Sets;
-import com.google.common.collect.Table;
 
 /**
  * @author Jan Gorman
@@ -317,6 +315,8 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
    * @return this {@link TableAssert} for assertion chaining.
    * @throws AssertionError if the actual {@link Table} is {@code null}.
    * @throws AssertionError if the actual {@link Table} is empty.
+   *
+   * @since 3.27.0
    */
   public TableAssert<R, C, V> isNotEmpty() {
     isNotNull();

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
@@ -13,8 +13,8 @@
 package org.assertj.tests.guava.api;
 
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.guava.api.Assertions.assertThat;
 
@@ -27,7 +27,9 @@ public class TableAssert_isEmpty_Test extends TableAssertBaseTest {
 
   @Test
   public void should_pass_if_actual_is_empty() {
+    // GIVEN
     actual.clear();
+    // WHEN/THEN
     assertThat(actual).isEmpty();
   }
 
@@ -36,19 +38,19 @@ public class TableAssert_isEmpty_Test extends TableAssertBaseTest {
     // GIVEN
     actual = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).isEmpty());
+    Throwable thrown = catchThrowable(() -> assertThat(actual).isEmpty());
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(actualIsNull());
+    then(thrown).isInstanceOf(AssertionError.class)
+                .hasMessage(actualIsNull());
   }
 
   @Test
   public void should_fail_if_actual_is_not_empty() {
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).isEmpty());
+    Throwable thrown = catchThrowable(() -> assertThat(actual).isEmpty());
     // THEN
-    assertThat(throwable).isInstanceOf(AssertionError.class)
-                         .hasMessage(format("%nExpecting empty but was: {1={3=Millard Fillmore, 4=Franklin Pierce}, 2={5=Grover Cleveland}}"));
+    then(thrown).isInstanceOf(AssertionError.class)
+                .hasMessage(format("%nExpecting empty but was: {1={3=Millard Fillmore, 4=Franklin Pierce}, 2={5=Grover Cleveland}}"));
   }
 
 }

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
@@ -36,7 +36,7 @@ public class TableAssert_isEmpty_Test extends TableAssertBaseTest {
     // GIVEN
     actual = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).containsValues("Manu Ginobili"));
+    Throwable throwable = catchThrowable(() -> assertThat(actual).isEmpty());
     // THEN
     assertThat(throwable).isInstanceOf(AssertionError.class)
                          .hasMessage(actualIsNull());

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_isNotEmpty_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_not_empty() {
+    // WHEN/THEN
+    assertThat(actual).isNotEmpty();
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).isNotEmpty());
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty() {
+    // GIVEN
+    actual.clear();
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).isNotEmpty());
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(format("%nExpecting actual not to be empty"));
+  }
+
+  @Test
+  void should_return_this() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    TableAssert<Integer, Integer, String> returnedAssertion = assertion.isNotEmpty();
+    // THEN
+    then(returnedAssertion).isSameAs(assertion);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
@@ -37,10 +37,10 @@ class TableAssert_isNotEmpty_Test extends TableAssertBaseTest {
     // GIVEN
     actual = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).isNotEmpty());
+    Throwable thrown = catchThrowable(() -> assertThat(actual).isNotEmpty());
     // THEN
-    then(throwable).isInstanceOf(AssertionError.class)
-                   .hasMessage(actualIsNull());
+    then(thrown).isInstanceOf(AssertionError.class)
+                .hasMessage(actualIsNull());
   }
 
   @Test
@@ -48,10 +48,10 @@ class TableAssert_isNotEmpty_Test extends TableAssertBaseTest {
     // GIVEN
     actual.clear();
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).isNotEmpty());
+    Throwable thrown = catchThrowable(() -> assertThat(actual).isNotEmpty());
     // THEN
-    then(throwable).isInstanceOf(AssertionError.class)
-                   .hasMessage(format("%nExpecting actual not to be empty"));
+    then(thrown).isInstanceOf(AssertionError.class)
+                .hasMessage(format("%nExpecting actual not to be empty"));
   }
 
   @Test


### PR DESCRIPTION
The `TableAssert` currently contains `isEmpty()` assertion, but no `isNotEmpty()`. I want to extend this to be like other collection assertions.

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

#### Changes in this PR:
* A new assertion `isNotEmpty()` added to the `TableAssert` class
* Added unit tests for `TableAssert#isNotEmpty()`
* Fixed typo in the `TableAssert_isEmpty_Test#should_fail_if_actual_is_null()` test method