### PR TITLE
Add warnings about Stream closing to assertThat JavaDocs

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -341,7 +341,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link Stream}. The stream is closed after the list is built.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual {@link Stream} value.
@@ -360,7 +360,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link Stream}. The stream is closed after the list is built.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -377,7 +377,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link DoubleStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link DoubleStream}.
+   * interacts with the {@link List} built from the {@link DoubleStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
@@ -392,7 +392,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link LongStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link LongStream}.
+   * interacts with the {@link List} built from the {@link LongStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
@@ -407,7 +407,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link IntStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link IntStream}.
+   * interacts with the {@link List} built from the {@link IntStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.

--- a/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -329,7 +329,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link Stream}. The stream is closed after the list is built.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual {@link Stream} value.
@@ -348,7 +348,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link Stream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link Stream}.
+   * interacts with the {@link List} built from the {@link Stream}. The stream is closed after the list is built.
    *
    * @param <ELEMENT> the type of elements.
    * @param actual the actual value.
@@ -364,7 +364,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link DoubleStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link DoubleStream}.
+   * interacts with the {@link List} built from the {@link DoubleStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link DoubleStream} value.
    * @return the created assertion object.
@@ -379,7 +379,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link LongStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link LongStream}.
+   * interacts with the {@link List} built from the {@link LongStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link LongStream} value.
    * @return the created assertion object.
@@ -394,7 +394,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * <p>
    * <b>Be aware that to create the returned {@link ListAssert} the given the {@link IntStream} is consumed so it won't be
    * possible to use it again.</b> Calling multiple methods on the returned {@link ListAssert} is safe as it only
-   * interacts with the {@link List} built from the {@link IntStream}.
+   * interacts with the {@link List} built from the {@link IntStream}. The stream is closed after the list is built.
    *
    * @param actual the actual {@link IntStream} value.
    * @return the created assertion object.


### PR DESCRIPTION
#### Check List:
* NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

I noticed that since https://github.com/assertj/assertj/pull/1218 , `assertThat` automatically closes streams that are passed to it.  This is worth documenting for cases where running assertions on the the items in the stream is dependent on the stream remaining open.  For instance, I have just had a case where I wanted to test a stream that's backed by a `ZipFile`, where the items in the stream are only usable so long as the stream (and backing `ZipFile`) remain open.  This isn't possible with `assertThat(BaseStream)`.  This was easy enough to work around (by collecting the stream to an array myself), but it would be very helpful towards understanding the problem if the documentation specified that the stream gets closed by `assertThat`.

This PR adds a brief mention of this closing behavior to the relevant javadocs that I could find.
