### PR TITLE
Add predicate descriptions overloads to anyMatch and noneMatch

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -3848,6 +3848,15 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF anyMatch(Predicate<? super ELEMENT> predicate, String predicateDescription) {
+    iterables.assertAnyMatch(info, actual, predicate, new PredicateDescription(predicateDescription));
+    return myself;
+  }
+
+  /**
    * Verifies that the zipped pairs of actual and other elements, i.e: (actual 1st element, other 1st element), (actual 2nd element, other 2nd element), ...
    * all satisfy the given {@code zipRequirements}.
    * <p>
@@ -4149,6 +4158,12 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   @Override
   public SELF noneMatch(Predicate<? super ELEMENT> predicate) {
     iterables.assertNoneMatch(info, actual, predicate, PredicateDescription.GIVEN);
+    return myself;
+  }
+
+  @Override
+  public SELF noneMatch(Predicate<? super ELEMENT> predicate, String predicateDescription) {
+    iterables.assertNoneMatch(info, actual, predicate, new PredicateDescription(predicateDescription));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3388,6 +3388,15 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF anyMatch(Predicate<? super ELEMENT> predicate, String predicateDescription) {
+    iterables.assertAnyMatch(info, newArrayList(actual), predicate, new PredicateDescription(predicateDescription));
+    return myself;
+  }
+
+  /**
    * Verifies that the zipped pairs of actual and other elements, i.e: (actual 1st element, other 1st element), (actual 2nd element, other 2nd element), ...
    * all satisfy the given {@code zipRequirements}.
    * <p>
@@ -3910,6 +3919,15 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   @Override
   public SELF noneMatch(Predicate<? super ELEMENT> predicate) {
     iterables.assertNoneMatch(info, newArrayList(actual), predicate, PredicateDescription.GIVEN);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF noneMatch(Predicate<? super ELEMENT> predicate, String predicateDescription) {
+    iterables.assertNoneMatch(info, newArrayList(actual), predicate, new PredicateDescription(predicateDescription));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -3469,6 +3469,15 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> anyMatch(Predicate<? super T> predicate, String predicateDescription) {
+    iterables.assertAnyMatch(info, newArrayList(array), predicate, new PredicateDescription(predicateDescription));
+    return myself;
+  }
+
+  /**
    * Verifies that at least one element satisfies the given requirements expressed as a {@link Consumer}.
    * <p>
    * This is useful to check that a group of assertions is verified by (at least) one element.
@@ -3980,6 +3989,15 @@ public class AtomicReferenceArrayAssert<T>
   @Override
   public AtomicReferenceArrayAssert<T> noneMatch(Predicate<? super T> predicate) {
     iterables.assertNoneMatch(info, newArrayList(array), predicate, PredicateDescription.GIVEN);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> noneMatch(Predicate<? super T> predicate, String predicateDescription) {
+    iterables.assertNoneMatch(info, newArrayList(array), predicate, new PredicateDescription(predicateDescription));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1626,6 +1626,34 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF anyMatch(Predicate<? super ELEMENT> predicate);
 
   /**
+   * Verifies whether any elements match the provided {@link Predicate}. The predicate description is used
+   * to get an informative error message.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
+   *
+   * // assertion will pass
+   * assertThat(abcc).anyMatch(s -&gt; s.length() == 2, "length of 2");
+   *
+   * // assertion will fail
+   * assertThat(abcc).anyMatch(s -&gt; s.length() &gt; 2, "length greater than 2);</code></pre>
+   *
+   * The message of the failed assertion would be:
+   * <pre><code class='java'>Expecting any elements of:
+   *  &lt;["a", "b", "cc"]&gt;
+   *  to match 'length greater than 2' predicate but none did.</code></pre>
+   *
+   *
+   * @param predicate the given {@link Predicate}.
+   * @param predicateDescription a description of the {@link Predicate} used in the error message
+   * @return {@code this} object.
+   * @throws NullPointerException if the given predicate is {@code null}.
+   * @throws AssertionError if no elements satisfy the given predicate.
+   * @since 3.27.0
+   */
+  SELF anyMatch(Predicate<? super ELEMENT> predicate, String predicateDescription);
+
+  /**
    * Verifies that at least one element satisfies the given requirements expressed as a {@link Consumer}.
    * <p>
    * This is useful to check that a group of assertions is verified by (at least) one element.
@@ -1821,4 +1849,33 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @since 3.9.0
    */
   SELF noneMatch(Predicate<? super ELEMENT> predicate);
