### PR TITLE
Add assertions for Paths/Files/InputStreams to validate the encoding

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -46,6 +46,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Valeriy Vyrva
  * @author Nikolaos Georgiou
  * @author Rostyslav Ivankiv
+ * @author Ludovic VIEGAS
  */
 public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> extends AbstractAssert<SELF, File> {
 
@@ -835,6 +836,86 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    */
   public SELF hasNoParent() {
     files.assertHasNoParent(info, actual);
+    return myself;
+  }
+
+  /**
+   * Synonyme of {@link #isEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the expected encoding of the actual file.
+   * @return {@code this} assertion object.
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset) {
+    return isEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the content of the actual {@code File} contains only characters valid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // A file with text encoded in UTF-8
+   * File aFile = Files.write(Paths.get("a-file.txt"), "éèàû".getBytes(UTF-8)).toFile();
+   *
+   * // The following assertion succeeds:
+   * assertThat(aFile).isEncodedIn(UTF-8);
+   *
+   * // The following assertion fails:
+   * assertThat(aFile).isEncodedIn(ISO_8859_1);
+   * }</pre>
+   *
+   * @param charset the expected encoding of the actual file.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the replacement character, which can be a sign of a previous wrong encoding operation.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws AssertionError if the content of the actual {@code File} contains characters invalid in the specified {@code Charset}.
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset, boolean lenient) {
+    files.assertIsEncodedIn(info, actual, charset, lenient);
+    return myself;
+  }
+
+  /**
+   * Synonyme of {@link #isNotEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the unexpected encoding of the actual file.
+   * @return {@code this} assertion object.
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset) {
+    return isNotEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the content of the actual {@code File} contains character invalid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // A file with content encoded in UTF-8
+   * File aFile = Files.write(Paths.get("a-file.txt"), "éèàû".getBytes(UTF-8)).toFile();
+   *
+   * // The following assertion succeeds:
+   * assertThat(aFile).isNotEncodedIn(ISO_8859_1);
+   *
+   * // The following assertion fails:
+   * assertThat(aFile).isNotEncodedIn(UTF-8);
+   * }</pre>
+   *
+   * @param charset the unexpected encoding of the actual file.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the replacement character, which can be a sign of a previous wrong encoding operation.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws AssertionError if the content of the actual {@code File} is valid in the specified encoding.
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset, boolean lenient) {
+    files.assertIsNotEncodedIn(info, actual, charset, lenient);
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -36,6 +36,7 @@ import org.assertj.core.util.VisibleForTesting;
  *          for more details.
  * @param <ACTUAL> the type of the "actual" value.
  *
+ * @author Ludovic VIEGAS
  * @author Matthieu Baechler
  * @author Mikhail Mazursky
  * @author Stefan Birkner
@@ -234,6 +235,91 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    */
   public SELF hasBinaryContent(byte[] expected) {
     inputStreams.assertHasBinaryContent(info, actual, expected);
+    return myself;
+  }
+
+  /**
+   * Synonyme of {@link #isEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the expected encoding.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the content of the tested {@code InputStream} contains characters invalid in the specified {@code Charset}.
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset) {
+    return isEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the tested {@code InputStream} contains only characters valid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // An input stream with text encoded in UTF-8
+   * InputStream inputStream = new ByteArrayInputStream("éèàû".getBytes(UTF-8));
+   *
+   * // The following assertion succeeds:
+   * assertThat(inputStream).isEncodedIn(UTF-8);
+   *
+   * // The following assertion fails:
+   * assertThat(inputStream).isEncodedIn(ISO_8859_1);
+   * }</pre>
+   *
+   * @param charset the expected encoding.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the replacement character, which can be a sign of a previous wrong encoding operation.
+   *
+   * @return {@code this} assertion object.
+   *
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the content of the tested {@code InputStream} contains characters invalid in the specified {@code Charset}.
+   *
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset, boolean lenient) {
+    inputStreams.assertIsEncodedIn(info, actual, charset, lenient);
+    return myself;
+  }
+
+  /**
+   * Synonyme of {@link #isNotEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the unexpected encoding.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the content of the tested {@code InputStream} contains only characters valid in the specified {@code Charset}.
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset) {
+    return isNotEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the tested {@code InputStream} contains character invalid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // An input stream with text encoded in UTF-8
+   * InputStream inputStream = new ByteArrayInputStream("éèàû".getBytes(UTF-8));
+   *
+   * // The following assertion succeeds:
+   * assertThat(inputStream).isNotEncodedIn(ISO_8859_1);
+   *
+   * // The following assertion fails:
+   * assertThat(inputStream).isNotEncodedIn(UTF-8);
+   * }</pre>
+   *
+   * @param charset the unexpected encoding.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the replacement character, which can be a sign of a previous wrong encoding operation.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the content of the tested {@code InputStream} contains only characters valid in the specified {@code Charset}.
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset, boolean lenient) {
+    inputStreams.assertIsNotEncodedIn(info, actual, charset, lenient);
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -83,6 +83,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @see java.nio.file.FileSystems#getDefault()
  * @see Files
  *
+ * @author Ludovic VIEGAS
  * @author Valeriy Vyrva
  */
 public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> extends AbstractComparableAssert<SELF, Path> {
@@ -95,6 +96,90 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
 
   protected AbstractPathAssert(final Path actual, final Class<?> selfType) {
     super(actual, selfType);
+  }
+
+  /**
+   * Synonyme of {@link #isEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the expected encoding of the actual file.
+   * @return {@code this} assertion object.
+   * @author Ludovic VIEGAS
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset) {
+    return isEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the content of the actual {@code Path} contains only characters valid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // A file with text encoded in UTF-8
+   * Path aFile = Files.write(Paths.get("a-file.txt"), "éèàû".getBytes(UTF-8));
+   *
+   * // The following assertion succeeds:
+   * assertThat(aFile).isEncodedIn(UTF-8);
+   *
+   * // The following assertion fails:
+   * assertThat(aFile).isEncodedIn(ISO_8859_1);
+   * }</pre>
+   *
+   * @param charset the expected encoding of the actual file.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the replacement character, which can be a sign of a previous wrong encoding operation.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the actual {@code Path} is not an existing file.
+   * @throws AssertionError if the content of the actual {@code Path} contains characters invalid in the specified {@code Charset}.
+   * @author Ludovic VIEGAS
+   * @since 3.26.4
+   */
+  public SELF isEncodedIn(Charset charset, boolean lenient) {
+    paths.assertIsEncodedIn(info, actual, charset, lenient);
+    return myself;
+  }
+
+  /**
+   * Synonyme of {@link #isNotEncodedIn(Charset, boolean)} with {@code lenient = false}.
+   *
+   * @param charset the unexpected encoding of the actual file.
+   * @return {@code this} assertion object.
+   * @author Ludovic VIEGAS
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset) {
+    return isNotEncodedIn(charset, false);
+  }
+
+  /**
+   * Verifies that the content of the actual {@code Path} contains character invalid in the specified {@link Charset}.
+   * <p>
+   * Examples:
+   * <pre>{@code
+   * // A path with content encoded in UTF-8
+   * Path aPath = Files.write(Paths.get("a-file.txt"), "éèàû".getBytes(UTF-8));
+   *
+   * // The following assertion succeeds:
+   * assertThat(aPath).isNotEncodedIn(ISO_8859_1);
+   *
+   * // The following assertion fails:
+   * assertThat(aPath).isNotEncodedIn(UTF-8);
+   * }</pre>
+   *
+   * @param charset the unexpected encoding of the actual file.
+   * @param lenient {@code TRUE} to accept the presence of the replacement character of the charset, often "�" ({@code U+FFFD}`).
+   * {@code FALSE} to reject the absence of the replacement character.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Charset} is {@code null}.
+   * @throws AssertionError if the actual {@code Path} is not an existing file.
+   * @throws AssertionError if the content of the actual {@code Path} contains only characters valid in the specified {@code Charset}.
+   * @author Ludovic VIEGAS
+   * @since 3.26.4
+   */
+  public SELF isNotEncodedIn(Charset charset, boolean lenient) {
+    paths.assertIsNotEncodedIn(info, actual, charset, lenient);
+    return myself;
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEncodedIn.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEncodedIn.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.EncodingIssue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Creates an error message indicating that an assertion that verifies the text encoding on files/inputStreams/paths
+ * is properly encoded.
+ *
+ * @author Ludovic VIEGAS
+ */
+public class ShouldBeEncodedIn extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeEncodedIn}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param charset the expected text encoding in the failed assertion.
+   * @param issues the encoding issues.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEncodedIn(File actual, Charset charset, List<EncodingIssue> issues) {
+    return new ShouldBeEncodedIn(actual, charset, issuesAsString(issues));
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeEncodedIn}</code>.
+   * @param actual the actual input-stream in the failed assertion.
+   * @param charset the expected text encoding in the failed assertion.
+   * @param issues the encoding issues.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEncodedIn(InputStream actual, Charset charset, List<EncodingIssue> issues) {
+    return new ShouldBeEncodedIn(actual, charset, issuesAsString(issues));
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeEncodedIn}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param charset the expected text encoding in the failed assertion.
+   * @param issues the encoding issues.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeEncodedIn(Path actual, Charset charset, List<EncodingIssue> issues) {
+    return new ShouldBeEncodedIn(actual, charset, issuesAsString(issues));
+  }
+
+  private ShouldBeEncodedIn(File actual, Charset charset, String issues) {
+    super("%nFile has %s encoding issues%n  File: %s%n  At lines:%n%s%n%n", charset, actual, issues);
+  }
+
+  private ShouldBeEncodedIn(InputStream actual, Charset charset, String issues) {
+    super("%nInputStream has %s encoding issues%n  At lines:%n%s%n%n", charset, issues);
+  }
+
+  private ShouldBeEncodedIn(Path actual, Charset charset, String issues) {
+    super("%nPath has %s encoding issues:%n  Path: %s%n  At lines:%n%s%n%n", charset, actual, issues);
+  }
+
+  private static String issuesAsString(List<EncodingIssue> encodingIssues) {
+    return encodingIssues.stream().map(EncodingIssue::toString).collect(joining(System.lineSeparator()));
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEncodedIn.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEncodedIn.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that an assertion that verifies the text on files/inputStreams/paths
+ * is not encoded in a given charset.
+ *
+ * @author Ludovic VIEGAS
+ */
+public class ShouldNotBeEncodedIn extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotBeEncodedIn}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param charset the unexpected text encoding in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotBeEncodedIn(File actual, Charset charset) {
+    return new ShouldNotBeEncodedIn(actual, charset);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldNotBeEncodedIn}</code>.
+   * @param actual the actual input-stream in the failed assertion.
+   * @param charset the unexpected text encoding in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotBeEncodedIn(InputStream actual, Charset charset) {
+    return new ShouldNotBeEncodedIn(actual, charset);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldNotBeEncodedIn}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param charset the unexpected text encoding in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotBeEncodedIn(Path actual, Charset charset) {
+    return new ShouldNotBeEncodedIn(actual, charset);
+  }
+
+  private ShouldNotBeEncodedIn(File actual, Charset charset) {
+    super("%nFile should not be encoded in %s: %s%n%n", charset, actual);
+  }
+
+  private ShouldNotBeEncodedIn(InputStream actual, Charset charset) {
+    super("%nInputStream should not be encoded in %s%n%n", charset);
+  }
+
+  private ShouldNotBeEncodedIn(Path actual, Charset charset) {
+    super("%nPath should not be encoded in %s: %s%n%n", charset, actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Encoding.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Encoding.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import static java.nio.file.Files.newInputStream;
+import static java.util.Collections.unmodifiableList;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.util.Closeables.closeQuietly;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class that validates the charset encoding of a {@link Path}, {@link File} or {@link InputStream}.
+ *
+ * @author Ludovic VIEGAS
+ */
+public class Encoding {
+
+  private final boolean lenient;
+
+  private final CharsetDecoder charsetDecoder;
+
+  public Encoding(Charset charset, boolean lenient) {
+    this.lenient = lenient;
+
+    // Store the charset decoder and make it throw an exception if a decoding issue is encountered
+    charsetDecoder = charset.newDecoder();
+    charsetDecoder.onMalformedInput(CodingErrorAction.REPORT);
+    charsetDecoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+  }
+
+  public List<EncodingIssue> validate(File actual) {
+    return validate(actual.toPath());
+  }
+
+  public List<EncodingIssue> validate(Path actual) {
+    try {
+      return validate(newInputStream(actual));
+    } catch (IOException e) {
+      return fail("Failed to create BufferedReader: " + actual, e);
+    }
+  }
+
+  public List<EncodingIssue> validate(InputStream inputStream) {
+    return validate(readerFor(inputStream));
+  }
+
+  private BufferedReader readerFor(InputStream stream) {
+    return new BufferedReader(new InputStreamReader(stream, charsetDecoder));
+  }
+
+  private List<EncodingIssue> validate(BufferedReader reader) {
+    final List<EncodingIssue> encodingIssues = new ArrayList<>();
+
+    // A line counter that starts at 1
+    long lineCounter = 1;
+
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+
+        // Look for the replacement character if validation is not lenient = false.
+        if (!lenient && line.contains(charsetDecoder.replacement())) {
+          encodingIssues.add(new EncodingIssue(lineCounter, line));
+        }
+
+        // Increment line counter before reading next line
+        lineCounter++;
+      }
+    } catch (CharacterCodingException e) {
+      encodingIssues.add(new EncodingIssue(lineCounter, null));
+    } catch (IOException e) {
+      // Any other IOException shall fail immediately
+      return fail("Failed to read lines", e);
+    } finally {
+      closeQuietly(reader);
+    }
+
+    return unmodifiableList(encodingIssues);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/EncodingIssue.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/EncodingIssue.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+/**
+ * Reports an encoding issue.
+ *
+ * @author Ludovic VIEGAS
+ */
+public class EncodingIssue {
+  private final long line;
+  private final String string;
+
+  public EncodingIssue(long line, String string) {
+    this.line = line;
+    this.string = string;
+  }
+
+  /**
+   * Get the line containing the encoding issue.
+   *
+   * @return the line number
+   */
+  public long getLine() {
+    return line;
+  }
+
+  /**
+   * Get the text containing the encoding issue.
+   *
+   * @return the string
+   */
+  public String getString() {
+    return string;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("line %d: %s", line, string);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Files.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Files.java
@@ -21,6 +21,7 @@ import static org.assertj.core.error.ShouldBeAbsolutePath.shouldBeAbsolutePath;
 import static org.assertj.core.error.ShouldBeDirectory.shouldBeDirectory;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeEmptyDirectory.shouldBeEmptyDirectory;
+import static org.assertj.core.error.ShouldBeEncodedIn.shouldBeEncodedIn;
 import static org.assertj.core.error.ShouldBeExecutable.shouldBeExecutable;
 import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
@@ -40,6 +41,7 @@ import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.error.ShouldNotBeEncodedIn.shouldNotBeEncodedIn;
 import static org.assertj.core.error.ShouldNotContain.directoryShouldNotContain;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
 import static org.assertj.core.internal.Digests.digestDiff;
@@ -64,6 +66,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.diff.Delta;
 
@@ -76,6 +79,7 @@ import org.assertj.core.util.diff.Delta;
  * @author Olivier Demeijer
  * @author Valeriy Vyrva
  * @author Rostyslav Ivankiv
+ * @author Ludovic VIEGAS
  */
 public class Files {
 
@@ -452,6 +456,24 @@ public class Files {
     assertNotNull(info, actual);
     if (actual.getParentFile() == null) return;
     throw failures.failure(info, shouldHaveNoParent(actual));
+  }
+
+  public void assertIsEncodedIn(WritableAssertionInfo info, File actual, Charset charset, boolean lenient) {
+    requireNonNull(charset, "The charset should not be null.");
+    assertIsFile(info, actual);
+    assertCanRead(info, actual);
+
+    List<EncodingIssue> issues = new Encoding(charset, lenient).validate(actual);
+    if (!issues.isEmpty()) throw failures.failure(info, shouldBeEncodedIn(actual, charset, issues));
+  }
+
+  public void assertIsNotEncodedIn(WritableAssertionInfo info, File actual, Charset charset, boolean lenient) {
+    requireNonNull(charset, "The charset should not be null.");
+    assertIsFile(info, actual);
+    assertCanRead(info, actual);
+
+    List<EncodingIssue> issues = new Encoding(charset, lenient).validate(actual);
+    if (issues.isEmpty()) throw failures.failure(info, shouldNotBeEncodedIn(actual, charset));
   }
 
   public void assertHasDigest(AssertionInfo info, File actual, MessageDigest digest, byte[] expected) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/InputStreams.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/InputStreams.java
@@ -14,24 +14,29 @@ package org.assertj.core.internal;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ShouldBeEncodedIn.shouldBeEncodedIn;
 import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
+import static org.assertj.core.error.ShouldNotBeEncodedIn.shouldNotBeEncodedIn;
 import static org.assertj.core.internal.Digests.digestDiff;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.diff.Delta;
 
 /**
  * Reusable assertions for <code>{@link InputStream}</code>s.
  *
+ * @author Ludovic VIEGAS
  * @author Matthieu Baechler
  */
 public class InputStreams {
@@ -128,6 +133,22 @@ public class InputStreams {
 
   private static void assertNotNull(AssertionInfo info, InputStream stream) {
     Objects.instance().assertNotNull(info, stream);
+  }
+
+  public void assertIsEncodedIn(WritableAssertionInfo info, InputStream actual, Charset charset, boolean lenient) {
+    requireNonNull(charset, "The charset should not be null.");
+    assertNotNull(info, actual);
+
+    List<EncodingIssue> issues = new Encoding(charset, lenient).validate(actual);
+    if (!issues.isEmpty()) throw failures.failure(info, shouldBeEncodedIn(actual, charset, issues));
+  }
+
+  public void assertIsNotEncodedIn(WritableAssertionInfo info, InputStream actual, Charset charset, boolean lenient) {
+    requireNonNull(charset, "The charset should not be null.");
+    assertNotNull(info, actual);
+
+    List<EncodingIssue> issues = new Encoding(charset, lenient).validate(actual);
+    if (issues.isEmpty()) throw failures.failure(info, shouldNotBeEncodedIn(actual, charset));
   }
 
   public void assertHasDigest(AssertionInfo info, InputStream actual, MessageDigest digest, byte[] expected) {

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_isEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_isEncodedIn_Test.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class FileAssert_isEncodedIn_Test {
+
+  @TempDir
+  Path tempDir;
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) {
+    File path = writeToTempFile(specialStr, charset);
+
+    assertThat(path).isEncodedIn(charset);
+    assertThat(path).isEncodedIn(charset, false);
+    assertThat(path).isEncodedIn(charset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation accepts the replacement char
+    final File file = writeToTempFile(str, UTF_8);
+    assertThat(file).isEncodedIn(UTF_8, true);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> assertThat(file).isEncodedIn(UTF_8, false))
+                                                                    .hasMessageContainingAll("File:", file.getName())
+                                                                    .hasMessageContaining("line 2")
+                                                                    .hasMessageContaining("line2 is nok")
+                                                                    .hasMessageContaining("line 4")
+                                                                    .hasMessageContaining("line4 is nok");
+  }
+
+  private File writeToTempFile(String str, Charset charset) {
+    Path tempFile = tempDir.resolve("actualCharset.txt");
+
+    try {
+      byte[] bytes = str.getBytes(charset);
+
+      return Files.write(tempFile, bytes).toFile();
+    } catch (IOException e) {
+      return fail("Failed to write to temp file: " + tempFile, e);
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_isNotEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_isNotEncodedIn_Test.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isNotEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class FileAssert_isNotEncodedIn_Test {
+
+  @TempDir
+  Path tempDir;
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) {
+    // Test charset against UTF-8, and UTF-8 against UTF-16
+    Charset otherCharset = charset != UTF_8 ? UTF_8 : UTF_16;
+
+    File file = writeToTempFile(specialStr, charset);
+    assertThat(file).isNotEncodedIn(otherCharset);
+    assertThat(file).isNotEncodedIn(otherCharset, false);
+    assertThat(file).isNotEncodedIn(otherCharset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation rejects the replacement char
+    final File file = writeToTempFile(str, UTF_8);
+    assertThat(file).isNotEncodedIn(UTF_8, false);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> assertThat(file).isNotEncodedIn(UTF_8, true))
+                                                                      .hasMessageContaining("File should not be encoded in %s",
+                                                                                            UTF_8)
+                                                                      .hasMessageContaining(file.getName());
+  }
+
+  private File writeToTempFile(String str, Charset charset) {
+    Path tempFile = tempDir.resolve("actualCharset.txt");
+
+    try {
+      byte[] bytes = str.getBytes(charset);
+
+      return Files.write(tempFile, bytes).toFile();
+    } catch (IOException e) {
+      return fail("Failed to write to temp file: " + tempFile, e);
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_isEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_isEncodedIn_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class InputStreamAssert_isEncodedIn_Test {
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) throws Exception {
+    InputStream inputStream = toInputStream(specialStr, charset);
+    assertThat(inputStream).isEncodedIn(charset);
+
+    inputStream.reset();
+    assertThat(inputStream).isEncodedIn(charset, false);
+
+    inputStream.reset();
+    assertThat(inputStream).isEncodedIn(charset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation accepts the replacement char
+    final InputStream inputStream = toInputStream(str, UTF_8);
+    assertThat(inputStream).isEncodedIn(UTF_8, true);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> {
+      inputStream.reset();
+      assertThat(inputStream).isEncodedIn(UTF_8, false);
+    })
+      .hasMessageContaining("InputStream has %s encoding issues", UTF_8)
+      .hasMessageContaining("line 2")
+      .hasMessageContaining("line2 is nok")
+      .hasMessageContaining("line 4")
+      .hasMessageContaining("line4 is nok");
+  }
+
+  private InputStream toInputStream(String str, Charset charset) {
+    return new ByteArrayInputStream(str.getBytes(charset));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_isNotEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/inputstream/InputStreamAssert_isNotEncodedIn_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.inputstream;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isNotEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class InputStreamAssert_isNotEncodedIn_Test {
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) throws Exception {
+    // Test charset against UTF-8, and UTF-8 against UTF-16
+    Charset otherCharset = charset != UTF_8 ? UTF_8 : UTF_16;
+
+    InputStream inputStream = toInputStream(specialStr, charset);
+    assertThat(inputStream).isNotEncodedIn(otherCharset);
+
+    inputStream.reset();
+    assertThat(inputStream).isNotEncodedIn(otherCharset, false);
+
+    inputStream.reset();
+    assertThat(inputStream).isNotEncodedIn(otherCharset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation rejects the replacement char
+    final InputStream inputStream = toInputStream(str, UTF_8);
+    assertThat(inputStream).isNotEncodedIn(UTF_8, false);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> {
+      inputStream.reset();
+      assertThat(inputStream).isNotEncodedIn(UTF_8, true);
+    })
+      .hasMessageContaining("InputStream should not be encoded in " + UTF_8);
+  }
+
+  private static ByteArrayInputStream toInputStream(String str, Charset charset) {
+    return new ByteArrayInputStream(str.getBytes(charset));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_isEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_isEncodedIn_Test.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class PathAssert_isEncodedIn_Test {
+
+  @TempDir
+  Path tempDir;
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) {
+    Path path = writeToTempFile(specialStr, charset);
+
+    assertThat(path).isEncodedIn(charset);
+    assertThat(path).isEncodedIn(charset, false);
+    assertThat(path).isEncodedIn(charset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation accepts the replacement char
+    final Path file = writeToTempFile(str, UTF_8);
+    assertThat(file).isEncodedIn(UTF_8, true);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> assertThat(file).isEncodedIn(UTF_8, false))
+                                                                    .hasMessageContaining("Path has %s encoding issues", UTF_8)
+                                                                    .hasMessageContainingAll("Path:",
+                                                                                             file.getFileName().toString())
+                                                                    .hasMessageContaining("line 2")
+                                                                    .hasMessageContaining("line2 is nok")
+                                                                    .hasMessageContaining("line 4")
+                                                                    .hasMessageContaining("line4 is nok");
+  }
+
+  private Path writeToTempFile(String str, Charset charset) {
+    Path tempFile = tempDir.resolve("actualCharset.txt");
+
+    try {
+      byte[] bytes = str.getBytes(charset);
+
+      return Files.write(tempFile, bytes);
+    } catch (IOException e) {
+      return fail("Failed to write to temp file: " + tempFile, e);
+    }
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_isNotEncodedIn_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_isNotEncodedIn_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import static java.lang.System.lineSeparator;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.InputStreamAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link InputStreamAssert#isNotEncodedIn(Charset)} methods.
+ *
+ * @author Ludovic VIEGAS
+ */
+class PathAssert_isNotEncodedIn_Test {
+
+  @TempDir
+  Path tempDir;
+
+  private final String specialStr = "àâäéèêëiìîïoòôöuùûü";
+
+  public static Stream<Charset> commonCharsetsArguments() {
+    return Stream.of(UTF_8, ISO_8859_1, UTF_16, Charset.forName("windows-1252"));
+  }
+
+  @ParameterizedTest(name = "[{index}] Charset {0}")
+  @MethodSource("commonCharsetsArguments")
+  void should_validate(Charset charset) {
+    // Test charset against UTF-8, and UTF-8 against UTF-16
+    Charset otherCharset = charset != UTF_8 ? UTF_8 : UTF_16;
+
+    Path file = writeToTempFile(specialStr, charset);
+    assertThat(file).isNotEncodedIn(otherCharset);
+    assertThat(file).isNotEncodedIn(otherCharset, false);
+    assertThat(file).isNotEncodedIn(otherCharset, true);
+  }
+
+  @Test
+  void should_validate_lenient() {
+    String replacement = UTF_8.newDecoder().replacement();
+
+    String str = Stream.of(
+                           "line1 is ok",
+                           "line2 is nok" + replacement,
+                           "line3 is ok",
+                           "line4 is nok" + replacement)
+                       .collect(joining(lineSeparator()));
+
+    // Test lenient validation rejects the replacement char
+    final Path file = writeToTempFile(str, UTF_8);
+    assertThat(file).isNotEncodedIn(UTF_8, false);
+
+    // Test strict validation does not accept the replacement char
+    assertThatCode(() -> assertThat(file).isNotEncodedIn(UTF_8, true))
+                                                                      .hasMessageContaining("Path should not be encoded in %s",
+                                                                                            UTF_8)
+                                                                      .hasMessageContaining(file.getFileName().toString());
+  }
+
+  private Path writeToTempFile(String str, Charset charset) {
+    Path tempFile = tempDir.resolve("actualCharset.txt");
+
+    try {
+      byte[] bytes = str.getBytes(charset);
+
+      return Files.write(tempFile, bytes);
+    } catch (IOException e) {
+      return fail("Failed to write to temp file: " + tempFile, e);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `isEncodedIn(Charset)`, `isEncodedIn(Charset, boolean)`, `isNotEncodedIn(Charset)`, `isNotEncodedIn(Charset, boolean)`.

Even though detecting encoding issues might not be 100% possible because some charsets can simply map some inputs to something else valide to them, there are some cases where having assertions can be handly such as:
 - Explicit invalid or unmappable bytes.
 - The simple presence of the replacement char.

The assertions I added, are based on internal testing functions that I use in various projects. I though it would be a good addition to AssertJ.

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md): YES
