### PR TITLE
Fix: hasNoNullFields() now detects null collections and arrays

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
@@ -66,7 +66,7 @@ public class RecursiveAssertionDriver {
     boolean nodeAlreadyVisited = markNodeAsVisited(node);
     if (nodeAlreadyVisited) return;
 
-    if (!isRootObject(fieldLocation) && shouldEvaluateAssertion(nodeType)) {
+    if (!isRootObject(fieldLocation) && (node == null || shouldEvaluateAssertion(nodeType))) {
       evaluateAssertion(predicate, node, fieldLocation);
     }
     recurseIntoFieldsOfCurrentNode(predicate, node, nodeType, fieldLocation);

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_hasNoNullFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_hasNoNullFields_Test.java
@@ -113,9 +113,6 @@ class RecursiveAssertionAssert_hasNoNullFields_Test {
                                                                             .hasNoNullFields());
     // THEN
     then(error).hasMessageContainingAll("arrayOuter", "inner.array");
-
-    assertThat(testObject).usingRecursiveAssertion().hasNoNullFields();
-
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #3810

### Description

This PR fixes a bug in `hasNoNullFields()` where fields of type `Collection`, `Map`, `Optional`, or `Array` that were `null` were not evaluated by the recursive assertion engine. As a result, the assertion passed even when some fields were actually `null`.

### GIVEN / WHEN / THEN

- GIVEN: an object with a `null` List, Map, Optional, or Array field
- WHEN: asserting using `assertThat(obj).usingRecursiveAssertion().hasNoNullFields()`
- THEN: the assertion should fail if any field is `null`, regardless of type

### Fix

We modified the condition in `RecursiveAssertionDriver#assertRecursively` to ensure that fields which are `null` are evaluated by the predicate, regardless of their type:

if (!isRootObject(fieldLocation) && (node == null || shouldEvaluateAssertion(nodeType))) {
    evaluateAssertion(predicate, node, fieldLocation);
}
