### PR TITLE
Add standard representation for `CharSequence`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -235,6 +235,7 @@ public class StandardRepresentation implements Representation {
     if (object instanceof File) return toStringOf((File) object);
     if (object instanceof Path) return fallbackToStringOf(object);
     if (object instanceof String) return toStringOf((String) object);
+    if (object instanceof CharSequence) return toStringOf((CharSequence) object);
     if (object instanceof Character) return toStringOf((Character) object);
     if (object instanceof Comparator) return toStringOf((Comparator<?>) object);
     if (object instanceof SimpleDateFormat) return toStringOf((SimpleDateFormat) object);
@@ -401,6 +402,10 @@ public class StandardRepresentation implements Representation {
   }
 
   protected String toStringOf(String s) {
+    return toStringOf((CharSequence) s);
+  }
+
+  protected String toStringOf(CharSequence s) {
     return concat("\"", s, "\"");
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -401,12 +401,16 @@ public class StandardRepresentation implements Representation {
     return String.format("local class %s", c.getSimpleName());
   }
 
+  private static String toQuotedString(CharSequence s) {
+    return concat("\"", s, "\"");
+  }
+
   protected String toStringOf(String s) {
-    return toStringOf((CharSequence) s);
+    return toQuotedString(s);
   }
 
   protected String toStringOf(CharSequence s) {
-    return concat("\"", s, "\"");
+    return toQuotedString(s);
   }
 
   protected String toStringOf(Character c) {

--- a/assertj-core/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
@@ -43,14 +43,15 @@ public class UnicodeRepresentation extends StandardRepresentation {
   }
 
   @Override
-  protected String toStringOf(String string) {
+  protected String toStringOf(CharSequence string) {
     return escapeUnicode(string);
   }
 
-  private static String escapeUnicode(String input) {
+  private static String escapeUnicode(CharSequence input) {
     StringBuilder b = new StringBuilder(input.length());
     Formatter formatter = new Formatter(b);
-    for (char c : input.toCharArray()) {
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
       if (c < 128) {
         b.append(c);
       } else {

--- a/assertj-core/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/UnicodeRepresentation.java
@@ -33,6 +33,7 @@ public class UnicodeRepresentation extends StandardRepresentation {
   public String toStringOf(Object object) {
     if (hasCustomFormatterFor(object)) return customFormat(object);
     if (object instanceof String) return toStringOf((String) object);
+    if (object instanceof CharSequence) return toStringOf((CharSequence) object);
     if (object instanceof Character) return toStringOf((Character) object);
     return super.toStringOf(object);
   }
@@ -40,6 +41,11 @@ public class UnicodeRepresentation extends StandardRepresentation {
   @Override
   protected String toStringOf(Character string) {
     return escapeUnicode(string.toString());
+  }
+
+  @Override
+  protected String toStringOf(String string) {
+    return escapeUnicode(string);
   }
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AutoCloseableBDDSoftAssertionsTest.java
@@ -162,7 +162,7 @@ class AutoCloseableBDDSoftAssertionsTest {
       assertThat(errors.get(8)).contains(shouldBeEqualMessage("'C'", "'D'"));
       assertThat(errors.get(9)).contains(shouldBeEqualMessage("['E']", "['F']"));
 
-      assertThat(errors.get(10)).contains(shouldBeEqualMessage("a", "b"));
+      assertThat(errors.get(10)).contains(shouldBeEqualMessage("\"a\"", "\"b\""));
 
       assertThat(errors.get(11)).contains(shouldBeEqualMessage("java.lang.Object", "java.lang.String"));
 

--- a/assertj-core/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/AutoCloseableSoftAssertionsTest.java
@@ -177,7 +177,7 @@ class AutoCloseableSoftAssertionsTest {
       assertThat(errors.get(8)).contains(shouldBeEqualMessage("'C'", "'D'"));
       assertThat(errors.get(9)).contains(shouldBeEqualMessage("['E']", "['F']"));
 
-      assertThat(errors.get(10)).contains(shouldBeEqualMessage("a", "b"));
+      assertThat(errors.get(10)).contains(shouldBeEqualMessage("\"a\"", "\"b\""));
 
       assertThat(errors.get(11)).contains(shouldBeEqualMessage("java.lang.Object", "java.lang.String"));
 

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -294,7 +294,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errors.get(7)).contains(shouldBeEqualMessage("'A'", "'B'"));
     assertThat(errors.get(8)).contains(shouldBeEqualMessage("'C'", "'D'"));
     assertThat(errors.get(9)).contains(shouldBeEqualMessage("['E']", "['F']"));
-    assertThat(errors.get(10)).contains(shouldBeEqualMessage("a", "b"));
+    assertThat(errors.get(10)).contains(shouldBeEqualMessage("\"a\"", "\"b\""));
     assertThat(errors.get(11)).contains(shouldBeEqualMessage("java.lang.Object", "java.lang.String"));
     assertThat(errors.get(12)).contains(shouldBeEqualMessage("1999-12-31T23:59:59.000 (java.util.Date)",
                                                              "2000-01-01T00:00:01.000 (java.util.Date)"));

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -323,7 +323,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
       then(errors.get(8)).contains(shouldBeEqualMessage("'C'", "'D'"));
       then(errors.get(9)).contains(shouldBeEqualMessage("['E']", "['F']"));
 
-      then(errors.get(10)).contains(shouldBeEqualMessage("a", "b"));
+      then(errors.get(10)).contains(shouldBeEqualMessage("\"a\"", "\"b\""));
 
       then(errors.get(11)).contains(shouldBeEqualMessage("java.lang.Object", "java.lang.String"));
 

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
@@ -67,18 +67,6 @@ class ShouldBeEqual_Test {
   }
 
   @Test
-  void should_display_class_for_ambiguous_CharSequence() {
-    // GIVEN
-    CharSequence actual = "test";
-    CharSequence expected = new StringBuilder("test");
-    // WHEN
-    AssertionError error = expectAssertionError(() -> then(actual).isEqualTo(expected));
-    // THEN
-    then(error).hasMessageContainingAll(format("%nexpected: \"\"test\" (StringBuilder"),
-                                        format("%n but was: \"\"test\" (String"));
-  }
-
-  @Test
   void should_display_multiline_values_nicely() {
     // GIVEN
     Xml actual = new Xml("1");

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
@@ -67,6 +67,18 @@ class ShouldBeEqual_Test {
   }
 
   @Test
+  void should_display_class_for_ambiguous_CharSequence() {
+    // GIVEN
+    CharSequence actual = "test";
+    CharSequence expected = new StringBuilder("test");
+    // WHEN
+    AssertionError error = expectAssertionError(() -> then(actual).isEqualTo(expected));
+    // THEN
+    then(error).hasMessageContainingAll(format("%nexpected: \"\"test\" (StringBuilder"),
+      format("%n but was: \"\"test\" (String"));
+  }
+
+  @Test
   void should_display_multiline_values_nicely() {
     // GIVEN
     Xml actual = new Xml("1");
@@ -154,7 +166,7 @@ class ShouldBeEqual_Test {
   }
 
   @Test
-  void should_display_multiline_values_nicely_for_ambiguous_representation_for_ambiguous_representation() {
+  void should_display_multiline_values_nicely_with_comparison_strategy_for_ambiguous_representation() {
     // GIVEN
     Xml actual = new Xml("1");
     XmlDuplicate expected = new XmlDuplicate("1");

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
@@ -75,7 +75,7 @@ class ShouldBeEqual_Test {
     AssertionError error = expectAssertionError(() -> then(actual).isEqualTo(expected));
     // THEN
     then(error).hasMessageContainingAll(format("%nexpected: \"\"test\" (StringBuilder"),
-      format("%n but was: \"\"test\" (String"));
+                                        format("%n but was: \"\"test\" (String"));
   }
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inUnicode_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inUnicode_Test.java
@@ -35,6 +35,15 @@ class Assertions_assertThat_inUnicode_Test {
   }
 
   @Test
+  void should_assert_CharSequence_implementation_in_unicode() {
+    // WHEN
+    CharSequence charSequence = new StringBuilder("abó");
+    AssertionError assertionError = expectAssertionError(() -> assertThat("a6c").inUnicode().isEqualTo(charSequence));
+    // THEN
+    then(assertionError).hasMessage(shouldBeEqualMessage("a6c", "ab\\u00f3"));
+  }
+
+  @Test
   void should_assert_Character_in_unicode() {
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat('o').inUnicode().isEqualTo('ó'));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_toStringOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_toStringOf_Test.java
@@ -105,6 +105,16 @@ class StandardRepresentation_toStringOf_Test extends AbstractBaseRepresentationT
   }
 
   @Test
+  void should_quote_CharSequence_implementation() {
+    // GIVEN
+    CharSequence charSequence = new StringBuilder("Hello");
+    // WHEN
+    String emptyStringStandardRepresentation = STANDARD_REPRESENTATION.toStringOf(charSequence);
+    // THEN
+    then(emptyStringStandardRepresentation).isEqualTo("\"Hello\"");
+  }
+
+  @Test
   void should_return_toString_of_File() {
     // GIVEN
     final String path = "/someFile.txt";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_unambiguousToStringOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_unambiguousToStringOf_Test.java
@@ -76,6 +76,16 @@ class StandardRepresentation_unambiguousToStringOf_Test extends AbstractBaseRepr
   }
 
   @Test
+  void should_quote_CharSequence_implementation() {
+    // GIVEN
+    CharSequence charSequence = new StringBuilder("Hello");
+    // WHEN
+    String unambiguousToString = unambiguousToStringOf(charSequence);
+    // THEN
+    then(unambiguousToString).isEqualTo(format("\"Hello\" (StringBuilder@%s)", toHexString(identityHashCode(charSequence))));
+  }
+
+  @Test
   void should_quote_empty_String() {
     // GIVEN
     String emptyString = "";
@@ -83,6 +93,16 @@ class StandardRepresentation_unambiguousToStringOf_Test extends AbstractBaseRepr
     String unambiguousToString = unambiguousToStringOf(emptyString);
     // THEN
     then(unambiguousToString).isEqualTo(format("\"\" (String@%s)", toHexString(identityHashCode(emptyString))));
+  }
+
+  @Test
+  void should_quote_empty_CharSequence_implementation() {
+    // GIVEN
+    CharSequence emptyCharSequence = new StringBuilder();
+    // WHEN
+    String unambiguousToString = unambiguousToStringOf(emptyCharSequence);
+    // THEN
+    then(unambiguousToString).isEqualTo(format("\"\" (StringBuilder@%s)", toHexString(identityHashCode(emptyCharSequence))));
   }
 
   @Test


### PR DESCRIPTION
Currently `CharSequence` has no special handling in `StandardRepresentation`, so when you accidentally compare a `String` with for example a `StringBuilder` you get something like:
> expected: test
> but was: "test"

This assumes that for custom `CharSequence` types users have overridden `toString`, as required by the `CharSequence` Javadoc. Otherwise it might be a bit confusing that the result is now enclosed in `"`.

#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
