### PR TITLE
hasFieldOrPropertyWithValue with getters throwing exception #3563

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.util.Preconditions.checkNotNullOrEmpty;
 import static org.assertj.core.util.Strings.quote;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
@@ -69,6 +70,10 @@ public final class Introspection {
       // force access for static class with public getter
       getter.setAccessible(true);
       getter.invoke(target);
+    } catch (InvocationTargetException ex) {
+      String message = String.format("Unable to invoke getter %s in %s, exception: %s",
+                                     getter.getName(), target.getClass().getSimpleName(), ex.getTargetException());
+      throw new IntrospectionError(message, ex, ex.getTargetException());
     } catch (Exception t) {
       throw new IntrospectionError(propertyNotFoundErrorMessage("Unable to find property %s in %s", propertyName, target), t);
     }

--- a/assertj-core/src/main/java/org/assertj/core/util/introspection/IntrospectionError.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/introspection/IntrospectionError.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.util.introspection;
 
+import java.util.Optional;
+
 /**
  * Error that occurred when using <a href="http://java.sun.com/docs/books/tutorial/javabeans/introspection/index.html">JavaBeans
  * Introspection</a>.
@@ -23,11 +25,19 @@ public class IntrospectionError extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   /**
+   * This (nullable) field holds the original Exception thrown by the tested code
+   * during the invocation of a getter/accessor method. This allows us to reference
+   * or rethrow it if alternative means of resolving the field are unsuccessful.
+   */
+  private final Throwable getterInvocationException;
+
+  /**
    * Creates a new <code>{@link IntrospectionError}</code>.
    * @param message the detail message.
    */
   public IntrospectionError(String message) {
     super(message);
+    this.getterInvocationException = null;
   }
 
   /**
@@ -36,6 +46,21 @@ public class IntrospectionError extends RuntimeException {
    * @param cause the original cause.
    */
   public IntrospectionError(String message, Throwable cause) {
+    this(message, cause, null);
+  }
+
+  /**
+   * Creates a new <code>{@link IntrospectionError}</code>.
+   * @param message the detail message.
+   * @param cause the original cause.
+   * @param getterInvocationException the original exception thrown by the tested code.
+   */
+  public IntrospectionError(String message, Throwable cause, Throwable getterInvocationException) {
     super(message, cause);
+    this.getterInvocationException = getterInvocationException;
+  }
+
+  public Optional<Throwable> getterInvocationException() {
+    return Optional.ofNullable(getterInvocationException);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/introspection/PropertyOrFieldSupport.java
@@ -80,6 +80,12 @@ public class PropertyOrFieldSupport {
           if (map.containsKey(name)) return map.get(name);
         }
 
+        // if the getter invocation throws exception and there's no field present,
+        // we'll propagate the IntrospectionError containing the original exception
+        if (propertyIntrospectionError.getterInvocationException().isPresent()) {
+          throw propertyIntrospectionError;
+        }
+
         // no value found with given name, it is considered as an error
         String message = format("%nCan't find any field or property with name '%s'.%n" +
                                 "Error when introspecting properties was :%n" +

--- a/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.internal.objects;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.error.ShouldHavePropertyOrField.shouldHavePropertyOrField;
 import static org.assertj.core.error.ShouldHavePropertyOrFieldWithValue.shouldHavePropertyOrFieldWithValue;
 import static org.assertj.core.test.TestData.someInfo;
@@ -21,6 +20,8 @@ import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.ObjectsBaseTest;
 import org.junit.jupiter.api.Test;
 
@@ -107,18 +108,16 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
   }
 
   @Test
-  void should_fail_if_getters_throws_exception_and_field_is_missing() {
+  void should_rethrow_getter_exception_if_field_is_missing() {
     // GIVEN
     Object actual = new Data();
     String fieldName = "unknownFieldWithGetterThrowing";
     // WHEN
-    AssertionError error = expectAssertionError(() -> objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "foo"));
+    ThrowingCallable test = () -> objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "foo");
     // THEN
-    assertThat(error)
-                     .isInstanceOf(AssertionError.class)
-                     .hasMessageContainingAll(
-                                              "Expecting",
-                                              "to have a property or a field named \"unknownFieldWithGetterThrowing\"");
+    assertThatThrownBy(test)
+                            .isInstanceOf(RuntimeException.class)
+                            .hasMessage("some dummy exception");
   }
 
   @SuppressWarnings("unused")

