### PR TITLE
Propagate common basetype for the `extracting` method

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -912,18 +912,18 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   @SafeVarargs
-  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, ?>... extractors) {
+  public final <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> extracting(Function<? super ACTUAL, ? extends T>... extractors) {
     return extractingForProxy(extractors);
   }
 
   // This method is protected in order to be proxied for SoftAssertions / Assumptions.
   // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
   // in order to avoid compiler warning in user code
-  protected AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extractingForProxy(Function<? super ACTUAL, ?>[] extractors) {
+  protected <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> extractingForProxy(Function<? super ACTUAL, ? extends T>[] extractors) {
     requireNonNull(extractors, shouldNotBeNull("extractors")::create);
-    List<Object> values = Stream.of(extractors)
-                                .map(extractor -> extractor.apply(actual))
-                                .collect(toList());
+    List<T> values = Stream.of(extractors)
+                           .map(extractor -> extractor.apply(actual))
+                           .collect(toList());
     return newListAssertInstance(values).withAssertionState(myself);
   }
 


### PR DESCRIPTION
before it was always Object. This resolves #3372.

```
Co-authored-by: IvoHD <IvoHD@users.noreply.github.com>
Co-authored-by: Alexandra Junghans <alexandra-junghans@users.noreply.github.com>
Co-authored-by: Mahmoud Ben Hassine <fmbenhassine@users.noreply.github.com>
```