### PR TITLE
Guava TableAssert: assertions for columnCount, rowCount, size

### DIFF
--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -25,10 +25,9 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import java.util.Set;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractIntegerAssert;
-import org.assertj.core.api.IntegerAssert;
 import org.assertj.core.error.ShouldBeEmpty;
 import org.assertj.core.error.ShouldNotBeEmpty;
+import org.assertj.core.util.CheckReturnValue;
 
 /**
  * @author Jan Gorman
@@ -100,7 +99,10 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
   }
 
   /**
-   * Creates a new instance of <code>{@link IntegerAssert}</code> for asserting row count in the actual table.
+   * Returns a {@link TableIntegerAssert} object that allows performing assertions on the row count of the actual {@link Table}.
+   * <p>
+   * Once this method is called, the object under test is no longer the {@link Table} but its row count,
+   * to perform assertions on the {@link Table}, call {@link TableIntegerAssert#returnToTable()}.
    * <p>
    * Example:
    *
@@ -111,7 +113,10 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
    * actual.put(2, 5, "Grover Cleveland");
    *
    * // assertion will pass
-   * assertThat(actual).rowCount().isGreaterThan(1);
+   * assertThat(actual).rowCount().isGreaterThan(1)
+   *                              .isLessThan(5)
+   *                              .returnToTable()
+   *                              .containsValues("Franklin Pierce", "Millard Fillmore");
    *
    * // assertion will fail
    * assertThat(actual).rowCount().isLessThan(2);</code></pre>
@@ -119,13 +124,17 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
    * @return the created assertion object.
    * @throws AssertionError if the actual {@link Table} is {@code null}.
    */