+
+  /**
+   * Verifies that no elements match the given {@link Predicate}. The predicate description is used
+   * to get an informative error message.
+   * <p>
+   * Example :
+   * <pre><code class='java'> Iterable&lt;String&gt; abcc = newArrayList("a", "b", "cc");
+   *
+   * // assertion will pass
+   * assertThat(abcc).noneMatch(s -&gt; s.isEmpty(), "is empty");
+   *
+   * // assertion will fail
+   * assertThat(abcc).noneMatch(s -&gt; s.length() == 2, "length of 2");</code></pre>
+   *
+   * The message of the failed assertion would be:
+   * <pre><code class='java'>Expecting no elements of:
+   *  &lt;["a", "b", "cc"]&gt;
+   *  to match 'length of 2' predicate but this element did:
+   *  &lt;"cc"&gt;</code></pre>
+   *
+   *
+   * @param predicate the given {@link Predicate}.
+   * @param predicateDescription a description of the {@link Predicate} used in the error message
+   * @return {@code this} object.
+   * @throws NullPointerException if the given predicate is {@code null}.
+   * @throws AssertionError if any elements satisfy the given predicate.
+   * @since 3.27.0
+   */
+  SELF noneMatch(Predicate<? super ELEMENT> predicate, String predicateDescription);
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_anyMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_anyMatch_with_description_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+class AtomicReferenceArrayAssert_anyMatch_with_description_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.anyMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertAnyMatch(info(), newArrayList(internalArray()), predicate,
+                                     new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_noneMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_noneMatch_with_description_Test.java
@@ -39,6 +39,6 @@ class AtomicReferenceArrayAssert_noneMatch_with_description_Test extends AtomicR
   @Override
   protected void verify_internal_effects() {
     verify(iterables).assertNoneMatch(info(), newArrayList(internalArray()), predicate,
-                                     new PredicateDescription("custom"));
+                                      new PredicateDescription("custom"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_noneMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_noneMatch_with_description_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+class AtomicReferenceArrayAssert_noneMatch_with_description_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.noneMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertNoneMatch(info(), newArrayList(internalArray()), predicate,
+                                     new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_anyMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_anyMatch_with_description_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+class IterableAssert_anyMatch_with_description_Test extends IterableAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.anyMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables)
+                     .assertAnyMatch(getInfo(assertions), getActual(assertions), predicate, new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_noneMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_noneMatch_with_description_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.mockito.Mockito.verify;
+
+class IterableAssert_noneMatch_with_description_Test extends IterableAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.noneMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables)
+                     .assertNoneMatch(getInfo(assertions), getActual(assertions), predicate, new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_anyMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_anyMatch_with_description_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+class ObjectArrayAssert_anyMatch_with_description_Test extends ObjectArrayAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.anyMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertAnyMatch(getInfo(assertions), newArrayList(getActual(assertions)), predicate,
+                                     new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_noneMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_noneMatch_with_description_Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+import org.assertj.core.presentation.PredicateDescription;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+class ObjectArrayAssert_noneMatch_with_description_Test extends ObjectArrayAssertBaseTest {
+
+  private Predicate<Object> predicate;
+
+  @BeforeEach
+  void beforeOnce() {
+    predicate = o -> o != null;
+  }
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.noneMatch(predicate, "custom");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertNoneMatch(getInfo(assertions), newArrayList(getActual(assertions)), predicate,
+                                     new PredicateDescription("custom"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_noneMatch_with_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_noneMatch_with_description_Test.java
@@ -39,6 +39,6 @@ class ObjectArrayAssert_noneMatch_with_description_Test extends ObjectArrayAsser
   @Override
   protected void verify_internal_effects() {
     verify(iterables).assertNoneMatch(getInfo(assertions), newArrayList(getActual(assertions)), predicate,
-                                     new PredicateDescription("custom"));
+                                      new PredicateDescription("custom"));
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #3638 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) : I think so!

Hopefully fairly self explanatory. Happy to make any necessary changes. Not sure how to calculate the `@since` field on the Javadoc, so took a guess at the next minor version.