### PR TITLE
Add option to ignore compared fields existence check

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2515,6 +2515,52 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   }
 
   /**
+   * Allows to ignore non-existent fields in the recursive comparison when using
+   * {@link #usingRecursiveFieldByFieldElementComparatorOnFields(String...)} or similar methods.
+   * <p>
+   * This is useful when comparing collections of polymorphic objects where some fields might not exist in all subtypes.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * // GIVEN
+   * class BaseClass {
+   *   String common = "same";
+   * }
+   *
+   * class SubType1 extends BaseClass {
+   *   String onlyInSubType1 = "type1";
+   * }
+   *
+   * class SubType2 extends BaseClass {
+   *   // No 'onlyInSubType1' field
+   *   String onlyInSubType2 = "type2";
+   * }
+   *
+   * // WHEN
+   * List&lt;BaseClass&gt; list1 = Arrays.asList(new SubType1(), new SubType2());
+   * List&lt;BaseClass&gt; list2 = Arrays.asList(new SubType1(), new SubType2());
+   *
+   * // THEN
+   * // Without ignoringNonExistentComparedFields(), this would fail
+   * // because 'onlyInSubType1' and 'onlyInSubType2' don't exist in both types
+   * assertThat(list1)
+   *       .usingRecursiveFieldByFieldElementComparatorOnFields("common", "onlyInSubType1", "onlyInSubType2")
+   *       .ignoringNonExistentComparedFields()
+   *       .containsExactlyInAnyOrderElementsOf(list2);
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   */
+  @CheckReturnValue
+  public SELF ignoringNonExistentComparedFields() {
+    RecursiveComparisonConfiguration recursiveComparisonConfiguration = RecursiveComparisonConfiguration.builder()
+                                                                                                        .withIgnoreNonExistentComparedFields(true)
+                                                                                                        .build();
+
+    return usingRecursiveFieldByFieldElementComparator(recursiveComparisonConfiguration);
+  }
+
+  /**
    * Enable hexadecimal representation of Iterable elements instead of standard representation in error messages.
    * <p>
    * It can be useful to better understand what the error was with a more meaningful error message.

--- a/assertj-core/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -650,6 +650,46 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
   }
 
   /**
+   * Allows to ignore non-existent fields in the recursive comparison.
+   * <p>
+   * This is useful when comparing polymorphic objects where some fields might not exist in all subtypes.
+   * <p>
+   * Example:
+   * <pre><code class='java'> class BaseClass {
+   *   String commonField = "common";
+   * }
+   *
+   * class SubClass1 extends BaseClass {
+   *   String subField1 = "sub1";
+   * }
+   *
+   * class SubClass2 extends BaseClass {
+   *   // 'subField1' doesn't exist here
+   *   String subField2 = "sub2";
+   * }
+   *
+   * SubClass1 actual = new SubClass1();
+   * SubClass2 expected = new SubClass2();
+   *
+   * // Regular recursive comparison - fails due to field existence check
+   * // assertThat(actual).usingRecursiveComparison().isEqualTo(expected); // fails!
+   *
+   * // Using ignoringNonExistentComparedFields() makes it pass
+   * assertThat(actual)
+   *   .usingRecursiveComparison()
+   *   .ignoringNonExistentComparedFields()
+   *   .isEqualTo(expected);
+   * </code></pre>
+   *
+   * @return this {@link RecursiveComparisonAssert} to allow fluent chaining.
+   */
+  @CheckReturnValue
+  public SELF ignoringNonExistentComparedFields() {
+    recursiveComparisonConfiguration.setIgnoreNonExistentComparedFields(true);
+    return myself;
+  }
+
+  /**
    * Makes the recursive comparison to ignore all <b>expected null fields</b>.
    * <p>
    * Example:

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -57,6 +57,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
   private boolean ignoreAllActualNullFields = false;
   private boolean ignoreAllActualEmptyOptionalFields = false;
   private boolean ignoreAllExpectedNullFields = false;
+  private boolean ignoreNonExistentComparedFields = false;
 
   // fields to compare (no other field will be)
   private Set<FieldLocation> comparedFields = new LinkedHashSet<>();
@@ -102,6 +103,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
     this.ignoreAllActualEmptyOptionalFields = builder.ignoreAllActualEmptyOptionalFields;
     this.strictTypeChecking = builder.strictTypeChecking;
     this.ignoreAllExpectedNullFields = builder.ignoreAllExpectedNullFields;
+    this.ignoreNonExistentComparedFields = builder.ignoreNonExistentComparedFields;
     this.comparedFields = newLinkedHashSet(builder.comparedFields);
     this.comparedTypes = newLinkedHashSet(builder.comparedTypes);
     ignoreOverriddenEqualsForTypes(builder.ignoredOverriddenEqualsForTypes);
@@ -189,6 +191,10 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
     return ignoreAllExpectedNullFields;
   }
 
+  public boolean getIgnoreNonExistentComparedFields() {
+    return ignoreNonExistentComparedFields;
+  }
+
   public boolean getIgnoreAllOverriddenEquals() {
     return ignoreAllOverriddenEquals;
   }
@@ -228,6 +234,19 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
    */
   public void setIgnoreAllExpectedNullFields(boolean ignoreAllExpectedNullFields) {
     this.ignoreAllExpectedNullFields = ignoreAllExpectedNullFields;
+  }
+
+  /**
+   * Sets whether fields that don't exist in the object should be ignored in the recursive comparison.
+   * <p>
+   * This is useful when comparing polymorphic objects where some fields might not exist in all subtypes.
+   * <p>
+   * See {@link RecursiveComparisonAssert#ignoringNonExistentComparedFields()} for code examples.
+   *
+   * @param ignoreNonExistentComparedFields whether to ignore non-existent fields in the recursive comparison
+   */
+  public void setIgnoreNonExistentComparedFields(boolean ignoreNonExistentComparedFields) {
+    this.ignoreNonExistentComparedFields = ignoreNonExistentComparedFields;
   }
 
   /**
@@ -644,7 +663,8 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
   @Override
   public int hashCode() {
     return java.util.Objects.hash(fieldComparators, ignoreAllActualEmptyOptionalFields, ignoreAllActualNullFields,
-                                  ignoreAllExpectedNullFields, ignoreAllOverriddenEquals, ignoreCollectionOrder,
+                                  ignoreAllExpectedNullFields, ignoreNonExistentComparedFields, ignoreAllOverriddenEquals,
+                                  ignoreCollectionOrder,
                                   ignoredCollectionOrderInFields, ignoredCollectionOrderInFieldsMatchingRegexes,
                                   getIgnoredFields(), getIgnoredFieldsRegexes(), ignoredOverriddenEqualsForFields,
                                   ignoredOverriddenEqualsForTypes, ignoredOverriddenEqualsForFieldsMatchingRegexes,
@@ -662,6 +682,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
            && ignoreAllActualEmptyOptionalFields == other.ignoreAllActualEmptyOptionalFields
            && ignoreAllActualNullFields == other.ignoreAllActualNullFields
            && ignoreAllExpectedNullFields == other.ignoreAllExpectedNullFields
+           && ignoreNonExistentComparedFields == other.ignoreNonExistentComparedFields
            && ignoreAllOverriddenEquals == other.ignoreAllOverriddenEquals
            && ignoreCollectionOrder == other.ignoreCollectionOrder
            && ignoreArrayOrder == other.ignoreArrayOrder
@@ -688,6 +709,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
     describeIgnoreAllActualNullFields(description);
     describeIgnoreAllActualEmptyOptionalFields(description);
     describeIgnoreAllExpectedNullFields(description);
+    describeIgnoreNonExistentFields(description);
     describeComparedFields(description);
     describeComparedTypes(description);
     describeIgnoredFields(description);
@@ -876,6 +898,11 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
   private void describeIgnoreAllExpectedNullFields(StringBuilder description) {
     if (ignoreAllExpectedNullFields)
       description.append("- all expected null fields were ignored in the comparison%n".formatted());
+  }
+
+  private void describeIgnoreNonExistentFields(StringBuilder description) {
+    if (ignoreNonExistentComparedFields)
+      description.append("- fields that do not exist in the actual object were ignored in the comparison%n".formatted());
   }
 
   private void describeOverriddenEqualsMethodsUsage(StringBuilder description, Representation representation) {
@@ -1132,6 +1159,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
   }
 
   void checkComparedFieldsExist(Object actual) {
+    if (ignoreNonExistentComparedFields) return;
     Map<FieldLocation, String> unknownComparedFields = new TreeMap<>();
     for (FieldLocation comparedField : comparedFields) {
       checkComparedFieldExists(actual,
@@ -1207,6 +1235,7 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
     private boolean ignoreAllActualNullFields;
     private boolean ignoreAllActualEmptyOptionalFields;
     private boolean ignoreAllExpectedNullFields;
+    private boolean ignoreNonExistentComparedFields;
     private FieldLocation[] comparedFields = {};
     private Class<?>[] comparedTypes = {};
     private Class<?>[] ignoredOverriddenEqualsForTypes = {};
@@ -1289,6 +1318,19 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
      */
     public Builder withIgnoreAllExpectedNullFields(boolean ignoreAllExpectedNullFields) {
       this.ignoreAllExpectedNullFields = ignoreAllExpectedNullFields;
+      return this;
+    }
+
+    /**
+     * Sets whether the field existence check should be ignored during recursive comparison.
+     * <p>
+     * This is useful when comparing polymorphic objects where some fields might not exist in all subtypes.
+     *
+     * @param ignoreNonExistentComparedFields whether to ignore the field existence check
+     * @return this builder.
+     */
+    public Builder withIgnoreNonExistentComparedFields(boolean ignoreNonExistentComparedFields) {
+      this.ignoreNonExistentComparedFields = ignoreNonExistentComparedFields;
       return this;
     }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/configuration/RecursiveComparisonConfiguration_builder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/configuration/RecursiveComparisonConfiguration_builder_Test.java
