### PR TITLE
Add throwable stacktrace to ShouldNotContainCharSequence

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
@@ -17,6 +17,9 @@ import java.util.Set;
 import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.StandardComparisonStrategy;
 
+import static org.assertj.core.util.Strings.escapePercent;
+import static org.assertj.core.util.Throwables.getStackTrace;
+
 /**
  * Creates an error message indicating that an assertion that verifies that a {@code CharSequence} does not contain another
  * {@code CharSequence} failed.
@@ -58,6 +61,36 @@ public class ShouldNotContainCharSequence extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldNotContain(CharSequence actual, CharSequence sequence) {
     return shouldNotContain(actual, sequence, StandardComparisonStrategy.instance());
+  }
+
+  public static ErrorMessageFactory shouldNotContain(Throwable actual, CharSequence sequence) {
+    String format = "%n" +
+                    "Expecting throwable message:%n" +
+                    "  %s%n" +
+                    "not to contain:%n" +
+                    "  %s%n" +
+                    "but found:%n" +
+                    "%n" +
+                    "Throwable that failed the check:%n" +
+                    "%n" + escapePercent(getStackTrace(actual)); // to avoid AssertJ default String formatting
+
+    return new ShouldNotContainCharSequence(format, actual.getMessage(), sequence, StandardComparisonStrategy.instance());
+  }
+
+  public static ErrorMessageFactory shouldNotContain(Throwable actual, CharSequence[] sequence,
+                                                     Set<? extends CharSequence> found) {
+    String format = "%n" +
+                    "Expecting throwable message:%n" +
+                    "  %s%n" +
+                    "not to contain:%n" +
+                    "  %s%n" +
+                    "but found:%n" +
+                    "  %s%n" +
+                    "%n" +
+                    "Throwable that failed the check:%n" +
+                    "%n" + escapePercent(getStackTrace(actual)); // to avoid AssertJ default String formatting
+
+    return new ShouldNotContainCharSequence(format, actual.getMessage(), sequence, found, StandardComparisonStrategy.instance());
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/internal/Throwables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Throwables.java
@@ -259,7 +259,7 @@ public class Throwables {
   public void assertHasMessageNotContaining(AssertionInfo info, Throwable actual, String content) {
     assertNotNull(info, actual);
     if (actual.getMessage() == null || !actual.getMessage().contains(content)) return;
-    throw failures.failure(info, shouldNotContain(actual.getMessage(), content), actual.getMessage(), content);
+    throw failures.failure(info, shouldNotContain(actual, content), actual.getMessage(), content);
   }
 
   /**
@@ -278,10 +278,9 @@ public class Throwables {
                                             .collect(toCollection(LinkedHashSet::new));
     if (found.isEmpty()) return;
     if (found.size() == 1 && values.length == 1) {
-      throw failures.failure(info, shouldNotContain(actualMessage, values[0]), actualMessage, values[0]);
+      throw failures.failure(info, shouldNotContain(actual, values[0]), actualMessage, values[0]);
     }
-    throw failures.failure(info, shouldNotContain(actualMessage, values, found, StandardComparisonStrategy.instance()),
-                           actualMessage, values);
+    throw failures.failure(info, shouldNotContain(actual, values, found), actualMessage, values);
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainThrowable_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainThrowable_create_Test.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2024 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Throwables.getStackTrace;
+import static org.mockito.internal.util.collections.Sets.newSet;
+
+/**
+ * Tests for <code>{@link ShouldNotContainCharSequence#shouldNotContain(Throwable, CharSequence[], Set)})}</code> and
+ * <code>{@link ShouldNotContainCharSequence#shouldNotContain(Throwable, CharSequence)})}</code>.
+ *
+ * @author Usman Shaikh
+ */
+@DisplayName("ShouldNotContainThrowable create")
+class ShouldNotContainThrowable_create_Test {
+  @Test
+  void should_create_error_message_with_escaping_percent() {
+    // GIVEN
+    RuntimeException actual = new RuntimeException("You know nothing %");
+    // WHEN
+    String errorMessage = shouldNotContain(actual, "You know nothing % Jon Snow").create(new TestDescription("TEST"));
+    // THEN
+    then(errorMessage).isEqualTo("[TEST] %n" +
+                                 "Expecting throwable message:%n" +
+                                 "  \"You know nothing %%\"%n" +
+                                 "not to contain:%n" +
+                                 "  \"You know nothing %% Jon Snow\"%n" +
+                                 "but found:%n" +
+                                 "%n" +
+                                 "Throwable that failed the check:%n" +
+                                 "%n%s", getStackTrace(actual));
+  }
+
+  @Test
+  void should_create_error_message_with_several_values_not_found() {
+    // GIVEN
+    RuntimeException actual = new RuntimeException("You know nothing");
+    String[] sequence = array("You", "know", "nothing", "Jon", "Snow");
+    Set<String> notFound = newSet("Jon", "Snow");
+    // WHEN
+    String errorMessage = shouldNotContain(actual, sequence, notFound).create(new TestDescription("TEST"));
+    // THEN
+    then(errorMessage).isEqualTo("[TEST] %n" +
+                                 "Expecting throwable message:%n" +
+                                 "  \"You know nothing\"%n" +
+                                 "not to contain:%n" +
+                                 "  [\"You\", \"know\", \"nothing\", \"Jon\", \"Snow\"]%n" +
+                                 "but found:%n" +
+                                 "  [\"Jon\", \"Snow\"]%n" +
+                                 "%n" +
+                                 "Throwable that failed the check:%n" +
+                                 "%n%s", getStackTrace(actual));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
@@ -66,7 +66,7 @@ class Throwables_assertHasMessageNotContainingAny_Test extends ThrowablesBaseTes
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageNotContainingAny(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldNotContain(actual.getMessage(), content), actual.getMessage(), content);
+    verify(failures).failure(INFO, shouldNotContain(actual, content), actual.getMessage(), content);
   }
 
   @Test
@@ -76,8 +76,6 @@ class Throwables_assertHasMessageNotContainingAny_Test extends ThrowablesBaseTes
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageNotContainingAny(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldNotContain(actual.getMessage(), content, singleton("message"),
-                                                    StandardComparisonStrategy.instance()),
-                             actual.getMessage(), content);
+    verify(failures).failure(INFO, shouldNotContain(actual, content, singleton("message")), actual.getMessage(), content);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContaining_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/throwables/Throwables_assertHasMessageNotContaining_Test.java
@@ -60,6 +60,6 @@ class Throwables_assertHasMessageNotContaining_Test extends ThrowablesBaseTest {
     // WHEN
     expectAssertionError(() -> throwables.assertHasMessageNotContaining(INFO, actual, content));
     // THEN
-    verify(failures).failure(INFO, shouldNotContain(actual.getMessage(), content), actual.getMessage(), content);
+    verify(failures).failure(INFO, shouldNotContain(actual, content), actual.getMessage(), content);
   }
 }


### PR DESCRIPTION
* Fixes #1355 
* Unit tests : YES 
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

