### PR TITLE
Added control flow in the form of ADT for assertThatCode

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -843,7 +843,9 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
    * @since 3.7.0
    */
   public void doesNotThrowAnyException() {
-    if (actual != null) throw Failures.instance().failure(info, shouldNotHaveThrown(actual));
+    if (actual != null) {
+      throw Failures.instance().failure(info, shouldNotHaveThrown(actual));
+    }
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/ResultOrErrorAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ResultOrErrorAssert.java
@@ -1,0 +1,54 @@
+package org.assertj.core.api;
+
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+
+import java.util.function.Predicate;
+
+import org.assertj.core.error.ShouldBeInstance;
+import org.assertj.core.error.ShouldMatch;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.ResultOrError;
+import org.assertj.core.presentation.PredicateDescription;
+
+/**
+ * Implementation of {@link AbstractObjectAssert} that is aimed to work with {@link ResultOrError} ADT.
+ *
+ * @author Mikhail Polivakha
+ */
+public class ResultOrErrorAssert<R, E extends Throwable>
+    extends AbstractObjectAssert<ResultOrErrorAssert<R, E>, ResultOrError<R, E>> {
+
+  public ResultOrErrorAssert(ResultOrError<R, E> reResultOrError) {
+    super(reResultOrError, ResultOrErrorAssert.class);
+  }
+
+  public ResultOrErrorAssert<R, E> doesNotThrowAnyException() {
+    doesNotThrowAnyExceptionInternal();
+    return myself;
+  }
+
+  public ResultOrErrorAssert<R, E> resultsInValueSatisfying(Predicate<R> predicate) {
+    doesNotThrowAnyExceptionInternal();
+    if (!predicate.test(actual.getResult())) {
+      throw Failures.instance().failure(info, ShouldMatch.shouldMatch(actual.getResult(), predicate, PredicateDescription.GIVEN));
+    }
+    return myself;
+  }
+
+  public ResultOrErrorAssert<R, E> raisesThrowableOfType(Class<? extends Throwable> throwableType) {
+    if (actual.isSuccessfulResult()) {
+      throw Failures.instance().failure(info, ShouldHaveThrown.shouldHaveThrown(throwableType));
+    }
+
+    if (!throwableType.isAssignableFrom(actual.getError().getClass())) {
+      throw Failures.instance().failure(info, ShouldBeInstance.shouldBeInstance(actual.getError(), throwableType));
+    }
+    return myself;
+  }
+
+  private void doesNotThrowAnyExceptionInternal() {
+    if (actual.isError()) {
+      throw Failures.instance().failure(info, shouldNotHaveThrown(actual.getError()));
+    }
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/ShouldHaveThrown.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ShouldHaveThrown.java
@@ -1,0 +1,36 @@
+package org.assertj.core.api;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that some {@link Throwable} was expected
+ * to be thrown, but actually wasn't
+ *
+ * @author Mikhail Polivakha
+ */
+public class ShouldHaveThrown extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldHaveThrown(Class<? extends Throwable> throwable) {
+    return new ShouldHaveThrown(List.of(throwable));
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldHaveThrown}</code>.
+   *
+   * @param throwables arguments referenced by the format specifiers in the format string.
+   */
+  public ShouldHaveThrown(Collection<Class<? extends Throwable>> throwables) {
+    super(errorMessageTemplate(), throwables);
+  }
+
+  private static String errorMessageTemplate() {
+    return "%nExpecting code block to raise a Throwable with any type below:%n" +
+           "  %s%n" +
+           "but nothing was thrown";
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -16,6 +16,8 @@ import static org.assertj.core.error.ShouldBeInstance.shouldBeInstance;
 
 import java.util.concurrent.Callable;
 
+import org.assertj.core.internal.ResultOrError;
+
 /**
  * Assertion methods for {@link Throwable}s.
  * <p>
@@ -29,7 +31,13 @@ import java.util.concurrent.Callable;
  */
 public class ThrowableAssert<ACTUAL extends Throwable> extends AbstractThrowableAssert<ThrowableAssert<ACTUAL>, ACTUAL> {
 
+  /**
+   * That's actually not a {@link Callable}, because it does not return any result
+   *
+   * @deprecated use {@link org.assertj.core.api.ThrowingCallable} instead
+   */
   public interface ThrowingCallable {
+
     void call() throws Throwable;
   }
 
@@ -65,6 +73,15 @@ public class ThrowableAssert<ACTUAL extends Throwable> extends AbstractThrowable
       return throwable;
     }
     return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <RESULT, E extends Throwable> ResultOrError<RESULT, E> catchThrowable(org.assertj.core.api.ThrowingCallable<RESULT, E> shouldRaiseThrowable) {
+    try {
+      return ResultOrError.result(shouldRaiseThrowable.call());
+    } catch (Throwable throwable) {
+      return ResultOrError.error((E) throwable);
+    }
   }
 
   @Deprecated

--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowingCallable.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowingCallable.java
@@ -1,0 +1,16 @@
+package org.assertj.core.api;
+
+/**
+ * Functional interface to represent any {@link java.util.concurrent.Callable} that can throw any {@link Throwable}
+ *
+ * @author Mikhail Polivakha
+ * @param <T> - the return type of the call
+ * @param <E> - the type of the exception expected to be thrown
+ */
+public interface ThrowingCallable<T, E extends Throwable> {
+
+  /**
+   * Execution that can result in error
+   */
+  T call() throws E;
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/ResultOrError.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/ResultOrError.java
@@ -1,0 +1,98 @@
+package org.assertj.core.internal;
+
+import java.util.Objects;
+
+import org.assertj.core.api.ThrowingCallable;
+
+/**
+ * Custom Algebraic Data Type (ADT). Can hold either the result (see {@link ResultOrError#result(Object)}),
+ * or the error (see {@link ResultOrError#error(Throwable)})
+ *
+ * @author Mikhail Polivakha
+ */
+public interface ResultOrError<R, E extends Throwable> {
+
+  @SuppressWarnings("unchecked")
+  static <R, E extends Throwable> ResultOrError<R, E> from(ThrowingCallable<R, E> t) {
+    try {
+      return ResultOrError.result(t.call());
+    } catch (Throwable any) {
+      return ResultOrError.error((E) any);
+    }
+  }
+
+  class Result<R, E extends Throwable> implements ResultOrError<R, E> {
+
+    private final R result;
+
+    public Result(R result) {
+      this.result = result;
+    }
+
+    @Override
+    public boolean isError() {
+      return false;
+    }
+
+    @Override
+    public boolean isSuccessfulResult() {
+      return true;
+    }
+
+    @Override
+    public R getResult() {
+      return result;
+    }
+
+    @Override
+    public E getError() {
+      throw new UnsupportedOperationException("GetError on Result");
+    }
+  }
+
+  class Error<R, E extends Throwable> implements ResultOrError<R, E> {
+
+    private final E throwable;
+
+    public Error(E throwable) {
+      Objects.requireNonNull(throwable, "Throwable cannot be null in ResultOnError.Error");
+      this.throwable = throwable;
+    }
+
+    @Override
+    public boolean isError() {
+      return true;
+    }
+
+    @Override
+    public boolean isSuccessfulResult() {
+      return false;
+    }
+
+    @Override
+    public R getResult() {
+      throw new UnsupportedOperationException("GetResult on Error");
+    }
+
+    @Override
+    public E getError() {
+      return throwable;
+    }
+  }
+
+  boolean isError();
+
+  boolean isSuccessfulResult();
+
+  R getResult();
+
+  E getError();
+
+  static <R, E extends Throwable> ResultOrError<R, E> result(R result) {
+    return new Result<>(result);
+  }
+
+  static <R, E extends Throwable> ResultOrError<R, E> error(E error) {
+    return new Error<>(error);
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatCodeDeprecated_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatCodeDeprecated_Test.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.core.api;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenCode;
+import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
+import static org.assertj.core.error.ShouldNotHaveThrownExcept.shouldNotHaveThrownExcept;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.io.IOException;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+
+@Deprecated(forRemoval = true)
+class Assertions_assertThatCodeDeprecated_Test {
+
+  @Test
+  void can_invoke_late_assertion() {
+    // GIVEN
+    ThrowingCallable boom = raisingException("boom!");
+
+    // WHEN/THEN
+    thenCode(boom).isInstanceOf(Exception.class)
+                  .hasMessageContaining("boom!");
+  }
+
+  @Test
+  void should_fail_when_asserting_no_exception_was_thrown_and_an_exception_was_thrown() {
+    // GIVEN
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyException());
+    // THEN
+    then(error).hasMessage(shouldNotHaveThrown(exception).create());
+  }
+
+  @Test
+  void should_fail_when_asserting_no_exception_was_thrown_except_an_empty_list_and_an_exception_was_thrown() {
+    // GIVEN
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyExceptionExcept());
+    // THEN
+    then(error).hasMessage(shouldNotHaveThrownExcept(exception).create());
+  }
+
+  @Test
+  void should_fail_when_asserting_no_exception_was_thrown_except_some_and_a_non_ignored_exception_was_thrown() {
+    // GIVEN
+    Exception exception = new IllegalArgumentException("boom");
+    ThrowingCallable boom = raisingException(exception);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyExceptionExcept(IllegalStateException.class,
+                                                                                                          IOException.class));
+    // THEN
+    then(error).hasMessage(shouldNotHaveThrownExcept(exception, IllegalStateException.class, IOException.class).create());
+  }
+
+  @Test
+  void can_use_description_in_error_message() {
+    // GIVEN
+    ThrowingCallable boom = raisingException("boom");
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThatCode(boom).as("Test").doesNotThrowAnyException());
+    // THEN
+    then(error).hasMessageStartingWith("[Test]");
+  }
+
+  @Test
+  void error_message_contains_stacktrace() {
+    // GIVEN
+    Exception exception = new Exception("boom");
+    ThrowingCallable boom = raisingException(exception);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyException());
+    // THEN
+    then(error).hasMessageContainingAll("java.lang.Exception: boom",
+                                        "at org.assertj.tests.core.api.Assertions_assertThatCode_Test.error_message_contains_stacktrace");
+  }
+
+  @Test
+  void should_succeed_when_asserting_no_exception_was_thrown() {
+    // GIVEN
+    ThrowingCallable silent = () -> {};
+    // WHEN/THEN
+    thenCode(silent).doesNotThrowAnyException();
+  }
+
+  @Test
+  void should_succeed_when_asserting_no_exception_was_thrown_except_an_empty_list() {
+    // GIVEN
+    ThrowingCallable silent = () -> {};
+    // WHEN/THEN
+    thenCode(silent).doesNotThrowAnyExceptionExcept();
+  }
+
+  @Test
+  void should_succeed_when_asserting_no_exception_was_thrown_except_some() {
+    // GIVEN
+    ThrowingCallable silent = () -> {};
+    // WHEN/THEN
+    thenCode(silent).doesNotThrowAnyExceptionExcept(IOException.class, IllegalStateException.class);
+  }
+
+  @Test
+  void should_succeed_when_asserting_no_exception_was_thrown_except_one_that_is_an_ignored() {
+    // GIVEN
+    ThrowingCallable boom = raisingException(new IllegalArgumentException("boom"));
+    // WHEN/THEN
+    thenCode(boom).doesNotThrowAnyExceptionExcept(IOException.class, IllegalArgumentException.class);
+  }
+
+  @Test
+  void should_succeed_when_asserting_no_exception_was_thrown_except_one_that_inherits_an_ignored_exception() {
+    // GIVEN
+    ThrowingCallable boom = raisingException(new IllegalArgumentException("boom"));
+    // WHEN/THEN
+    thenCode(boom).doesNotThrowAnyExceptionExcept(RuntimeException.class);
+  }
+
+  private ThrowingCallable raisingException(final String reason) {
+    return raisingException(new Exception(reason));
+  }
+
+  private ThrowingCallable raisingException(final Exception exception) {
+    return () -> {
+      throw exception;
+    };
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatCode_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatCode_Test.java
@@ -1,143 +1,78 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- *
- * Copyright 2012-2024 the original author or authors.
- */
 package org.assertj.tests.core.api;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenCode;
-import static org.assertj.core.error.ShouldNotHaveThrown.shouldNotHaveThrown;
-import static org.assertj.core.error.ShouldNotHaveThrownExcept.shouldNotHaveThrownExcept;
-import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.io.IOException;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import java.io.EOFException;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
-class Assertions_assertThatCode_Test {
+/**
+ * Tests for {@link org.assertj.core.api.Assertions#assertThatCode(ThrowingCallable)}
+ *
+ * @author Mikhail Polivakha
+ */
+public class Assertions_assertThatCode_Test {
 
   @Test
-  void can_invoke_late_assertion() {
-    // GIVEN
-    ThrowingCallable boom = raisingException("boom!");
+  void should_pass_assert_happy_path() {
+    String value = "value";
 
-    // WHEN/THEN
-    thenCode(boom).isInstanceOf(Exception.class)
-                  .hasMessageContaining("boom!");
-  }
-
-  @Test
-  void should_fail_when_asserting_no_exception_was_thrown_and_an_exception_was_thrown() {
-    // GIVEN
-    Exception exception = new Exception("boom");
-    ThrowingCallable boom = raisingException(exception);
-    // WHEN
-    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyException());
-    // THEN
-    then(error).hasMessage(shouldNotHaveThrown(exception).create());
+    Assertions
+              .assertThatCode(() -> value)
+              .doesNotThrowAnyException()
+              .resultsInValueSatisfying(s -> s.equals(value));
   }
 
   @Test
-  void should_fail_when_asserting_no_exception_was_thrown_except_an_empty_list_and_an_exception_was_thrown() {
-    // GIVEN
-    Exception exception = new Exception("boom");
-    ThrowingCallable boom = raisingException(exception);
-    // WHEN
-    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyExceptionExcept());
-    // THEN
-    then(error).hasMessage(shouldNotHaveThrownExcept(exception).create());
+  void should_pass_assert_error_path() {
+    Assertions
+              .assertThatCode(() -> {
+                if (true) {
+                  throw new IllegalArgumentException();
+                } else {
+                  return "unreachable";
+                }
+              })
+              .raisesThrowableOfType(IllegalArgumentException.class);
   }
 
   @Test
-  void should_fail_when_asserting_no_exception_was_thrown_except_some_and_a_non_ignored_exception_was_thrown() {
-    // GIVEN
-    Exception exception = new IllegalArgumentException("boom");
-    ThrowingCallable boom = raisingException(exception);
-    // WHEN
-    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyExceptionExcept(IllegalStateException.class,
-                                                                                                          IOException.class));
-    // THEN
-    then(error).hasMessage(shouldNotHaveThrownExcept(exception, IllegalStateException.class, IOException.class).create());
+  void should_fail_assert_on_exception_type_mismatch_on_error_path() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions
+                                                                               .assertThatCode(() -> {
+                                                                                 if (true) {
+                                                                                   throw new IllegalArgumentException();
+                                                                                 } else {
+                                                                                   return "unreachable";
+                                                                                 }
+                                                                               })
+                                                                               .raisesThrowableOfType(EOFException.class));
   }
 
   @Test
-  void can_use_description_in_error_message() {
-    // GIVEN
-    ThrowingCallable boom = raisingException("boom");
-    // WHEN
-    AssertionError error = expectAssertionError(() -> assertThatCode(boom).as("Test").doesNotThrowAnyException());
-    // THEN
-    then(error).hasMessageStartingWith("[Test]");
+  void should_fail_assertion_on_exception() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions
+                                                                               .assertThatCode(() -> {
+                                                                                 throw new RuntimeException();
+                                                                               })
+                                                                               .doesNotThrowAnyException());
   }
 
   @Test
-  void error_message_contains_stacktrace() {
-    // GIVEN
-    Exception exception = new Exception("boom");
-    ThrowingCallable boom = raisingException(exception);
-    // WHEN
-    AssertionError error = expectAssertionError(() -> assertThatCode(boom).doesNotThrowAnyException());
-    // THEN
-    then(error).hasMessageContainingAll("java.lang.Exception: boom",
-                                        "at org.assertj.tests.core.api.Assertions_assertThatCode_Test.error_message_contains_stacktrace");
+  void should_fail_on_evaluated_value_mismatch() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions
+                                                                               .assertThatCode(() -> "one")
+                                                                               .resultsInValueSatisfying(s -> s.equals("another")));
   }
 
   @Test
-  void should_succeed_when_asserting_no_exception_was_thrown() {
-    // GIVEN
-    ThrowingCallable silent = () -> {};
-    // WHEN/THEN
-    thenCode(silent).doesNotThrowAnyException();
-  }
-
-  @Test
-  void should_succeed_when_asserting_no_exception_was_thrown_except_an_empty_list() {
-    // GIVEN
-    ThrowingCallable silent = () -> {};
-    // WHEN/THEN
-    thenCode(silent).doesNotThrowAnyExceptionExcept();
-  }
-
-  @Test
-  void should_succeed_when_asserting_no_exception_was_thrown_except_some() {
-    // GIVEN
-    ThrowingCallable silent = () -> {};
-    // WHEN/THEN
-    thenCode(silent).doesNotThrowAnyExceptionExcept(IOException.class, IllegalStateException.class);
-  }
-
-  @Test
-  void should_succeed_when_asserting_no_exception_was_thrown_except_one_that_is_an_ignored() {
-    // GIVEN
-    ThrowingCallable boom = raisingException(new IllegalArgumentException("boom"));
-    // WHEN/THEN
-    thenCode(boom).doesNotThrowAnyExceptionExcept(IOException.class, IllegalArgumentException.class);
-  }
-
-  @Test
-  void should_succeed_when_asserting_no_exception_was_thrown_except_one_that_inherits_an_ignored_exception() {
-    // GIVEN
-    ThrowingCallable boom = raisingException(new IllegalArgumentException("boom"));
-    // WHEN/THEN
-    thenCode(boom).doesNotThrowAnyExceptionExcept(RuntimeException.class);
-  }
-
-  private ThrowingCallable raisingException(final String reason) {
-    return raisingException(new Exception(reason));
-  }
-
-  private ThrowingCallable raisingException(final Exception exception) {
-    return () -> {
-      throw exception;
-    };
+  void should_fail_with_description() {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> Assertions
+                                                                               .assertThatCode(() -> "one")
+                                                                               .describedAs("Some message")
+                                                                               .as("Some message")
+                                                                               .resultsInValueSatisfying(s -> s.equals("another")));
   }
 }


### PR DESCRIPTION
This PR brings the ability to control the execution of the code block in a more general manner. For now, `assertThatCode` creates `AbstractTrhowableAssert`, which only checks the error thrown by the code block. But sometimes, asserting that the code block did not throw anything and resulted in the particular value is very useful. Example:

```
String value = "value";

Assertions
    .assertThatCode(() -> value)
    .doesNotThrowAnyException()
    .resultsInValueSatisfying(s -> s.equals(value));
```