@@ -397,6 +397,24 @@ class RecursiveComparisonConfiguration_builder_Test {
     then(recursiveComparisonConfiguration.getRepresentation()).isSameAs(STANDARD_REPRESENTATION);
   }
 
+  @Test
+  void should_set_ignoreNonExistentFields() {
+    // GIVEN
+    boolean value = RandomUtils.secure().randomBoolean();
+    // WHEN
+    RecursiveComparisonConfiguration configuration = configBuilder().withIgnoreNonExistentComparedFields(value).build();
+    // THEN
+    then(configuration.getIgnoreNonExistentComparedFields()).isEqualTo(value);
+  }
+
+  @Test
+  void should_set_ignoreNonExistentFields_with_shortcut_method() {
+    // WHEN
+    RecursiveComparisonConfiguration configuration = configBuilder().build();
+    // THEN
+    then(configuration.getIgnoreNonExistentComparedFields()).isFalse();
+  }
+
   private static Builder configBuilder() {
     return RecursiveComparisonConfiguration.builder();
   }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/configuration/RecursiveComparisonConfiguration_multiLineDescription_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/configuration/RecursiveComparisonConfiguration_multiLineDescription_Test.java
@@ -338,6 +338,7 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
     recursiveComparisonConfiguration.setIgnoreAllActualNullFields(true);
     recursiveComparisonConfiguration.setIgnoreAllActualEmptyOptionalFields(true);
     recursiveComparisonConfiguration.setIgnoreAllExpectedNullFields(true);
