### PR TITLE
Enforce Java 17+ as build environment

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -291,29 +291,21 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-dependencies</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <includes>
-                    <include>net.bytebuddy:byte-buddy</include>
-                  </includes>
-                  <excludes>
-                    <exclude>org.assertj:assertj-core</exclude>
-                    <exclude>org.hamcrest:hamcrest-core</exclude>
-                    <exclude>*:*:*:jar:compile</exclude>
-                  </excludes>
-                </bannedDependencies>
-                <dependencyConvergence />
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <rules combine-children="append">
+            <bannedDependencies>
+              <includes>
+                <include>net.bytebuddy:byte-buddy</include>
+              </includes>
+              <excludes>
+                <exclude>org.assertj:assertj-core</exclude>
+                <exclude>org.hamcrest:hamcrest-core</exclude>
+                <exclude>*:*:*:jar:compile</exclude>
+              </excludes>
+            </bannedDependencies>
+            <dependencyConvergence />
+          </rules>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/assertj-guava/pom.xml
+++ b/assertj-guava/pom.xml
@@ -64,29 +64,21 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-dependencies</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <includes>
-                    <include>net.bytebuddy:byte-buddy</include>
-                    <include>org.assertj:assertj-core</include>
-                  </includes>
-                  <excludes>
-                    <exclude>org.assertj:assertj-guava</exclude>
-                    <exclude>*:*:*:jar:compile</exclude>
-                  </excludes>
-                </bannedDependencies>
-                <dependencyConvergence />
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <rules combine-children="append">
+            <bannedDependencies>
+              <includes>
+                <include>net.bytebuddy:byte-buddy</include>
+                <include>org.assertj:assertj-core</include>
+              </includes>
+              <excludes>
+                <exclude>org.assertj:assertj-guava</exclude>
+                <exclude>*:*:*:jar:compile</exclude>
+              </excludes>
+            </bannedDependencies>
+            <dependencyConvergence />
+          </rules>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>

--- a/assertj-tests/pom.xml
+++ b/assertj-tests/pom.xml
@@ -33,27 +33,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-test-only-dependencies</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <bannedDependencies>
-                  <includes>
-                    <include>*:*:*:jar:test</include>
-                  </includes>
-                  <excludes>
-                    <exclude>*</exclude>
-                  </excludes>
-                </bannedDependencies>
-                <dependencyConvergence />
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <rules combine-children="append">
+            <bannedDependencies>
+              <includes>
+                <include>*:*:*:jar:test</include>
+              </includes>
+              <excludes>
+                <exclude>*</exclude>
+              </excludes>
+            </bannedDependencies>
+            <dependencyConvergence />
+          </rules>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,22 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <rules>
+              <requireJavaVersion>
+                <version>[17,)</version>
+                <message>The build requires Java 17 or better.</message>
+              </requireJavaVersion>
+              <requirePluginVersions />
+            </rules>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The build otherwise fails with low level bytecode class version related exceptions. Make this far more explicit, as the exception doesn't really tell what's wrong.

Also simplify the configuration of the enforcer plugin. It's not a good pattern to have separate executions in each module, rather just inherit a default configuration and add more specific rules. Note the "combine-children" attribute.