### PR TITLE
Add throwable stacktrace to ShouldNotContainCharSequence - Correct message

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
@@ -69,7 +69,7 @@ public class ShouldNotContainCharSequence extends BasicErrorMessageFactory {
                     "  %s%n" +
                     "not to contain:%n" +
                     "  %s%n" +
-                    "but found:%n" +
+                    "but did:%n" +
                     "%n" +
                     "Throwable that failed the check:%n" +
                     "%n" + escapePercent(getStackTrace(actual)); // to avoid AssertJ default String formatting

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainThrowable_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainThrowable_create_Test.java
@@ -33,16 +33,16 @@ class ShouldNotContainThrowable_create_Test {
   @Test
   void should_create_error_message_with_escaping_percent() {
     // GIVEN
-    RuntimeException actual = new RuntimeException("You know nothing %");
+    RuntimeException actual = new RuntimeException("You know nothing % Jon Snow");
     // WHEN
-    String errorMessage = shouldNotContain(actual, "You know nothing % Jon Snow").create(new TestDescription("TEST"));
+    String errorMessage = shouldNotContain(actual, "You know nothing %").create(new TestDescription("TEST"));
     // THEN
     then(errorMessage).isEqualTo("[TEST] %n" +
                                  "Expecting throwable message:%n" +
-                                 "  \"You know nothing %%\"%n" +
-                                 "not to contain:%n" +
                                  "  \"You know nothing %% Jon Snow\"%n" +
-                                 "but found:%n" +
+                                 "not to contain:%n" +
+                                 "  \"You know nothing %%\"%n" +
+                                 "but did:%n" +
                                  "%n" +
                                  "Throwable that failed the check:%n" +
                                  "%n%s", getStackTrace(actual));
@@ -51,19 +51,19 @@ class ShouldNotContainThrowable_create_Test {
   @Test
   void should_create_error_message_with_several_values_not_found() {
     // GIVEN
-    RuntimeException actual = new RuntimeException("You know nothing");
-    String[] sequence = array("You", "know", "nothing", "Jon", "Snow");
-    Set<String> notFound = newSet("Jon", "Snow");
+    RuntimeException actual = new RuntimeException("You know nothing Jon Snow");
+    String[] sequence = array("You", "know", "nothing");
+    Set<String> found = newSet("You", "know", "nothing");
     // WHEN
-    String errorMessage = shouldNotContain(actual, sequence, notFound).create(new TestDescription("TEST"));
+    String errorMessage = shouldNotContain(actual, sequence, found).create(new TestDescription("TEST"));
     // THEN
     then(errorMessage).isEqualTo("[TEST] %n" +
                                  "Expecting throwable message:%n" +
-                                 "  \"You know nothing\"%n" +
+                                 "  \"You know nothing Jon Snow\"%n" +
                                  "not to contain:%n" +
-                                 "  [\"You\", \"know\", \"nothing\", \"Jon\", \"Snow\"]%n" +
+                                 "  [\"You\", \"know\", \"nothing\"]%n" +
                                  "but found:%n" +
-                                 "  [\"Jon\", \"Snow\"]%n" +
+                                 "  [\"You\", \"know\", \"nothing\"]%n" +
                                  "%n" +
                                  "Throwable that failed the check:%n" +
                                  "%n%s", getStackTrace(actual));


### PR DESCRIPTION
Apologies, double checking, I don't think the previous [PR ](https://github.com/assertj/assertj/pull/3686) was implemented correctly. 😓 Using [ShouldContainThrowable_create_Test](https://github.com/shaikhu/assertj/blob/3.x/assertj-core/src/test/java/org/assertj/core/error/ShouldContainThrowable_create_Test.java) as a basis, this PR has the correct implementation.

#### Check List:
* Fixes #1355
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