+    recursiveComparisonConfiguration.setIgnoreNonExistentComparedFields(true);
     recursiveComparisonConfiguration.compareOnlyFields("name", "address.number");
     recursiveComparisonConfiguration.compareOnlyFieldsOfTypes(String.class, Integer.class);
     recursiveComparisonConfiguration.ignoreFields("foo", "bar", "foo.bar");
@@ -364,6 +365,7 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
                "- all actual null fields were ignored in the comparison%n" +
                "- all actual empty optional fields were ignored in the comparison (including Optional, OptionalInt, OptionalLong and OptionalDouble)%n" +
                "- all expected null fields were ignored in the comparison%n" +
+               "- fields that do not exist in the actual object were ignored in the comparison%n" +
                "- the comparison was performed on the following fields: name, address.number%n" +
                "- the comparison was performed on any fields with types: java.lang.String, java.lang.Integer%n" +
                "- the following fields were ignored in the comparison: foo, bar, foo.bar%n" +
@@ -421,6 +423,17 @@ class RecursiveComparisonConfiguration_multiLineDescription_Test {
     String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
     // THEN
     then(multiLineDescription).contains("- enums can be compared against strings (and vice versa), e.g. Color.RED and \"RED\" are considered equal");
+  }
+
+  @Test
+  void should_show_ignoreNonExistentFields_in_the_description() {
+    // GIVEN
+    RecursiveComparisonConfiguration recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
+    recursiveComparisonConfiguration.setIgnoreNonExistentComparedFields(true);
+    // WHEN
+    String multiLineDescription = recursiveComparisonConfiguration.multiLineDescription(STANDARD_REPRESENTATION);
+    // THEN
+    then(multiLineDescription).contains("- fields that do not exist in the actual object were ignored in the comparison");
   }
 
   // just to test the description does not fail when given a comparator with various String.format reserved flags


### PR DESCRIPTION
This adds a new option (ignoringNonExistentFields) to recursive comparison that allows polymorphic objects with different field structures to be compared effectively. When enabled, the comparison will skip field existence validation, which is useful when comparing objects of different subtypes where some fields might only exist in certain implementations.

## Overview
This PR adds a new feature to the recursive comparison functionality that allows ignoring non-existent field checks. This is particularly useful when comparing polymorphic objects where some fields might not exist in all subtypes.

## Implementation Details
- Added `ignoreNonExistentFields` boolean flag to `RecursiveComparisonConfiguration`
- Added `ignoringNonExistentFields()` method to `RecursiveComparisonAssert`
- Added appropriate builder methods and setters
- Added early return in `checkComparedFieldsExist` when this option is enabled
- Added corresponding toString/description methods to show when this option is active
- Added unit tests to verify the behavior

## Example Use Case
When comparing objects like:
```java
class BaseClass {
    String commonField = "common";
}

class SubClass1 extends BaseClass {
    String subField1 = "sub1";
}

class SubClass2 extends BaseClass {
    // 'subField1' doesn't exist here
    String subField2 = "sub2";
}
```

Regular recursive comparison would fail due to field existence checks. With this new option:
```java
SubClass1 actual = new SubClass1();
SubClass2 expected = new SubClass2();

// This will now pass
assertThat(actual)
    .usingRecursiveComparison()
    .ignoringNonExistentFields()
    .isEqualTo(expected);
```

#### Check List:
* Fixes #3806 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) : YES