### PR TITLE
Do not show values for missing map keys

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainEntries.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainEntries.java
@@ -30,12 +30,13 @@ public class ShouldContainEntries extends BasicErrorMessageFactory {
                                                                 Set<Entry<? extends K, ? extends V>> entriesWithWrongValue,
                                                                 Set<Entry<? extends K, ? extends V>> entriesWithKeyNotFound,
                                                                 Representation representation) {
-    if (entriesWithWrongValue.isEmpty()) return new ShouldContainEntries(actual, expectedEntries, entriesWithKeyNotFound);
+    if (entriesWithWrongValue.isEmpty())
+      return new ShouldContainEntries(actual, expectedEntries, getKeys(entriesWithKeyNotFound));
     if (entriesWithKeyNotFound.isEmpty())
       return new ShouldContainEntries(actual, expectedEntries,
                                       buildValueDifferences(actual, entriesWithWrongValue, representation));
     // mix of missing keys and keys with different values
-    return new ShouldContainEntries(actual, expectedEntries, entriesWithKeyNotFound,
+    return new ShouldContainEntries(actual, expectedEntries, getKeys(entriesWithKeyNotFound),
                                     buildValueDifferences(actual, entriesWithWrongValue, representation));
   }
 
@@ -45,6 +46,12 @@ public class ShouldContainEntries extends BasicErrorMessageFactory {
     return entriesWithWrongValues.stream()
                                  .map(entryWithWrongValue -> valueDifference(actual, entryWithWrongValue, representation))
                                  .collect(toList());
+  }
+
+  private static <K, V> List<K> getKeys(Set<Entry<? extends K, ? extends V>> entries) {
+    return entries.stream()
+                  .map(Entry::getKey)
+                  .collect(toList());
   }
 
   private static <K, V> String valueDifference(Map<? extends K, ? extends V> actual,
@@ -59,14 +66,14 @@ public class ShouldContainEntries extends BasicErrorMessageFactory {
 
   private <K, V> ShouldContainEntries(Map<? extends K, ? extends V> actual,
                                       Entry<? extends K, ? extends V>[] expectedEntries,
-                                      Set<Entry<? extends K, ? extends V>> notFound) {
+                                      Iterable<? extends K> keysNotFound) {
     super("%nExpecting map:%n" +
           "  %s%n" +
           "to contain entries:%n" +
           "  %s%n" +
-          "but could not find the following map entries:%n" +
+          "but could not find the following map keys:%n" +
           "  %s",
-          actual, expectedEntries, notFound);
+          actual, expectedEntries, keysNotFound);
   }
 
   private <K, V> ShouldContainEntries(Map<? extends K, ? extends V> actual,
@@ -83,13 +90,13 @@ public class ShouldContainEntries extends BasicErrorMessageFactory {
 
   private <K, V> ShouldContainEntries(Map<? extends K, ? extends V> actual,
                                       Entry<? extends K, ? extends V>[] expectedEntries,
-                                      Set<Entry<? extends K, ? extends V>> keysNotFound,
+                                      Iterable<? extends K> keysNotFound,
                                       List<String> valueDifferences) {
     super("%nExpecting map:%n" +
           "  %s%n" +
           "to contain entries:%n" +
           "  %s%n" +
-          "but could not find the following map entries:%n" +
+          "but could not find the following map keys:%n" +
           "  %s%n" +
           "and the following map entries had different values:%n" +
           "  " + valueDifferences,

--- a/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -180,8 +180,8 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
                                                           + "  {\"54\"=\"55\"}%n"
                                                           + "to contain entries:%n"
                                                           + "  [\"1\"=\"2\"]%n"
-                                                          + "but could not find the following map entries:%n"
-                                                          + "  [\"1\"=\"2\"]"));
+                                                          + "but could not find the following map keys:%n"
+                                                          + "  [\"1\"]"));
     assertThat(errors.get(1)).hasMessageContaining("Expecting empty but was: {\"54\"=\"55\"}");
   }
 
@@ -337,8 +337,8 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
                                                + "  {\"54\"=\"55\"}%n"
                                                + "to contain entries:%n"
                                                + "  [\"1\"=\"2\"]%n"
-                                               + "but could not find the following map entries:%n"
-                                               + "  [\"1\"=\"2\"]"));
+                                               + "but could not find the following map keys:%n"
+                                               + "  [\"1\"]"));
     assertThat(errors.get(40)).contains(shouldBeEqualMessage("12:00", "13:00"));
     assertThat(errors.get(41)).contains(shouldBeEqualMessage("12:00Z", "13:00Z"));
     assertThat(errors.get(42)).contains(shouldBeEqualMessage("Optional[not empty]", "\"empty\""));

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -192,8 +192,8 @@ class SoftAssertionsTest extends BaseAssertionsTest {
                                                       + "  {\"54\"=\"55\"}%n"
                                                       + "to contain entries:%n"
                                                       + "  [\"1\"=\"2\"]%n"
-                                                      + "but could not find the following map entries:%n"
-                                                      + "  [\"1\"=\"2\"]"));
+                                                      + "but could not find the following map keys:%n"
+                                                      + "  [\"1\"]"));
     then(errors.get(1)).hasMessageStartingWith("%nExpecting empty but was: {\"54\"=\"55\"}".formatted());
   }
 
