### PR TITLE
Fix ignoringFields with map containing a null key

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -51,6 +51,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.assertj.core.internal.DeepDifference;
 
 /**
@@ -698,8 +699,10 @@ public class RecursiveComparisonDifferenceCalculator {
       return map;
     }
     return map.entrySet().stream()
-              .filter(e -> !configuration.matchesAnIgnoredField(fieldLocation.field(e.getKey().toString())))
-              .filter(e -> !configuration.matchesAnIgnoredFieldRegex(fieldLocation.field(e.getKey().toString())))
+              .filter(e -> e.getKey() == null
+                           || !configuration.matchesAnIgnoredField(fieldLocation.field(e.getKey().toString())))
+              .filter(e -> e.getKey() == null
+                           || !configuration.matchesAnIgnoredFieldRegex(fieldLocation.field(e.getKey().toString())))
               .collect(toMap(Entry::getKey, Entry::getValue));
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringFields_Test.java
@@ -805,6 +805,22 @@ class RecursiveComparisonAssert_isEqualTo_ignoringFields_Test extends WithCompar
   }
 
   @Test
+  void should_honor_ignored_fields_in_map_with_null_key() {
+    // GIVEN
+    Map<String, String> actual = new HashMap<>();
+    actual.put("foo", "value1");
+    actual.put(null, "value");
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("foo", "value2");
+    expected.put(null, "value");
+    // WHEN/THEN
+    then(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                .ignoringFields("foo")
+                .isEqualTo(expected);
+  }
+
+  @Test
   void should_honor_ignored_fields_in_map_with_null_value() {
     // GIVEN
     Map<String, String> actual = new HashMap<>();


### PR DESCRIPTION
Fix ignoringFields with recursive comparison throwing NPE on maps with null keys

Fixes #3829