-  public AbstractIntegerAssert<?> rowCount() {
+  @CheckReturnValue
+  public TableIntegerAssert<R, C, V> rowCount() {
     isNotNull();
-    return org.assertj.core.api.Assertions.assertThat(actual.rowKeySet().size());
+    return new TableIntegerAssert<>(this, actual.rowKeySet().size());
   }
 
   /**
-   * Creates a new instance of <code>{@link IntegerAssert}</code> for asserting column count in the actual table.
+   * Returns a {@link TableIntegerAssert} object that allows performing assertions on the column count of the actual {@link Table}.
+   * <p>
+   * Once this method is called, the object under test is no longer the {@link Table} but its column count,
+   * to perform assertions on the {@link Table}, call {@link TableIntegerAssert#returnToTable()}.
    * <p>
    * Example:
    *
@@ -136,7 +145,10 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
    * actual.put(2, 5, "Grover Cleveland");
    *
    * // assertion will pass
-   * assertThat(actual).columnCount().isGreaterThan(1);
+   * assertThat(actual).columnCount().isGreaterThan(1)
+   *                                 .isLessThan(5)
+   *                                 .returnToTable()
+   *                                 .containsValues("Franklin Pierce", "Millard Fillmore");
    *
    * // assertion will fail
    * assertThat(actual).columnCount().isLessThan(3);</code></pre>
@@ -144,9 +156,42 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
    * @return the created assertion object.
    * @throws AssertionError if the actual {@link Table} is {@code null}.
    */
-  public AbstractIntegerAssert<?> columnCount() {
+  @CheckReturnValue
+  public TableIntegerAssert<R, C, V> columnCount() {
     isNotNull();
-    return org.assertj.core.api.Assertions.assertThat(actual.columnKeySet().size());
+    return new TableIntegerAssert<>(this, actual.columnKeySet().size());
+  }
+
+  /**
+   * Returns a {@link TableIntegerAssert} object that allows performing assertions on the size of the actual {@link Table}.
+   * <p>
+   * Once this method is called, the object under test is no longer the {@link Table} but its size,
+   * to perform assertions on the {@link Table}, call {@link TableIntegerAssert#returnToTable()}.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).size().isGreaterThan(1)
+   *                          .isLessThan(5)
+   *                          .returnToTable()
+   *                          .containsValues("Franklin Pierce", "Millard Fillmore");
+   *
+   * // assertion will fail
+   * assertThat(actual).size().isLessThan(2);</code></pre>
+   *
+   * @return the created assertion object.
+   * @throws AssertionError if the actual {@link Table} is {@code null}.
+   */
+  @CheckReturnValue
+  public TableIntegerAssert<R, C, V> size() {
+    isNotNull();
+    return new TableIntegerAssert<>(this, actual.size());
   }
 
   /**

--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -25,6 +25,8 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import java.util.Set;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.IntegerAssert;
 import org.assertj.core.error.ShouldBeEmpty;
 import org.assertj.core.error.ShouldNotBeEmpty;
 
@@ -95,6 +97,56 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
       throw assertionError(tableShouldHaveColumnCount(actual, actual.columnKeySet().size(), expectedSize));
     }
     return myself;
+  }
+
+  /**
+   * Creates a new instance of <code>{@link IntegerAssert}</code> for asserting row count in the actual table.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).rowCount().isGreaterThan(1);
+   *
+   * // assertion will fail
+   * assertThat(actual).rowCount().isLessThan(2);</code></pre>
+   *
+   * @return the created assertion object.
+   * @throws AssertionError if the actual {@link Table} is {@code null}.
+   */
+  public AbstractIntegerAssert<?> rowCount() {
+    isNotNull();
+    return org.assertj.core.api.Assertions.assertThat(actual.rowKeySet().size());
+  }
+
+  /**
+   * Creates a new instance of <code>{@link IntegerAssert}</code> for asserting column count in the actual table.
+   * <p>
+   * Example:
+   *
+   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
+   *
+   * actual.put(1, 3, "Millard Fillmore");
+   * actual.put(1, 4, "Franklin Pierce");
+   * actual.put(2, 5, "Grover Cleveland");
+   *
+   * // assertion will pass
+   * assertThat(actual).columnCount().isGreaterThan(1);
+   *
+   * // assertion will fail
+   * assertThat(actual).columnCount().isLessThan(3);</code></pre>
+   *
+   * @return the created assertion object.
+   * @throws AssertionError if the actual {@link Table} is {@code null}.
+   */
+  public AbstractIntegerAssert<?> columnCount() {
+    isNotNull();
+    return org.assertj.core.api.Assertions.assertThat(actual.columnKeySet().size());
   }
 
   /**

--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableIntegerAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableIntegerAssert.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.guava.api;
+
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.util.CheckReturnValue;
+
+/**
+ * Assertion methods for {@link Integer}s with the possibility of returning to the {@link TableAssert}.
+ */
+public class TableIntegerAssert<R, C, V> extends AbstractIntegerAssert<TableIntegerAssert<R, C, V>> {
+
+  private final TableAssert<R, C, V> source;
+
+  public TableIntegerAssert(TableAssert<R, C, V> source, Integer i) {
+    super(i, TableIntegerAssert.class);
+    this.source = source;
+  }
+
+  @CheckReturnValue
+  public TableAssert<R, C, V> returnToTable() {
+    return source;
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_columnCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_columnCount_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_columnCount_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).columnCount());
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_return_integer_assert() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    AbstractIntegerAssert<?> returnedAssertion = assertion.columnCount();
+    // THEN
+    then(returnedAssertion).isInstanceOf(IntegerAssert.class);
+  }
+
+  @Test
+  void should_hand_over_column_count_as_integer_assert_actual() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    AbstractIntegerAssert<?> returnedAssertion = assertion.columnCount();
+    // THEN
+    then(returnedAssertion.actual()).isEqualTo(3);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.tests.guava.api;
+
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.IntegerAssert;
+import org.assertj.guava.api.TableAssert;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+/**
+ * @author Maciej Kucharczyk
+ */
+class TableAssert_rowCount_Test extends TableAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(actual).rowCount());
+    // THEN
+    then(throwable).isInstanceOf(AssertionError.class)
+                   .hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_return_integer_assert() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    AbstractIntegerAssert<?> returnedAssertion = assertion.rowCount();
+    // THEN
+    then(returnedAssertion).isInstanceOf(IntegerAssert.class);
+  }
+
+  @Test
+  void should_hand_over_row_count_as_integer_assert_actual() {
+    // GIVEN
+    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    // WHEN
+    AbstractIntegerAssert<?> returnedAssertion = assertion.rowCount();
+    // THEN
+    then(returnedAssertion.actual()).isEqualTo(2);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
@@ -13,8 +13,8 @@
 package org.assertj.tests.guava.api;
 
 import org.assertj.core.api.AbstractIntegerAssert;
-import org.assertj.core.api.IntegerAssert;
 import org.assertj.guava.api.TableAssert;
+import org.assertj.guava.api.TableIntegerAssert;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -39,13 +39,14 @@ class TableAssert_rowCount_Test extends TableAssertBaseTest {
   }
 
   @Test
-  void should_return_integer_assert() {
+  void integer_assert_should_return_to_source_table() {
     // GIVEN
-    TableAssert<Integer, Integer, String> assertion = assertThat(actual);
+    TableAssert<Integer, Integer, String> tableAssertion = assertThat(actual);
+    TableIntegerAssert<Integer, Integer, String> rowCountAssertion = tableAssertion.rowCount();
     // WHEN
-    AbstractIntegerAssert<?> returnedAssertion = assertion.rowCount();
+    TableAssert<Integer, Integer, String> returnedAssertion = rowCountAssertion.returnToTable();
     // THEN
-    then(returnedAssertion).isInstanceOf(IntegerAssert.class);
+    then(returnedAssertion).isSameAs(tableAssertion);
   }
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_size_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_size_Test.java
@@ -25,14 +25,14 @@ import static org.assertj.guava.api.Assertions.assertThat;
 /**
  * @author Maciej Kucharczyk
  */
-class TableAssert_columnCount_Test extends TableAssertBaseTest {
+class TableAssert_size_Test extends TableAssertBaseTest {
 
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
     actual = null;
     // WHEN
-    Throwable throwable = catchThrowable(() -> assertThat(actual).columnCount());
+    Throwable throwable = catchThrowable(() -> assertThat(actual).size());
     // THEN
     then(throwable).isInstanceOf(AssertionError.class)
                    .hasMessage(actualIsNull());
@@ -42,19 +42,19 @@ class TableAssert_columnCount_Test extends TableAssertBaseTest {
   void integer_assert_should_return_to_source_table() {
     // GIVEN
     TableAssert<Integer, Integer, String> tableAssertion = assertThat(actual);
-    TableIntegerAssert<Integer, Integer, String> columnCountAssertion = tableAssertion.columnCount();
+    TableIntegerAssert<Integer, Integer, String> sizeAssertion = tableAssertion.size();
     // WHEN
-    TableAssert<Integer, Integer, String> returnedAssertion = columnCountAssertion.returnToTable();
+    TableAssert<Integer, Integer, String> returnedAssertion = sizeAssertion.returnToTable();
     // THEN
     then(returnedAssertion).isSameAs(tableAssertion);
   }
 
   @Test
-  void should_hand_over_column_count_as_integer_assert_actual() {
+  void should_hand_over_size_as_integer_assert_actual() {
     // GIVEN
     TableAssert<Integer, Integer, String> assertion = assertThat(actual);
     // WHEN
-    AbstractIntegerAssert<?> returnedAssertion = assertion.columnCount();
+    AbstractIntegerAssert<?> returnedAssertion = assertion.size();
     // THEN
     then(returnedAssertion.actual()).isEqualTo(3);
   }


### PR DESCRIPTION
Hello,

In this PR, I add two methods that allow for asserting the count of columns and rows:

- `rowCount()`
- `columnCount()`
- `size()`

Related suggestion: https://github.com/assertj/assertj/pull/3606#issuecomment-2351045476

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)