@@ -382,8 +382,8 @@ class SoftAssertionsTest extends BaseAssertionsTest {
                                            + "  {\"54\"=\"55\"}%n"
                                            + "to contain entries:%n"
                                            + "  [\"1\"=\"2\"]%n"
-                                           + "but could not find the following map entries:%n"
-                                           + "  [\"1\"=\"2\"]"));
+                                           + "but could not find the following map keys:%n"
+                                           + "  [\"1\"]"));
 
       then(errors.get(40)).contains(shouldBeEqualMessage("12:00", "13:00"));
       then(errors.get(41)).contains(shouldBeEqualMessage("12:00Z", "13:00Z"));

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainEntries_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainEntries_create_Test.java
@@ -69,8 +69,8 @@ class ShouldContainEntries_create_Test {
                                    "  {\"color\"=\"green\", \"name\"=\"yoda\"}%n" +
                                    "to contain entries:%n" +
                                    "  [\"NAME\"=\"vador\", \"COLOR\"=\"red\"]%n" +
-                                   "but could not find the following map entries:%n" +
-                                   "  [\"NAME\"=\"vador\", \"COLOR\"=\"red\"]"));
+                                   "but could not find the following map keys:%n" +
+                                   "  [\"NAME\", \"COLOR\"]"));
   }
 
   @Test
@@ -90,8 +90,8 @@ class ShouldContainEntries_create_Test {
                                    "  {\"color\"=\"green\", \"name\"=\"yoda\"}%n" +
                                    "to contain entries:%n" +
                                    "  [\"NAME\"=\"yoda\", \"COLOR\"=\"green\"]%n" +
-                                   "but could not find the following map entries:%n" +
-                                   "  [\"NAME\"=\"yoda\", \"COLOR\"=\"green\"]"));
+                                   "but could not find the following map keys:%n" +
+                                   "  [\"NAME\", \"COLOR\"]"));
   }
 
   @Test
@@ -111,8 +111,8 @@ class ShouldContainEntries_create_Test {
                                    "  {\"color\"=\"%%d\", \"name\"=\"yoda\", \"power\"=\"99%%\"}%n" +
                                    "to contain entries:%n" +
                                    "  [\"NAME\"=\"yoda\", \"color\"=\"red\", \"power\"=\"%%s\"]%n" +
-                                   "but could not find the following map entries:%n" +
-                                   "  [\"NAME\"=\"yoda\"]%n" +
+                                   "but could not find the following map keys:%n" +
+                                   "  [\"NAME\"]%n" +
                                    "and the following map entries had different values:%n" +
                                    "  [\"color\"=\"%%d\" (expected: \"red\"), \"power\"=\"99%%\" (expected: \"%%s\")]"));
   }


### PR DESCRIPTION
I find it misleading/distracting to show the entry value when the reason the assertion fails is the key not being found.
