### PR TITLE
Revert "Propagate common basetype for the `extracting` method (#3673)"

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -872,18 +872,18 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   @SafeVarargs
-  public final <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> extracting(Function<? super ACTUAL, ? extends T>... extractors) {
+  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(Function<? super ACTUAL, ?>... extractors) {
     return extractingForProxy(extractors);
   }
 
   // This method is protected in order to be proxied for SoftAssertions / Assumptions.
   // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
   // in order to avoid compiler warning in user code
-  protected <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> extractingForProxy(Function<? super ACTUAL, ? extends T>[] extractors) {
+  protected AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extractingForProxy(Function<? super ACTUAL, ?>[] extractors) {
     requireNonNull(extractors, shouldNotBeNull("extractors")::create);
-    List<T> values = Stream.of(extractors)
-                           .map(extractor -> extractor.apply(actual))
-                           .collect(toList());
+    List<Object> values = Stream.of(extractors)
+                                .map(extractor -> extractor.apply(actual))
+                                .collect(toList());
     return newListAssertInstance(values).withAssertionState(myself);
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/tests/core/kotlin/api/object_/ObjectAssert_extracting_with_Function_Test.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/tests/core/kotlin/api/object_/ObjectAssert_extracting_with_Function_Test.kt
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.tests.core.kotlin.api.object_
+
+import org.assertj.core.api.Assertions.assertThatObject
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ObjectAssert_extracting_with_Function_Test {
+
+  @Test
+  fun `should support lambda with implicit parameter`() {
+    // WHEN/THEN
+    assertThatObject(" ").extracting { it.trim() }.isEqualTo("")
+  }
+
+  @Test
+  fun `should support lambda with explicit parameter`() {
+    // WHEN/THEN
+    assertThatObject(" ").extracting { it -> it.trim() }.isEqualTo("")
+  }
+
+  @Disabled("Does not compile on Kotlin 1.9.25")
+  @Test
+  fun `should support lambda on two chained calls`() {
+/*
+    // WHEN/THEN
+    assertThatObject(" ")
+      .extracting { it.trim() }
+      .isEqualTo("")
+      .extracting { it.isEmpty() }
+      .isEqualTo(true)
+*/
+  }
+
+  @Test
+  fun `should support method reference`() {
+    // WHEN/THEN
+    assertThatObject(" ").extracting(String::trim).isEqualTo("")
+  }
+
+  @Disabled("Does not compile on Kotlin 1.9.25")
+  @Test
+  fun `should support method reference on two chained calls`() {
+/*
+    // WHEN/THEN
+    assertThatObject(" ")
+      .extracting(String::trim)
+      .isEqualTo("")
+      .extracting(String::isEmpty)
+      .isEqualTo(true)
+*/
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/tests/core/kotlin/api/object_/ObjectAssert_extracting_with_Function_Test.kt
+++ b/assertj-tests/assertj-integration-tests/assertj-core-kotlin/src/test/kotlin/org/assertj/tests/core/kotlin/api/object_/ObjectAssert_extracting_with_Function_Test.kt
@@ -30,9 +30,9 @@ class ObjectAssert_extracting_with_Function_Test {
     assertThatObject(" ").extracting { it -> it.trim() }.isEqualTo("")
   }
 
-  @Disabled("Does not compile on Kotlin 1.9.25")
+  @Disabled("Does not compile with Kotlin < 2.x")
   @Test
-  fun `should support lambda on two chained calls`() {
+  fun `should support lambda with implicit parameter on two chained calls`() {
 /*
     // WHEN/THEN
     assertThatObject(" ")
@@ -49,7 +49,7 @@ class ObjectAssert_extracting_with_Function_Test {
     assertThatObject(" ").extracting(String::trim).isEqualTo("")
   }
 
-  @Disabled("Does not compile on Kotlin 1.9.25")
+  @Disabled("Does not compile with Kotlin < 2.x")
   @Test
   fun `should support method reference on two chained calls`() {
 /*

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_Function_Array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_Function_Array_Test.java
@@ -17,20 +17,20 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.tests.core.testkit.AlwaysEqualComparator.ALWAYS_EQUALS;
+import static org.assertj.tests.core.testkit.AlwaysEqualComparator.ALWAYS_EQUALS_STRING;
 
 import java.util.List;
 import java.util.function.Function;
+
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.util.introspection.PropertyOrFieldSupport;
-import org.assertj.tests.core.testkit.AlwaysEqualComparator;
 import org.assertj.tests.core.testkit.Employee;
-import org.assertj.tests.core.testkit.Jedi;
 import org.assertj.tests.core.testkit.Name;
 import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
-import org.assertj.tests.core.testkit.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +38,7 @@ class ObjectAssert_extracting_with_Function_Array_Test implements NavigationMeth
 
   private Employee luke;
 
-  private static final Function<Employee, String> firstName = employee -> employee.getName().getFirst();
+  private static final Function<Employee, String> FIRST_NAME = employee -> employee.getName().getFirst();
 
   @BeforeEach
   void setUp() {
@@ -50,26 +50,10 @@ class ObjectAssert_extracting_with_Function_Array_Test implements NavigationMeth
     // GIVEN
     Function<Employee, Object> lastName = employee -> employee.getName().getLast();
     // WHEN
-    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertThat(luke).extracting(firstName, lastName);
+    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertThat(luke).extracting(FIRST_NAME, lastName);
     // THEN
     result.hasSize(2)
           .containsExactly("Luke", "Skywalker");
-  }
-
-  @Test
-  void should_allow_extracting_values_using_multiple_lambda_extractors_with_common_ancestor() {
-    // GIVEN
-    record Companions(Jedi jedi, Person person) {
-    }
-    Companions companions = new Companions(new Jedi("Luke", "blue"), new Person("Han"));
-    Function<Companions, Jedi> jedi = Companions::jedi;
-    Function<Companions, Person> person = Companions::person;
-    // WHEN
-    AbstractListAssert<?, List<? extends Person>, Person, ObjectAssert<Person>> result = assertThat(companions).extracting(jedi,
-                                                                                                                           person);
-    // THEN
-    result.hasSize(2)
-          .allSatisfy(e -> assertThat(e.getName()).isNotBlank());
   }
 
   @Test
@@ -77,8 +61,7 @@ class ObjectAssert_extracting_with_Function_Array_Test implements NavigationMeth
     // GIVEN
     Function<Employee, String> lastName = employee -> employee.getName().getLast();
     // WHEN
-    AbstractListAssert<?, List<? extends String>, String, ObjectAssert<String>> result = assertThat(luke).extracting(firstName,
-                                                                                                                     lastName);
+    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertThat(luke).extracting(FIRST_NAME, lastName);
     // THEN
     result.hasSize(2)
           .containsExactly("Luke", "Skywalker");
@@ -101,7 +84,7 @@ class ObjectAssert_extracting_with_Function_Array_Test implements NavigationMeth
       throw explosion;
     };
     // WHEN
-    Throwable error = catchThrowable(() -> assertThat(luke).extracting(firstName, bomb));
+    Throwable error = catchThrowable(() -> assertThat(luke).extracting(FIRST_NAME, bomb));
     // THEN
     then(error).isSameAs(explosion);
   }
@@ -124,18 +107,18 @@ class ObjectAssert_extracting_with_Function_Array_Test implements NavigationMeth
     ObjectAssert<Employee> assertion = assertThat(luke).as("test description")
                                                        .withFailMessage("error message")
                                                        .withRepresentation(UNICODE_REPRESENTATION)
-                                                       .usingComparator(AlwaysEqualComparator.ALWAYS_EQUALS)
-                                                       .usingComparatorForFields(AlwaysEqualComparator.ALWAYS_EQUALS_STRING,
+                                                       .usingComparator(ALWAYS_EQUALS)
+                                                       .usingComparatorForFields(ALWAYS_EQUALS_STRING,
                                                                                  "foo")
-                                                       .usingComparatorForType(AlwaysEqualComparator.ALWAYS_EQUALS_STRING,
+                                                       .usingComparatorForType(ALWAYS_EQUALS_STRING,
                                                                                String.class);
     // WHEN
-    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertion.extracting(firstName, Employee::getName);
+    AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> result = assertion.extracting(FIRST_NAME, Employee::getName);
     // THEN
     then(result.descriptionText()).isEqualTo("test description");
     then(result.info.overridingErrorMessage()).isEqualTo("error message");
     then(result.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
-    then(comparatorOf(result).getComparator()).isSameAs(AlwaysEqualComparator.ALWAYS_EQUALS);
+    then(comparatorOf(result).getComparator()).isSameAs(ALWAYS_EQUALS);
   }
 
   private static Objects comparatorOf(AbstractListAssert<?, ?, ?, ?> assertion) {


### PR DESCRIPTION
* Fixes #3728 
