### PR TITLE
Guava TableAssert: assertions for row count added

### DIFF
--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -20,6 +20,10 @@ import static org.assertj.guava.error.TableShouldContainColumns.tableShouldConta
 import static org.assertj.guava.error.TableShouldContainRows.tableShouldContainRows;
 import static org.assertj.guava.error.TableShouldHaveColumnCount.tableShouldHaveColumnCount;
 import static org.assertj.guava.error.TableShouldHaveRowCount.tableShouldHaveRowCount;
+import static org.assertj.guava.error.TableShouldHaveRowCountGreaterThan.tableShouldHaveRowCountGreaterThan;
+import static org.assertj.guava.error.TableShouldHaveRowCountGreaterThanOrEqualTo.tableShouldHaveRowCountGreaterThanOrEqualTo;
+import static org.assertj.guava.error.TableShouldHaveRowCountLessThan.tableShouldHaveRowCountLessThan;
+import static org.assertj.guava.error.TableShouldHaveRowCountLessThanOrEqualTo.tableShouldHaveRowCountLessThanOrEqualTo;
 
 import java.util.Set;
 
@@ -64,6 +68,138 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
 
     if (actual.rowKeySet().size() != expectedSize) {
       throw assertionError(tableShouldHaveRowCount(actual, actual.rowKeySet().size(), expectedSize));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the number of rows in the actual table is greater than the given boundary.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).hasRowCountGreaterThan(1);
