### PR TITLE
Feature/3636 Add indexing to hasFieldOrPropertyWithValue

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -662,6 +662,8 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * <p>
    * Private fields are matched by default but this can be changed by calling {@link Assertions#setAllowExtractingPrivateFields(boolean) Assertions.setAllowExtractingPrivateFields(false)}.
    * <p>
+   * For convenience, arrays and {@code List} fields or properties can be indexed using 'name[index]' (since 3.26.4).
+   * <p>
    * If you are looking to chain multiple assertions on different properties in a type safe way, consider chaining
    * {@link #returns(Object, Function)} and {@link #doesNotReturn(Object, Function)} calls.
    * <p>
@@ -669,19 +671,27 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * <pre><code class='java'> public class TolkienCharacter {
    *   private String name;
    *   private int age;
+   *   private List<TolkienCharacter> friends;
    *   // constructor omitted
    *
    *   public String getName() {
    *     return this.name;
    *   }
+   *
+   *   public void addFriend(TolkienCharacter character) {
+   *     friends.add(character);
+   *   }
    * }
    *
    * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33);
+   * TolkienCharacter sam = new TolkienCharacter("Sam", 34);
+   * frodo.addFriend(sam);
    * TolkienCharacter noname = new TolkienCharacter(null, 33);
    *
    * // assertions will pass :
    * assertThat(frodo).hasFieldOrPropertyWithValue("name", "Frodo");
    * assertThat(frodo).hasFieldOrPropertyWithValue("age", 33);
+   * assertThat(frodo).hasFieldOrPropertyWithValue("friends[0]", sam);
    * assertThat(noname).hasFieldOrPropertyWithValue("name", null);
    *
    * // assertions will fail :
@@ -697,6 +707,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @param value the field/property expected value
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual object is {@code null}.
+   * @throws AssertionError if using an index that is out of bounds.
    * @throws IllegalArgumentException if name is {@code null}.
    * @throws AssertionError if the actual object does not have the given field/property
    * @throws AssertionError if the actual object has the given field/property but not with the expected value

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -671,7 +671,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * <pre><code class='java'> public class TolkienCharacter {
    *   private String name;
    *   private int age;
-   *   private List<TolkienCharacter> friends;
+   *   private List&lt;TolkienCharacter&gt; friends;
    *   // constructor omitted
    *
    *   public String getName() {

--- a/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
@@ -54,7 +54,9 @@ public class PropertyOrFieldSupport {
 
     if (isNested(propertyOrFieldName)) {
       String firstPropertyName = popNameFrom(propertyOrFieldName);
-      Object propertyOrFieldValue = getSimpleValue(firstPropertyName, input);
+      // extract with or without and index
+      Object propertyOrFieldValue = hasIndex(firstPropertyName) ? getArrayOrListValue(firstPropertyName, input)
+          : getSimpleValue(firstPropertyName, input);
       // when one of the intermediate nested property/field value is null, return null
       if (propertyOrFieldValue == null) return null;
       // extract next sub-property/field value until reaching the last sub-property/field

--- a/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
@@ -15,6 +15,7 @@ package org.assertj.core.util.introspection;
 import static java.lang.String.format;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,6 +23,8 @@ import org.assertj.core.util.VisibleForTesting;
 
 public class PropertyOrFieldSupport {
   private static final String SEPARATOR = ".";
+  private static final String ARRAY_INDEX_START = "[";
+  private static final String ARRAY_INDEX_END = "]";
   private PropertySupport propertySupport;
   private FieldSupport fieldSupport;
 
@@ -58,6 +61,9 @@ public class PropertyOrFieldSupport {
       return getValueOf(nextNameFrom(propertyOrFieldName), propertyOrFieldValue);
     }
 
+    // we get property/field without the index
+    if (hasIndex(propertyOrFieldName)) return getArrayOrListValue(propertyOrFieldName, input);
+
     return getSimpleValue(propertyOrFieldName, input);
   }
 
@@ -93,6 +99,40 @@ public class PropertyOrFieldSupport {
     }
   }
 
+  @SuppressWarnings("rawtypes")
+  public Object getArrayOrListValue(String name, Object input) {
+    // we could still have a map that has 'name[indexvalue]' as an actual key so we fall back
+    // to getSimpleValue
+    String listOrArrayName = extractNameFrom(name);
+    try {
+      Object arrayOrList = getSimpleValue(listOrArrayName, input);
+      if (arrayOrList == null) return null;
+      int listOrArrayIndex = extractIndexFrom(name);
+      if (arrayOrList instanceof List)
+        return ((List) arrayOrList).get(listOrArrayIndex);
+      else if (arrayOrList instanceof Object[])
+        return ((Object[]) arrayOrList)[listOrArrayIndex];
+      else {
+        return getSimpleValue(name, input);
+      }
+    } catch (NumberFormatException e) {
+      String message = format("%nCould not parse the index of a list or array in name '%s'.%n" +
+                              "Parsing error was: %n" +
+                              "- %s%n",
+                              name,
+                              e.getMessage());
+      throw new IntrospectionError(message, e);
+    } catch (IndexOutOfBoundsException e) {
+      String message = format("%nIndex out of bounds when accessing name '%s':%n" +
+                              "- %s",
+                              name,
+                              e.getMessage());
+      throw new IntrospectionError(message, e);
+    } catch (IntrospectionError e) {
+      return getSimpleValue(name, input);
+    }
+  }
+
   private String popNameFrom(String propertyOrFieldNameChain) {
     if (!isNested(propertyOrFieldNameChain)) return propertyOrFieldNameChain;
     return propertyOrFieldNameChain.substring(0, propertyOrFieldNameChain.indexOf(SEPARATOR));
@@ -107,6 +147,24 @@ public class PropertyOrFieldSupport {
     return propertyOrFieldName.contains(SEPARATOR)
            && !propertyOrFieldName.startsWith(SEPARATOR)
            && !propertyOrFieldName.endsWith(SEPARATOR);
+  }
+
+  private boolean hasIndex(String propertyOrFieldName) {
+    return propertyOrFieldName.contains(ARRAY_INDEX_START)
+           && propertyOrFieldName.contains(ARRAY_INDEX_END)
+           && propertyOrFieldName.indexOf(ARRAY_INDEX_START) < propertyOrFieldName.indexOf(ARRAY_INDEX_END);
+  }
+
+  private String extractNameFrom(String propertyOrFieldNameWithIndex) {
+    int start = propertyOrFieldNameWithIndex.indexOf(ARRAY_INDEX_START);
+    return propertyOrFieldNameWithIndex.substring(0, start);
+  }
+
+  private int extractIndexFrom(String propertyOrFieldNameWithIndex) {
+    int start = propertyOrFieldNameWithIndex.indexOf(ARRAY_INDEX_START) + ARRAY_INDEX_START.length();
+    int end = propertyOrFieldNameWithIndex.indexOf(ARRAY_INDEX_END);
+    String indexAsString = propertyOrFieldNameWithIndex.substring(start, end);
+    return Integer.parseInt(indexAsString);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
@@ -20,6 +20,9 @@ import static org.assertj.core.testkit.TestData.someInfo;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ObjectsBaseTest;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,22 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
     Object actual = new Data();
     // WHEN/THEN
     objects.assertHasFieldOrPropertyWithValue(INFO, actual, "field3", "bar");
+  }
+
+  @Test
+  void should_pass_if_actual_has_expected_list_field_and_value_with_index() {
+    // GIVEN
+    Object actual = new Data();
+    // WHEN/THEN
+    objects.assertHasFieldOrPropertyWithValue(INFO, actual, "listField[0]", "bar");
+  }
+
+  @Test
+  void should_pass_if_actual_has_expected_array_field_and_value_with_index() {
+    // GIVEN
+    Object actual = new Data();
+    // WHEN/THEN
+    objects.assertHasFieldOrPropertyWithValue(INFO, actual, "arrayField[0]", "baz");
   }
 
   @Test
@@ -102,7 +121,13 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
 
     private Object field1 = "foo";
     private Object field2;
+    private List<String> listField = new ArrayList<String>(1);
+    private String[] arrayField = new String[] { "baz" };
     private static Object staticField;
+
+    public Data() {
+       listField.add("bar");
+    }
 
     @Override
     public String toString() {

--- a/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
@@ -126,7 +126,7 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
     private static Object staticField;
 
     public Data() {
-       listField.add("bar");
+      listField.add("bar");
     }
 
     @Override

--- a/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
+++ b/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.testkit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Object to test hasFieldOrPropertyWithValue accepting arrays/lists
+ * 
+ * @author Daniel Giribet Farre
+ */
+public class Office {
+
+  public List<Employee> employees = new ArrayList<Employee>();
+  public Employee[] employeesArray = new Employee[] {};
+  public String description = "This is an office";
+
+  public void addEmployee(Employee employee) {
+    employees.add(employee);
+  }
+
+  public void addEmployees(Iterable<Employee> employeesToAdd) {
+    employeesToAdd.forEach(employees::add);
+    employeesArray = employees.toArray(new Employee[] {});
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
+++ b/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
@@ -45,7 +45,8 @@ public class Office {
 
   @Override
   public String toString() {
-    return format("%s[desc=%s, employees=%s, employeesArray=%s, nearby=%s]", description, employees, employeesArray,
+    return format("%s[desc=%s, employees=%s, employeesArray=%s, nearby=%s]", getClass().getSimpleName(), description, employees,
+                  employeesArray,
                   nearbyOffices);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
+++ b/assertj-core/src/test/java/org/assertj/core/testkit/Office.java
@@ -12,7 +12,10 @@
  */
 package org.assertj.core.testkit;
 
-import java.util.ArrayList;
+import static org.assertj.core.util.Lists.newArrayList;
+import static java.lang.String.format;
+import static org.assertj.core.util.Arrays.array;
+
 import java.util.List;
 
 /*
@@ -22,9 +25,10 @@ import java.util.List;
  */
 public class Office {
 
-  public List<Employee> employees = new ArrayList<Employee>();
-  public Employee[] employeesArray = new Employee[] {};
   public String description = "This is an office";
+  public List<Employee> employees = newArrayList();
+  public Employee[] employeesArray = array();
+  public List<Office> nearbyOffices = newArrayList();
 
   public void addEmployee(Employee employee) {
     employees.add(employee);
@@ -33,6 +37,16 @@ public class Office {
   public void addEmployees(Iterable<Employee> employeesToAdd) {
     employeesToAdd.forEach(employees::add);
     employeesArray = employees.toArray(new Employee[] {});
+  }
+
+  public void addNearbyOffice(Office office) {
+    nearbyOffices.add(office);
+  }
+
+  @Override
+  public String toString() {
+    return format("%s[desc=%s, employees=%s, employeesArray=%s, nearby=%s]", description, employees, employeesArray,
+                  nearbyOffices);
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getArrayOrListValueOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getArrayOrListValueOf_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.util.introspection;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import org.assertj.core.testkit.Employee;
+import org.assertj.core.testkit.Name;
+import org.assertj.core.testkit.Office;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/*
+ * @author DAniel Giribet Farre
+ */
+public class PropertyOrFieldSupport_getArrayOrListValueOf_Test {
+
+  private final PropertyOrFieldSupport underTest = PropertyOrFieldSupport.EXTRACTION;
+  private final Employee yoda = new Employee(1L, new Name("Yoda"), 800);
+  private final Employee luke = new Employee(3L, new Name("Luke", "Skywalker"), 24);
+  private final Office office = new Office();
+
+  @BeforeEach
+  void setup() {
+    office.addEmployees(newArrayList(yoda, luke));
+  }
+
+  @Test
+  void should_throw_error_when_index_is_empty() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.getArrayOrListValue("employees[]", office));
+    // THEN
+    then(thrown).isInstanceOf(IntrospectionError.class);
+  }
+
+  @Test
+  void should_throw_error_when_index_is_not_a_number() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.getArrayOrListValue("employees[foo]", office));
+    // THEN
+    then(thrown).isInstanceOf(IntrospectionError.class);
+  }
+
+  @Test
+  void should_throw_error_when_index_is_out_of_bounds() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.getArrayOrListValue("employees[2]", office));
+    // THEN
+    then(thrown).isInstanceOf(IntrospectionError.class);
+  }
+
+  @Test
+  void should_throw_error_when_index_is_negative() {
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.getArrayOrListValue("employees[-1]", office));
+    // THEN
+    then(thrown).isInstanceOf(IntrospectionError.class);
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getArrayOrListValueOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getArrayOrListValueOf_Test.java
@@ -22,8 +22,8 @@ import org.assertj.core.testkit.Office;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
- * @author DAniel Giribet Farre
+/**
+ * @author Daniel Giribet Farre
  */
 public class PropertyOrFieldSupport_getArrayOrListValueOf_Test {
 

--- a/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
@@ -35,7 +35,7 @@ class PropertyOrFieldSupport_getValueOf_Test {
   private final PropertyOrFieldSupport underTest = PropertyOrFieldSupport.EXTRACTION;
   private final Employee yoda = new Employee(1L, new Name("Yoda"), 800);
   private final Employee luke = new Employee(3L, new Name("Luke", "Skywalker"), 24);
-  private final Employee han = new Employee(3L, new Name("Han"), 31); 
+  private final Employee han = new Employee(3L, new Name("Han"), 31);
   private final Office office = new Office();
   private final Office officeNearby = new Office();
 
@@ -262,7 +262,6 @@ class PropertyOrFieldSupport_getValueOf_Test {
     then(value).isEqualTo(han);
   }
 
-
   @Test
   void should_extract_property_value_with_index_if_array() {
     // WHEN
@@ -303,7 +302,6 @@ class PropertyOrFieldSupport_getValueOf_Test {
     then(value).isEqualTo(yoda);
   }
 
-  
   @Test
   void should_extract_single_value_from_maps_by_key_and_index_when_value_is_array() {
     // GIVEN


### PR DESCRIPTION
#### Check List:
* Adds convenience feature to `hasFieldOrPropertyWithValue` #3513
* Unit tests : YES ✅
* Javadoc with a code example (on API only) : YES ✅
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md): YES ✅ (to the best of my knowledge)

With this PR we can do something like `hasFieldOrPropertyWithValue("users[0].username", "foo")` for convenience.  This is consistent, backwards-compatible and reflects intuitive usage, given `[ or ]` are not valid field or property names in Java. Note that the implementation does what is expected when using maps, including maps with keys like `foo[0]`.

#### Done
- Made necessary changes, and expanded javadoc example on API
- Added new test files and test cases, including nesting
- Covered 2/2 map edge cases
- Ran the code formatter
- Though did not change any nesting code, add some tests on that for sanity checking, to check something like `foo.bar[0]`
- Use convenience methods in `utils.Arrays` and `utils.Lists`

#### Open to interpretation/discussion
- Could throw number format or index out of bounds exceptions as opposed to `AssertionError` (current behaviour)

#### Todo
- Nothing yet, but could add more sanity check tests?
- Not sure if need to add new authorship entries to modified files or just new ones?
- If accepted, then add examples to the examples project

#### Did not do:
- Did not add further tests to ObjectAssert_hasFieldOrPropertyWithValue_Test , NavigationMethodBaseTest, RecursiveAssertionAssert_* since I'm not clear on the scope of those test files.



#### Notes
This is part of hacktoberfest.
Note that there are two edge cases
- Maps that have `users[0]` as a key name (supported)
- Maps that have `users` as key name that is an array or list (also supported)


```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for AssertJ Build 3.26.4-SNAPSHOT:
[INFO] 
[INFO] AssertJ Build ...................................... SUCCESS [  0.046 s]
[INFO] AssertJ (Bill of Materials) ........................ SUCCESS [  0.102 s]
[INFO] AssertJ Parent ..................................... SUCCESS [  0.000 s]
[INFO] AssertJ Core ....................................... SUCCESS [ 39.077 s]
[INFO] AssertJ Guava ...................................... SUCCESS [  0.044 s]
[INFO] AssertJ Tests ...................................... SUCCESS [  0.040 s]
[INFO] AssertJ Integration Tests .......................... SUCCESS [  0.002 s]
[INFO] AssertJ Core Integration Tests (JUnit 4 and opentest4j) SUCCESS [  0.750 s]
[INFO] AssertJ Core Integration Tests (Kotlin) ............ SUCCESS [  4.289 s]
[INFO] AssertJ Core Integration Tests (OSGi) .............. SUCCESS [  0.170 s]
[INFO] AssertJ Core Integration Tests (Spring Boot) ....... SUCCESS [  3.358 s]
[INFO] AssertJ Core Integration Tests (TestNG and JUnit 4)  SUCCESS [  0.945 s]
[INFO] AssertJ Core Tests ................................. SUCCESS [  5.471 s]
[INFO] AssertJ Guava Integration Tests .................... SUCCESS [  0.956 s]
[INFO] AssertJ Core Integration Tests (Groovy) ............ SUCCESS [  1.398 s]
[INFO] AssertJ Performance Tests .......................... SUCCESS [  0.536 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  57.888 s
[INFO] Finished at: 2024-10-13T19:06:02+02:00
[INFO] ------------------------------------------------------------------------
```