### PR TITLE
Fix Unicode escapes in `inUnicode()` Javadoc

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharArrayAssert.java
@@ -820,7 +820,7 @@ public abstract class AbstractCharArrayAssert<SELF extends AbstractCharArrayAsse
    * <pre><code class='java'> assertThat("a6c".toCharArray()).inUnicode().isEqualTo("abó".toCharArray());
    *
    * org.junit.ComparisonFailure:
-   * Expected :[a, b, \u00f3]
+   * Expected :[a, b, &bsol;u00f3]
    * Actual   :[a, 6, c]</code></pre>
    *
    * @return {@code this} assertion object.

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -1553,9 +1553,9 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * java.lang.AssertionError:
    * Expecting:
-   *   &lt;\u00b5\u00b5\u00b5&gt;
+   *   &lt;&bsol;u00b5&bsol;u00b5&bsol;u00b5&gt;
    * to contain:
-   *   &lt;\u03bc\u03bc\u03bc&gt;</code></pre>
+   *   &lt;&bsol;u03bc&bsol;u03bc&bsol;u03bc&gt;</code></pre>
    *
    * @return {@code this} assertion object.
    */

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharacterAssert.java
@@ -169,8 +169,8 @@ public abstract class AbstractCharacterAssert<SELF extends AbstractCharacterAsse
    * <pre><code class='java'> assertThat('µ').inUnicode().isEqualTo('μ');
    *
    * org.junit.ComparisonFailure:
-   * Expected :\u03bc
-   * Actual   :\u00b5</code></pre>
+   * Expected :&bsol;u03bc
+   * Actual   :&bsol;u00b5</code></pre>
    *
    * @return {@code this} assertion object.
    */

--- a/assertj-core/src/main/java/org/assertj/core/api/Char2DArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Char2DArrayAssert.java
@@ -329,7 +329,7 @@ public class Char2DArrayAssert extends Abstract2DArrayAssert<Char2DArrayAssert, 
    * Expecting actual[1][0] value to be equal to:
    *  &lt;c&gt;
    * but was
-   *  &lt;\u0107&gt;</code></pre>
+   *  &lt;&bsol;0107&gt;</code></pre>
    *
    * @return {@code this} assertion object.
    */


### PR DESCRIPTION
They are already processed by the Java compiler, so previously instead of the Unicode escape the corresponding character was shown.

See for example [`AbstractCharacterAssert#inUnicode()` Javadoc](https://javadoc.io/doc/org.assertj/assertj-core/latest/org/assertj/core/api/AbstractCharacterAssert.html#inUnicode()):
![Javadoc screenshot](https://github.com/user-attachments/assets/b3e82764-fb34-42e3-b3b7-482dcab1a85f)
Notice how it does not show the Unicode escape.

I chose the HTML character reference `&bsol;` as replacement for `\`, but other approaches might work as well.

#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