--- a/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrPropertyWithValue_Test.java
@@ -97,11 +97,36 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
                                         .withMessage("The name of the property/field to read should not be null");
   }
 
+  @Test
+  void should_use_field_if_getters_throws_exception() {
+    // GIVEN
+    Object actual = new Data();
+    String fieldName = "fieldWithGetterThrowing";
+    // WHEN/THEN
+    objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "dummy");
+  }
+
+  @Test
+  void should_fail_if_getters_throws_exception_and_field_is_missing() {
+    // GIVEN
+    Object actual = new Data();
+    String fieldName = "unknownFieldWithGetterThrowing";
+    // WHEN
+    AssertionError error = expectAssertionError(() -> objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "foo"));
+    // THEN
+    assertThat(error)
+                     .isInstanceOf(AssertionError.class)
+                     .hasMessageContainingAll(
+                                              "Expecting",
+                                              "to have a property or a field named \"unknownFieldWithGetterThrowing\"");
+  }
+
   @SuppressWarnings("unused")
   private static class Data {
 
     private Object field1 = "foo";
     private Object field2;
+    private Object fieldWithGetterThrowing = "dummy";
     private static Object staticField;
 
     @Override
@@ -113,5 +138,12 @@ class Objects_assertHasFieldOrPropertyWithValue_Test extends ObjectsBaseTest {
       return "bar";
     }
 
+    public Object getUnknownFieldWithGetterThrowing() {
+      throw new RuntimeException("some dummy exception");
+    }
+
+    public Object getFieldWithGetterThrowing() {
+      return fieldWithGetterThrowing;
+    }
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrProperty_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objects/Objects_assertHasFieldOrProperty_Test.java
@@ -13,11 +13,11 @@
 package org.assertj.core.internal.objects;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.ObjectsBaseTest;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.error.ShouldHavePropertyOrField.shouldHavePropertyOrField;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
@@ -95,18 +95,16 @@ class Objects_assertHasFieldOrProperty_Test extends ObjectsBaseTest {
   }
 
   @Test
-  void should_fail_if_getters_throws_exception_and_field_is_missing() {
+  void should_rethrow_getter_exception_if_field_is_missing() {
     // GIVEN
     Object actual = new Data();
     String fieldName = "unknownFieldWithGetterThrowing";
     // WHEN
-    AssertionError error = expectAssertionError(() -> objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "foo"));
+    ThrowingCallable test = () -> objects.assertHasFieldOrPropertyWithValue(INFO, actual, fieldName, "foo");
     // THEN
-    assertThat(error)
-                     .isInstanceOf(AssertionError.class)
-                     .hasMessageContainingAll(
-                                              "Expecting",
-                                              "to have a property or a field named \"unknownFieldWithGetterThrowing\"");
+    assertThatThrownBy(test)
+                            .isInstanceOf(RuntimeException.class)
+                            .hasMessage("some dummy exception");
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
#### Overview

Current behavior for _hasFieldOrPropertyWithValue_ / _hasFieldOrProperty_ 
- we try to invoke the getter/accessor
- if not present **or if it throws an exception** we verify the field directly 
- even if the field is missing, the original exception is swallowed 

As discussed in #3563, we want to keep using the field verification as a fallback in case the getter invocation fails.
However, if the field is missing, we want to rethrow the original exception raised by the getter.

#### About the PR

- In the first commit, I've added some tests for the current behavior of the lib
- The 2nd commit updates 2 of the tests to reflect the new desired behavior (failing test)
- In 3rd commit we have the actual code changes

- In `Objects::assertHasFieldOrProperty` we can decide if we want to throw the original getter exception as a runtime (This would be similar to what happens when something like _.extracting(...)_ throws an exception). Alternatively, we can wrap it within an `AssertionError` with a custom message.

#### Check List:
* Fixes #3563 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
