### PR TITLE
Abort tests when symbolic links cannot be created

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/PathsBaseTest.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.internal;
 
+import static java.nio.file.Files.createSymbolicLink;
 import static org.assertj.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.reset;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.commons.function.Try;
+import org.opentest4j.TestAbortedException;
 
 /**
  * Base class for {@link Paths} tests.
@@ -66,6 +69,12 @@ public abstract class PathsBaseTest {
   @BeforeEach
   void resetSpies() {
     reset(nioFilesWrapper, failures, diff, binaryDiff);
+  }
+
+  // https://github.com/assertj/assertj/issues/3183
+  protected static Path tryToCreateSymbolicLink(Path link, Path target) {
+    return Try.call(() -> createSymbolicLink(link, target))
+              .getOrThrow(e -> new TestAbortedException("Failed to create symbolic link", e));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWithRaw_Test.java
@@ -72,7 +72,7 @@ class Paths_assertEndsWithRaw_Test extends PathsBaseTest {
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     Path other = Path.of("file");
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertEndsWithRaw(INFO, actual, other));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertEndsWith_Test.java
@@ -27,6 +27,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import org.assertj.core.internal.PathsBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.function.Try;
+import org.opentest4j.TestAbortedException;
 
 class Paths_assertEndsWith_Test extends PathsBaseTest {
 
@@ -89,7 +91,7 @@ class Paths_assertEndsWith_Test extends PathsBaseTest {
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     Path other = Path.of("file");
     // WHEN/THEN
     underTest.assertEndsWith(INFO, actual, other);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExistsNoFollowLinks_Test.java
@@ -57,7 +57,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
   void should_pass_if_actual_is_a_symbolic_link_and_target_exists() throws IOException {
     // GIVEN
     Path target = createFile(tempDir.resolve("target"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
     underTest.assertExistsNoFollowLinks(INFO, actual);
   }
@@ -66,7 +66,7 @@ class Paths_assertExistsNoFollowLinks_Test extends PathsBaseTest {
   void should_pass_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
     underTest.assertExistsNoFollowLinks(INFO, actual);
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertExists_Test.java
@@ -57,7 +57,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
   void should_pass_if_actual_is_a_symbolic_link_and_target_exists() throws IOException {
     // GIVEN
     Path target = createFile(tempDir.resolve("target"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN/THEN
     underTest.assertExists(INFO, actual);
   }
@@ -66,7 +66,7 @@ class Paths_assertExists_Test extends PathsBaseTest {
   void should_fail_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertExists(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasFileName_Test.java
@@ -92,7 +92,7 @@ class Paths_assertHasFileName_Test extends PathsBaseTest {
   @Test
   void should_pass_with_existing_symbolic_link() throws IOException {
     // GIVEN
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), tempDir);
     String filename = "actual";
     // WHEN/THEN
     underTest.assertHasFileName(INFO, actual, filename);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParentRaw_Test.java
@@ -57,7 +57,7 @@ class Paths_assertHasNoParentRaw_Test extends PathsBaseTest {
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path root = tempDir.getRoot();
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), root);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), root);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertHasNoParentRaw(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoParent_Test.java
@@ -74,7 +74,7 @@ class Paths_assertHasNoParent_Test extends PathsBaseTest {
   void should_pass_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path root = tempDir.getRoot();
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), root);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), root);
     // WHEN/THEN
     underTest.assertHasNoParent(INFO, actual);
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParentRaw_Test.java
@@ -86,7 +86,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
     // GIVEN
     Path expected = createDirectory(tempDir.resolve("expected"));
     Path file = createFile(expected.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));
     // THEN
@@ -97,7 +97,7 @@ class Paths_assertHasParentRaw_Test extends PathsBaseTest {
   void should_fail_if_expected_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));
-    Path expected = createSymbolicLink(tempDir.resolve("expected"), directory);
+    Path expected = tryToCreateSymbolicLink(tempDir.resolve("expected"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertHasParentRaw(INFO, actual, expected));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasParent_Test.java
@@ -117,7 +117,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
     // GIVEN
     Path expected = createDirectory(tempDir.resolve("expected"));
     Path file = createFile(expected.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN/THEN
     underTest.assertHasParent(INFO, actual, expected);
   }
@@ -126,7 +126,7 @@ class Paths_assertHasParent_Test extends PathsBaseTest {
   void should_pass_if_expected_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));
-    Path expected = createSymbolicLink(tempDir.resolve("expected"), directory);
+    Path expected = tryToCreateSymbolicLink(tempDir.resolve("expected"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN/THEN
     underTest.assertHasParent(INFO, actual, expected);

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsCanonical_Test.java
@@ -56,7 +56,7 @@ class Paths_assertIsCanonical_Test extends PathsBaseTest {
   void should_fail_if_actual_is_not_canonical() throws IOException {
     // GIVEN
     Path file = createFile(tempDir.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertIsCanonical(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertIsSymbolicLink_Test.java
@@ -59,7 +59,7 @@ class Paths_assertIsSymbolicLink_Test extends PathsBaseTest {
   @Test
   void should_succeed_if_actual_is_a_symbolic_link() throws IOException {
     // GIVEN
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), tempDir.resolve("target"));
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), tempDir.resolve("target"));
     // WHEN/THEN
     underTest.assertIsSymbolicLink(INFO, actual);
   }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertNotExists_Test.java
@@ -57,7 +57,7 @@ class Paths_assertNotExists_Test extends PathsBaseTest {
   void should_fail_if_actual_is_a_symbolic_link_and_target_does_not_exist() throws IOException {
     // GIVEN
     Path target = tempDir.resolve("non-existent");
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), target);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), target);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertDoesNotExist(INFO, actual));
     // THEN

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWithRaw_Test.java
@@ -75,7 +75,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
     // GIVEN
     Path other = createDirectory(tempDir.resolve("other"));
     Path file = createFile(other.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, actual, other));
     // THEN
@@ -86,7 +86,7 @@ class Paths_assertStartsWithRaw_Test extends PathsBaseTest {
   void should_fail_if_other_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));
-    Path other = createSymbolicLink(tempDir.resolve("other"), directory);
+    Path other = tryToCreateSymbolicLink(tempDir.resolve("other"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN
     AssertionError error = expectAssertionError(() -> underTest.assertStartsWithRaw(INFO, actual, other));

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertStartsWith_Test.java
@@ -106,7 +106,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
     // GIVEN
     Path other = createDirectory(tempDir.resolve("other"));
     Path file = createFile(other.resolve("file"));
-    Path actual = createSymbolicLink(tempDir.resolve("actual"), file);
+    Path actual = tryToCreateSymbolicLink(tempDir.resolve("actual"), file);
     // WHEN/THEN
     underTest.assertStartsWith(INFO, actual, other);
   }
@@ -115,7 +115,7 @@ class Paths_assertStartsWith_Test extends PathsBaseTest {
   void should_pass_if_other_is_not_canonical() throws IOException {
     // GIVEN
     Path directory = createDirectory(tempDir.resolve("directory"));
-    Path other = createSymbolicLink(tempDir.resolve("other"), directory);
+    Path other = tryToCreateSymbolicLink(tempDir.resolve("other"), directory);
     Path actual = createFile(directory.resolve("actual"));
     // WHEN/THEN
     underTest.assertStartsWith(INFO, actual, other);


### PR DESCRIPTION
Fixes #3183.