+   *
+   * // assertion will fail
+   * assertThat(actual).hasRowCountGreaterThan(2);</code></pre>
+   *
+   * @param boundary the given value to compare the actual row count to.
+   * @return this {@link TableAssert} for assertion chaining.
+   * @throws IllegalArgumentException if the expected size is negative
+   * @throws AssertionError           if the actual {@link Table} is {@code null}.
+   * @throws AssertionError           if the number of rows in the actual {@link Table} is not greater than the boundary.
+   */
+  public TableAssert<R, C, V> hasRowCountGreaterThan(int boundary) {
+    isNotNull();
+    checkExpectedSizeArgument(boundary);
+
+    if (actual.rowKeySet().size() <= boundary) {
+      throw assertionError(tableShouldHaveRowCountGreaterThan(actual, actual.rowKeySet().size(), boundary));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the number of rows in the actual table is greater than or equal to the given boundary.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).hasRowCountGreaterThanOrEqualTo(2);
+   *
+   * // assertion will fail
+   * assertThat(actual).hasRowCountGreaterThanOrEqualTo(3);</code></pre>
+   *
+   * @param boundary the given value to compare the actual row count to.
+   * @return this {@link TableAssert} for assertion chaining.
+   * @throws IllegalArgumentException if the expected size is negative
+   * @throws AssertionError           if the actual {@link Table} is {@code null}.
+   * @throws AssertionError           if the number of rows in the actual {@link Table} is not greater than or equal to the boundary.
+   */
+  public TableAssert<R, C, V> hasRowCountGreaterThanOrEqualTo(int boundary) {
+    isNotNull();
+    checkExpectedSizeArgument(boundary);
+
+    if (actual.rowKeySet().size() < boundary) {
+      throw assertionError(tableShouldHaveRowCountGreaterThanOrEqualTo(actual, actual.rowKeySet().size(), boundary));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the number of rows in the actual table is less than the given boundary.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).hasRowCountLessThan(3);
+   *
+   * // assertion will fail
+   * assertThat(actual).hasRowCountLessThan(2);</code></pre>
+   *
+   * @param boundary the given value to compare the actual row count to.
+   * @return this {@link TableAssert} for assertion chaining.
+   * @throws IllegalArgumentException if the expected size is negative
+   * @throws AssertionError           if the actual {@link Table} is {@code null}.
+   * @throws AssertionError           if the number of rows in the actual {@link Table} is not less than the boundary.
+   */
+  public TableAssert<R, C, V> hasRowCountLessThan(int boundary) {
+    isNotNull();
+    checkExpectedSizeArgument(boundary);
+
+    if (actual.rowKeySet().size() >= boundary) {
+      throw assertionError(tableShouldHaveRowCountLessThan(actual, actual.rowKeySet().size(), boundary));
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the number of rows in the actual table is less than or equal to the given boundary.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).hasRowCountLessThanOrEqualTo(2);
+   *
+   * // assertion will fail
+   * assertThat(actual).hasRowCountLessThanOrEqualTo(1);</code></pre>
+   *
+   * @param boundary the given value to compare the actual row count to.
+   * @return this {@link TableAssert} for assertion chaining.
+   * @throws IllegalArgumentException if the expected size is negative
+   * @throws AssertionError           if the actual {@link Table} is {@code null}.
+   * @throws AssertionError           if the number of rows in the actual {@link Table} is not less than or equal to the boundary.
+   */
+  public TableAssert<R, C, V> hasRowCountLessThanOrEqualTo(int boundary) {
+    isNotNull();
+    checkExpectedSizeArgument(boundary);
+
+    if (actual.rowKeySet().size() > boundary) {
+      throw assertionError(tableShouldHaveRowCountLessThanOrEqualTo(actual, actual.rowKeySet().size(), boundary));
     }
     return myself;
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountGreaterThan.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountGreaterThan.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Error message factory for a table assertion that verifies the minimum row count (exclusive).
+ *
+ * @author Maciej Kucharczyk
+ */
+public class TableShouldHaveRowCountGreaterThan extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link TableShouldHaveRowCountGreaterThan}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the number of rows in {@code actual}.
+   * @param expectedMinSize the expected min size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory tableShouldHaveRowCountGreaterThan(Object actual, int actualSize, int expectedMinSize) {
+    return new TableShouldHaveRowCountGreaterThan(actual, actualSize, expectedMinSize);
+  }
+
+  private TableShouldHaveRowCountGreaterThan(Object actual, int actualSize, int expectedSize) {
+    // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
+    // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
+    // %%s is going to be formatted to %s to be replaced by actual later on.
+    super(format("%n" +
+                 "Expecting row count:%n" +
+                 "  %%s%n" +
+                 "to be greater than %s but was %s", expectedSize, actualSize),
+          actual);
+  }
+}

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountGreaterThanOrEqualTo.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountGreaterThanOrEqualTo.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Error message factory for a table assertion that verifies the minimum row count (inclusive).
+ *
+ * @author Maciej Kucharczyk
+ */
+public class TableShouldHaveRowCountGreaterThanOrEqualTo extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link TableShouldHaveRowCountGreaterThanOrEqualTo}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the number of rows in {@code actual}.
+   * @param expectedMinSize the expected min size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory tableShouldHaveRowCountGreaterThanOrEqualTo(Object actual, int actualSize,
+                                                                                int expectedMinSize) {
+    return new TableShouldHaveRowCountGreaterThanOrEqualTo(actual, actualSize, expectedMinSize);
+  }
+
+  private TableShouldHaveRowCountGreaterThanOrEqualTo(Object actual, int actualSize, int expectedSize) {
+    // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
+    // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
+    // %%s is going to be formatted to %s to be replaced by actual later on.
+    super(format("%n" +
+                 "Expecting row count:%n" +
+                 "  %%s%n" +
+                 "to be greater than or equal to %s but was %s", expectedSize, actualSize),
+          actual);
+  }
+}

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountLessThan.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountLessThan.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Error message factory for a table assertion that verifies the maximum row count (exclusive).
+ *
+ * @author Maciej Kucharczyk
+ */
+public class TableShouldHaveRowCountLessThan extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link TableShouldHaveRowCountLessThan}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the number of rows in {@code actual}.
+   * @param expectedMaxSize the expected max size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory tableShouldHaveRowCountLessThan(Object actual, int actualSize, int expectedMaxSize) {
+    return new TableShouldHaveRowCountLessThan(actual, actualSize, expectedMaxSize);
+  }
+
+  private TableShouldHaveRowCountLessThan(Object actual, int actualSize, int expectedSize) {
+    // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
+    // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
+    // %%s is going to be formatted to %s to be replaced by actual later on.
+    super(format("%n" +
+                 "Expecting row count:%n" +
+                 "  %%s%n" +
+                 "to be less than %s but was %s", expectedSize, actualSize),
+          actual);
+  }
+}

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountLessThanOrEqualTo.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCountLessThanOrEqualTo.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Error message factory for a table assertion that verifies the maximum row count (inclusive).
+ *
+ * @author Maciej Kucharczyk
+ */
+public class TableShouldHaveRowCountLessThanOrEqualTo extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link TableShouldHaveRowCountLessThanOrEqualTo}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the number of rows in {@code actual}.
+   * @param expectedMaxSize the expected max size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory tableShouldHaveRowCountLessThanOrEqualTo(Object actual, int actualSize, int expectedMaxSize) {
+    return new TableShouldHaveRowCountLessThanOrEqualTo(actual, actualSize, expectedMaxSize);
+  }
+
+  private TableShouldHaveRowCountLessThanOrEqualTo(Object actual, int actualSize, int expectedSize) {
+    // format the sizes in a standard way, otherwise if we use (for ex) an Hexadecimal representation
+    // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
+    // %%s is going to be formatted to %s to be replaced by actual later on.
+    super(format("%n" +
+                 "Expecting row count:%n" +
+                 "  %%s%n" +
+                 "to be less than or equal to %s but was %s", expectedSize, actualSize),
+          actual);
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountGreaterThanOrEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountGreaterThanOrEqualTo_Test.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.guava.error.TableShouldHaveRowCountGreaterThanOrEqualTo.tableShouldHaveRowCountGreaterThanOrEqualTo;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_hasRowCountGreaterThanOrEqualTo_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThanOrEqualTo(0));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_is_negative() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThanOrEqualTo(-1));
+    // THEN
+    then(throwable).isInstanceOf(IllegalArgumentException.class)
+                   .hasMessage("The expected size should not be negative.");
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_less_than_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThanOrEqualTo(3));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountGreaterThanOrEqualTo(actual, 2, 3).create());
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_equal_to_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_greater_than_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  void should_return_this() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    TableAssert<Integer, Integer, String> returnedAssertion = assertion.hasRowCountGreaterThanOrEqualTo(0);
+    // THEN
+    then(returnedAssertion).isSameAs(assertion);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountGreaterThan_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountGreaterThan_Test.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.guava.error.TableShouldHaveRowCountGreaterThan.tableShouldHaveRowCountGreaterThan;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_hasRowCountGreaterThan_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThan(0));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_is_negative() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThan(-1));
+    // THEN
+    then(throwable).isInstanceOf(IllegalArgumentException.class)
+                   .hasMessage("The expected size should not be negative.");
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_less_than_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThan(3));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountGreaterThan(actual, 2, 3).create());
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_equal_to_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountGreaterThan(2));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountGreaterThan(actual, 2, 2).create());
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_greater_than_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountGreaterThan(1);
+  }
+
+  @Test
+  void should_return_this() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    TableAssert<Integer, Integer, String> returnedAssertion = assertion.hasRowCountGreaterThan(0);
+    // THEN
+    then(returnedAssertion).isSameAs(assertion);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountLessThanOrEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountLessThanOrEqualTo_Test.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.guava.error.TableShouldHaveRowCountLessThanOrEqualTo.tableShouldHaveRowCountLessThanOrEqualTo;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_hasRowCountLessThanOrEqualTo_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThanOrEqualTo(10));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_is_negative() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThanOrEqualTo(-1));
+    // THEN
+    then(throwable).isInstanceOf(IllegalArgumentException.class)
+                   .hasMessage("The expected size should not be negative.");
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_less_than_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountLessThanOrEqualTo(3);
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_equal_to_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountLessThanOrEqualTo(2);
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_greater_than_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThanOrEqualTo(1));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountLessThanOrEqualTo(actual, 2, 1).create());
+  }
+
+  @Test
+  void should_return_this() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    TableAssert<Integer, Integer, String> returnedAssertion = assertion.hasRowCountLessThanOrEqualTo(10);
+    // THEN
+    then(returnedAssertion).isSameAs(assertion);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountLessThan_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCountLessThan_Test.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+import static org.assertj.guava.error.TableShouldHaveRowCountLessThan.tableShouldHaveRowCountLessThan;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_hasRowCountLessThan_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThan(10));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_is_negative() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThan(-1));
+    // THEN
+    then(throwable).isInstanceOf(IllegalArgumentException.class)
+                   .hasMessage("The expected size should not be negative.");
+  }
+
+  @Test
+  void should_pass_if_rows_of_actual_is_less_than_boundary() {
+    // WHEN/THEN
+    assertThat(actual).hasRowCountLessThan(3);
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_equal_to_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThan(2));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountLessThan(actual, 2, 2).create());
+  }
+
+  @Test
+  void should_fail_if_rows_of_actual_is_greater_than_boundary() {
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).hasRowCountLessThan(1));
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(tableShouldHaveRowCountLessThan(actual, 2, 1).create());
+  }
+
+  @Test
+  void should_return_this() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    TableAssert<Integer, Integer, String> returnedAssertion = assertion.hasRowCountLessThan(10);
+    // THEN
+    then(returnedAssertion).isSameAs(assertion);
+  }
+
+}


### PR DESCRIPTION
Hello,

This is another PR that enriches the assertions for Guava `Table`.
In this PR, I add the following methods to `TableAssert`:

- `hasRowCountGreaterThan(int boundary)`
- `hasRowCountGreaterThanOrEqualTo(int boundary)`
- `hasRowCountLessThan(int boundary)`
- `hasRowCountLessThanOrEqualTo(int boundary)`

The new methods are a follow-up to the existing `hasRowCount(int expectedSize)` method.

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)