### PR TITLE
improve isThrown() method error msg

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -59,7 +59,9 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   protected void hasThrownExceptionOf(Class<? extends Throwable> expectedThrowableType) {
     if (actual == null) {
       String typeName = expectedThrowableType.getName();
-      throw Failures.instance().failure(info, new BasicErrorMessageFactory("%nExpecting code to throw %s, but no exception was thrown.".formatted(typeName)));
+      throw Failures.instance()
+                    .failure(info,
+                             new BasicErrorMessageFactory("%nExpecting code to throw %s, but no exception was thrown.".formatted(typeName)));
     }
     myself.isInstanceOf(expectedThrowableType);
   }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -59,7 +59,7 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
   protected void hasThrownExceptionOf(Class<? extends Throwable> expectedThrowableType) {
     if (actual == null) {
       String typeName = expectedThrowableType.getName();
-      throw Failures.instance().failure(info, new BasicErrorMessageFactory("%nExpecting code to throw %s, but no exception was thrown".formatted(typeName)));
+      throw Failures.instance().failure(info, new BasicErrorMessageFactory("%nExpecting code to throw %s, but no exception was thrown.".formatted(typeName)));
     }
     myself.isInstanceOf(expectedThrowableType);
   }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractThrowableAssert.java
@@ -56,6 +56,14 @@ public abstract class AbstractThrowableAssert<SELF extends AbstractThrowableAsse
     return myself;
   }
 
+  protected void hasThrownExceptionOf(Class<? extends Throwable> expectedThrowableType) {
+    if (actual == null) {
+      String typeName = expectedThrowableType.getName();
+      throw Failures.instance().failure(info, new BasicErrorMessageFactory("%nExpecting code to throw %s, but no exception was thrown".formatted(typeName)));
+    }
+    myself.isInstanceOf(expectedThrowableType);
+  }
+
   /**
    * Verifies that the message of the actual {@code Throwable} is equal to the given one.
    *

--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowableTypeAssert.java
@@ -63,7 +63,7 @@ public class ThrowableTypeAssert<T extends Throwable> implements Descriptable<Th
   }
 
   protected void checkThrowableType(Throwable throwable) {
-    assertThat(throwable).as(description).hasBeenThrown().isInstanceOf(expectedThrowableType);
+    assertThat(throwable).as(description).hasThrownExceptionOf(expectedThrowableType);
   }
 
   protected ThrowableAssertAlternative<T> buildThrowableTypeAssert(T throwable) {

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -2712,9 +2712,9 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     // WHEN
     Stream.of("A", "B").forEach(runAssertions);
     // THEN
-    then(softly.errorsCollected()).extracting(Throwable::getMessage)
-                                  .containsExactly("[checking A] %nExpecting code to raise a throwable.".formatted(),
-                                                   "[checking B] %nExpecting code to raise a throwable.".formatted());
+    then(softly.errorsCollected()).extracting(Throwable::getMessage).containsExactly(
+      "[checking A] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted(),
+      "[checking B] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted());
   }
 
   @ParameterizedTest

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -2713,8 +2713,8 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     Stream.of("A", "B").forEach(runAssertions);
     // THEN
     then(softly.errorsCollected()).extracting(Throwable::getMessage).containsExactly(
-      "[checking A] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted(),
-      "[checking B] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted());
+                                                                                     "[checking A] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted(),
+                                                                                     "[checking B] %nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted());
   }
 
   @ParameterizedTest

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ExpectThrowableAssert_isThrownBy_Test.java
@@ -15,6 +15,7 @@ package org.assertj.core.api.throwable;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.NoSuchElementException;
+
 import org.junit.jupiter.api.Test;
 
 class ExpectThrowableAssert_isThrownBy_Test {
@@ -51,6 +52,6 @@ class ExpectThrowableAssert_isThrownBy_Test {
   @Test
   void should_fail_if_nothing_is_thrown_by_lambda() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() -> {}))
-                                                   .withMessage("%nExpecting code to raise a throwable.".formatted());
+                                                   .withMessage("%nExpecting code to throw java.util.NoSuchElementException, but no exception was thrown.".formatted());
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableTypeAssert_description_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/throwable/ThrowableTypeAssert_description_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThr
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableTypeAssert;
 import org.assertj.core.description.TextDescription;
@@ -46,7 +47,7 @@ class ThrowableTypeAssert_description_Test {
   void should_contain_provided_description_if_nothing_is_thrown_by_lambda(Function<ThrowableTypeAssert<?>, ThrowableTypeAssert<?>> descriptionAdder) {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> descriptionAdder.apply(assertThatExceptionOfType(NoSuchElementException.class))
                                                                                      .isThrownBy(() -> {}))
-                                                   .withMessage("[test description] %nExpecting code to raise a throwable.".formatted());
+                                                   .withMessage("[test description] %nExpecting code to throw java.util.NoSuchElementException, but no exception was thrown.".formatted());
   }
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatException_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatException_Test.java
@@ -49,6 +49,6 @@ class Assertions_assertThatException_Test {
     // WHEN
     AssertionError assertionError = expectAssertionError(throwingCallable);
     // THEN
-    then(assertionError).hasMessage("%nExpecting code to raise a throwable.".formatted());
+    then(assertionError).hasMessage("%nExpecting code to throw java.lang.Exception, but no exception was thrown.".formatted());
   }
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatIndexOutOfBoundsException_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatIndexOutOfBoundsException_Test.java
@@ -44,6 +44,6 @@ class Assertions_assertThatIndexOutOfBoundsException_Test {
     // WHEN
     AssertionError assertionError = expectAssertionError(throwingCallable);
     // THEN
-    then(assertionError).hasMessage("%nExpecting code to raise a throwable.".formatted());
+    then(assertionError).hasMessage("%nExpecting code to throw java.lang.IndexOutOfBoundsException, but no exception was thrown.".formatted());
   }
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatReflectiveOperationException_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatReflectiveOperationException_Test.java
@@ -44,6 +44,6 @@ class Assertions_assertThatReflectiveOperationException_Test {
     // WHEN
     AssertionError assertionError = expectAssertionError(throwingCallable);
     // THEN
-    then(assertionError).hasMessage("%nExpecting code to raise a throwable.".formatted());
+    then(assertionError).hasMessage("%nExpecting code to throw java.lang.ReflectiveOperationException, but no exception was thrown.".formatted());
   }
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatRuntimeException_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThatRuntimeException_Test.java
@@ -44,6 +44,6 @@ class Assertions_assertThatRuntimeException_Test {
     // WHEN
     AssertionError assertionError = expectAssertionError(throwingCallable);
     // THEN
-    then(assertionError).hasMessage("%nExpecting code to raise a throwable.".formatted());
+    then(assertionError).hasMessage("%nExpecting code to throw java.lang.RuntimeException, but no exception was thrown.".formatted());
   }
 }


### PR DESCRIPTION
#### Description

This PR improves the clarity of error messages when no exception is thrown by a lambda passed to isThrownBy.

Previously, the failure message simply stated that “code should raise a throwable,” which could be vague in some contexts.
Now, the message explicitly mentions the expected exception type, e.g.:

```
Expecting code to throw java.lang.IllegalArgumentException, but no exception was thrown.
```

This change enhances the developer experience by providing more precise feedback during assertion failures, especially when working with soft assertions or parameterized exception checks.

I also updated related tests to align with the new message format.

#### Check List:
* Fixes #3845
* Unit tests : YES / NO / NA
* Javadoc with a code example (on API only) : YES / NO / NA

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.