### PR TITLE
Add `doesNotContainSequence` and `doesNotContainSubsequence` to `AbstractCharSequenceAssert`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -949,6 +949,118 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} does not contain the given sequence;
+   * a sequence is defined as a group of values arranged <b>in the given order without any other values
+   * between them</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'>{@literal  String book = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+   *
+   * // assertions will pass
+   * assertThat(book).doesNotContainSequence("A Game of ", "Shadows");
+   * assertThat(book).doesNotContainSequence("A Game of ", "George Martin");
+   *
+   * // assertions will fail
+   * assertThat(book).doesNotContainSequence("A Game of ", "Thrones");}</code></pre>
+   *
+   * @param sequence the sequence to look for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given values is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} contains the given values in the given order
+   * without any characters between them.
+   */
+  public SELF doesNotContainSequence(CharSequence... sequence) {
+    strings.assertDoesNotContainSequence(info, actual, sequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} does not contain the given sequence;
+   * a sequence is defined as a group of values arranged <b>in the given order without any other values
+   * between them</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'>{@literal  String book = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+   *
+   * // assertions will pass
+   * assertThat(book).doesNotContainSequence(asList("A Game of ", "Shadows"));
+   * assertThat(book).doesNotContainSequence(asList("A Game of ", "George Martin"));
+   *
+   * // assertions will fail
+   * assertThat(book).doesNotContainSequence(asList("A Game of ", "Thrones"));}</code></pre>
+   *
+   * @param sequence the sequence to look for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given values is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} contains the given values in the given order
+   * without any characters between them.
+   */
+  public SELF doesNotContainSequence(Iterable<? extends CharSequence> sequence) {
+    strings.assertDoesNotContainSequence(info, actual, toArray(sequence, CharSequence.class));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} does not contain the given subsequence;
+   * a subsequence is defined as a group of values arranged <b>in the given order, possibly with some values
+   * between them</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'>{@literal  String book = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+   *
+   * // assertions will pass
+   * assertThat(book).doesNotContainSubsequence("A Game of ", "Shadows");
+   *
+   * // assertions will fail
+   * assertThat(book).doesNotContainSubsequence("A Game of ", "George Martin");
+   * assertThat(book).doesNotContainSubsequence("A Game of ", "Thrones");}</code></pre>
+   *
+   * @param subsequence the subsequence to look for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given values is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} contains the given values in the given order,
+   * possibly with other characters between them.
+   */
+  public SELF doesNotContainSubsequence(CharSequence... subsequence) {
+    strings.assertDoesNotContainSubsequence(info, actual, subsequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} does not contain the given subsequence;
+   * a subsequence is defined as a group of values arranged <b>in the given order, possibly with some values
+   * between them</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'>{@literal  String book = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+   *
+   * // assertions will pass
+   * assertThat(book).doesNotContainSubsequence(asList("A Game of ", "Shadows"));
+   *
+   * // assertions will fail
+   * assertThat(book).doesNotContainSubsequence(asList("A Game of ", "George Martin"));
+   * assertThat(book).doesNotContainSubsequence(asList("A Game of ", "Thrones"));}</code></pre>
+   *
+   * @param subsequence the subsequence to look for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given values is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} contains the given values in the given order,
+   * possibly with other characters between them.
+   */
+  public SELF doesNotContainSubsequence(Iterable<? extends CharSequence> subsequence) {
+    strings.assertDoesNotContainSubsequence(info, actual, toArray(subsequence, CharSequence.class));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} does not contain any of the given values, ignoring case considerations.
    * <p>
    * Example:

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.comparisonstrategy.ComparisonStrategy;
+import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that {@link CharSequence} does not contain
+ * a sequence of several {@code CharSequence} in order failed.
+ */
+public class ShouldNotContainSequenceOfCharSequence extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new {@link ShouldNotContainSequenceOfCharSequence}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param sequence the sequence of {@link CharSequence} expected not to be in {@code actual}.
+   * @param index the index where the sequence was found in {@code actual}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@link ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainSequence(CharSequence actual, CharSequence[] sequence, int index,
+                                                             ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotContainSequenceOfCharSequence(actual, sequence, index, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new {@link ShouldNotContainSequenceOfCharSequence}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param sequence the sequence of {@link CharSequence} expected not to be in {@code actual}.
+   * @param index the index where the sequence was found in {@code actual}.
+   * @return the created {@link ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainSequence(CharSequence actual, CharSequence[] sequence, int index) {
+    return new ShouldNotContainSequenceOfCharSequence(actual, sequence, index, StandardComparisonStrategy.instance());
+  }
+
+  private ShouldNotContainSequenceOfCharSequence(CharSequence actual, CharSequence[] sequence, int index,
+                                                 ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto not contain sequence:%n  %s%nbut was found at index %s%n%s", actual, sequence, index,
+          comparisonStrategy);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.comparisonstrategy.ComparisonStrategy;
+import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that {@link CharSequence} does not contain
+ * a subsequence of several {@code CharSequence} in order failed.
+ */
+public class ShouldNotContainSubsequenceOfCharSequence extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new {@link ShouldNotContainSubsequenceOfCharSequence}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param subsequence the subsequence of {@link CharSequence} expected not to be in {@code actual}.
+   * @param subsequenceIndexes the indexes of items of {@code subsequence} found in {@code actual}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@link ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainSubsequence(CharSequence actual, CharSequence[] subsequence,
+                                                                int[] subsequenceIndexes, ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotContainSubsequenceOfCharSequence(actual, subsequence, subsequenceIndexes, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new {@link ShouldNotContainSubsequenceOfCharSequence}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param subsequence the subsequence of {@link CharSequence} expected not to be in {@code actual}.
+   * @param subsequenceIndexes the indexes of items of {@code subsequence} found in {@code actual}.
+   * @return the created {@link ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotContainSubsequence(CharSequence actual, CharSequence[] subsequence,
+                                                                int[] subsequenceIndexes) {
+    return new ShouldNotContainSubsequenceOfCharSequence(actual, subsequence, subsequenceIndexes,
+                                                         StandardComparisonStrategy.instance());
+  }
+
+  private ShouldNotContainSubsequenceOfCharSequence(CharSequence actual, CharSequence[] subsequence, int[] subsequenceIndexes,
+                                                    ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto not contain subsequence:%n  %s%nbut was found with indexes:%n  %s%n%s", actual,
+          subsequence, subsequenceIndexes, comparisonStrategy);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Strings.java
@@ -60,6 +60,8 @@ import static org.assertj.core.error.ShouldNotBeEqualNormalizingWhitespace.shoul
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContain;
 import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotContainIgnoringCase;
 import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
+import static org.assertj.core.error.ShouldNotContainSequenceOfCharSequence.shouldNotContainSequence;
+import static org.assertj.core.error.ShouldNotContainSubsequenceOfCharSequence.shouldNotContainSubsequence;
 import static org.assertj.core.error.ShouldNotEndWith.shouldNotEndWith;
 import static org.assertj.core.error.ShouldNotEndWithIgnoringCase.shouldNotEndWithIgnoringCase;
 import static org.assertj.core.error.ShouldNotMatchPattern.shouldNotMatch;
@@ -680,20 +682,57 @@ public class Strings {
 
   private String removeUpTo(String string, CharSequence toRemove) {
     // we have already checked that toRemove was not null in doCommonCheckForCharSequence and this point string is not neither
-    int index = indexOf(string, toRemove);
-    // remove the start of string up to toRemove included
+    int index = indexOf(string, toRemove.toString());
+    // remove the start of string up to toRemove included.
+    // index cannot be -1 here since we this method is used from assertContainsSubsequence at a step where we know
+    // that toRemove was found, and we are checking whether it was at the right place/order.
     return string.substring(index + toRemove.length());
   }
 
-  private int indexOf(String string, CharSequence toFind) {
-    if (EMPTY_STRING.equals(string) && EMPTY_STRING.equals(toFind.toString())) return 0;
-    for (int i = 0; i < string.length(); i++) {
-      if (comparisonStrategy.stringStartsWith(string.substring(i), toFind.toString())) return i;
+  private int indexOf(String str, String toFind) {
+    return indexOf(str, toFind, 0);
+  }
+
+  private int indexOf(String str, String toFind, int fromIndex) {
+    if (EMPTY_STRING.equals(str) && EMPTY_STRING.equals(toFind)) return 0;
+    for (int i = fromIndex; i < str.length(); i++) {
+      if (comparisonStrategy.stringStartsWith(str.substring(i), toFind)) return i;
     }
-    // should not arrive here since we this method is used from assertContainsSubsequence at a step where we know that toFind
-    // was found and we are checking whether it was at the right place/order.
-    throw new IllegalStateException("%s should have been found in %s, please raise an assertj-core issue".formatted(toFind,
-                                                                                                                    string));
+
+    return -1;
+  }
+
+  public void assertDoesNotContainSequence(AssertionInfo info, CharSequence actual, CharSequence[] sequence) {
+    doCommonCheckForCharSequence(info, actual, sequence);
+
+    String strActual = actual.toString();
+    String strSequence = String.join(EMPTY_STRING, sequence);
+
+    int index = indexOf(strActual, strSequence);
+    if (index != -1) {
+      throw failures.failure(info, shouldNotContainSequence(actual, sequence, index, comparisonStrategy));
+    }
+  }
+
+  public void assertDoesNotContainSubsequence(AssertionInfo info, CharSequence actual, CharSequence[] subsequence) {
+    doCommonCheckForCharSequence(info, actual, subsequence);
+
+    String strActual = actual.toString();
+    int startIndex = 0;
+    int[] subsequenceIndexes = new int[subsequence.length];
+    for (int i = 0; i < subsequence.length; i++) {
+      String strSubsequenceItem = subsequence[i].toString();
+
+      int index = indexOf(strActual, strSubsequenceItem, startIndex);
+      if (index != -1) {
+        subsequenceIndexes[i] = index;
+        startIndex = index + strSubsequenceItem.length();
+      } else {
+        return;
+      }
+    }
+
+    throw failures.failure(info, shouldNotContainSubsequence(actual, subsequence, subsequenceIndexes, comparisonStrategy));
   }
 
   public void assertXmlEqualsTo(AssertionInfo info, CharSequence actualXml, CharSequence expectedXml) {

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSequence_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link CharSequenceAssert#doesNotContainSequence(Iterable)}.
+ */
+class CharSequenceAssert_doesNotContainSequence_Test extends CharSequenceAssertBaseTest {
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainSequence(Arrays.<CharSequence> asList("Yo", "da"));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainSequence(getInfo(assertions), getActual(assertions), array("Yo", "da"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSequence_with_var_args_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSequence_with_var_args_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link CharSequenceAssert#doesNotContainSequence(CharSequence...)}.
+ */
+class CharSequenceAssert_doesNotContainSequence_with_var_args_Test extends CharSequenceAssertBaseTest {
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainSequence("Yo", "da");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainSequence(getInfo(assertions), getActual(assertions), array("Yo", "da"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSubsequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSubsequence_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link CharSequenceAssert#doesNotContainSubsequence(Iterable)}.
+ */
+class CharSequenceAssert_doesNotContainSubsequence_Test extends CharSequenceAssertBaseTest {
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainSubsequence(Arrays.<CharSequence> asList("Yo", "da"));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainSubsequence(getInfo(assertions), getActual(assertions), array("Yo", "da"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSubsequence_with_var_args_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotContainSubsequence_with_var_args_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link CharSequenceAssert#doesNotContainSubsequence(CharSequence...)}.
+ */
+class CharSequenceAssert_doesNotContainSubsequence_with_var_args_Test extends CharSequenceAssertBaseTest {
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotContainSubsequence("Yo", "da");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotContainSubsequence(getInfo(assertions), getActual(assertions), array("Yo", "da"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.comparisonstrategy.ComparatorBasedComparisonStrategy;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.testkit.CaseInsensitiveStringComparator;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainSequenceOfCharSequence.shouldNotContainSequence;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.util.Arrays.array;
+
+/**
+ * Tests for {@link ShouldNotContainSequenceOfCharSequence#create(Description, Representation)}.
+ */
+class ShouldNotContainSequenceOfCharSequence_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotContainSequence("Yoda", array("Yo", "da"), 0);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda\"%n" +
+                                   "to not contain sequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found at index 0%n"));
+  }
+
+  @Test
+  void should_create_error_message_with_custom_comparison_strategy() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotContainSequence("Yoda", array("Yo", "da"), 0,
+                                                           new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.INSTANCE));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda\"%n" +
+                                   "to not contain sequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found at index 0%n" +
+                                   "when comparing values using CaseInsensitiveStringComparator"));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence_create_Test.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.comparisonstrategy.ComparatorBasedComparisonStrategy;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.presentation.Representation;
+import org.assertj.core.testkit.CaseInsensitiveStringComparator;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotContainSubsequenceOfCharSequence.shouldNotContainSubsequence;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.assertj.core.util.Arrays.array;
+
+/**
+ * Tests for {@link ShouldNotContainSubsequenceOfCharSequence#create(Description, Representation)}.
+ */
+class ShouldNotContainSubsequenceOfCharSequence_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotContainSubsequence("Yoda", array("Yo", "da"), new int[] { 0, 2 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda\"%n" +
+                                   "to not contain subsequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found with indexes:%n" +
+                                   "  [0, 2]%n"));
+  }
+
+  @Test
+  void should_create_error_message_with_custom_comparison_strategy() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotContainSubsequence("Yoda", array("Yo", "da"), new int[] { 0, 2 },
+                                                              new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.INSTANCE));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda\"%n" +
+                                   "to not contain subsequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found with indexes:%n" +
+                                   "  [0, 2]%n" +
+                                   "when comparing values using CaseInsensitiveStringComparator"));
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSequence_Test.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.tests.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.internal.Strings;
+import org.assertj.tests.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.assertj.core.error.ShouldNotContainSequenceOfCharSequence.shouldNotContainSequence;
+import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsNull;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.tests.core.testkit.TestData.someInfo;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+/**
+ * Tests for {@link Strings#assertDoesNotContainSequence(AssertionInfo, CharSequence, CharSequence[])}.
+ */
+class Strings_assertDoesNotContainSequence_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_does_not_contain_all_sequence_items() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "A Game of ", "Shadows" };
+
+    strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_sequence_items_but_not_in_the_correct_order() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "Thrones", " of ", "Game" };
+
+    strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_sequence_items_but_with_characters_between() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "A Game of ", "George Martin" };
+
+    strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_sequence_contains_non_empty_strings() {
+    String actual = "";
+    String[] sequence = { "A Game of ", "Thrones" };
+
+    strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+  }
+
+  @Test
+  void should_fail_if_actual_contains_sequence() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "A Game of ", "Thrones" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSequence(someInfo(), actual,
+                                                                                                    sequence));
+    then(assertionError).hasMessage(shouldNotContainSequence(actual, sequence, 11).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_sequence_according_to_the_custom_strategy() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "A GAME OF ", "THRONES" };
+
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSequence(someInfo(),
+                                                                                                                                         actual,
+                                                                                                                                         sequence));
+    then(assertionError).hasMessage(shouldNotContainSequence(actual, sequence, 11, comparisonStrategy).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_empty_and_sequence_contains_only_empty_strings() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "", "", "" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSequence(someInfo(), actual,
+                                                                                                    sequence));
+    then(assertionError).hasMessage(shouldNotContainSequence(actual, sequence, 0).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty_and_sequence_contains_only_empty_strings() {
+    String actual = "";
+    String[] sequence = { "", "" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSequence(someInfo(), actual,
+                                                                                                    sequence));
+    then(assertionError).hasMessage(shouldNotContainSequence(actual, sequence, 0).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    String actual = null;
+    String[] sequence = { "A Game of Thrones" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSequence(someInfo(), actual,
+                                                                                                    sequence));
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_throw_error_if_sequence_is_null() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = null;
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+    thenThrownBy(assertionCall).isInstanceOf(NullPointerException.class)
+                               .hasMessage(arrayOfValuesToLookForIsNull());
+  }
+
+  @Test
+  void should_throw_error_if_sequence_is_empty() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = {};
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+    thenThrownBy(assertionCall).isInstanceOf(IllegalArgumentException.class)
+                               .hasMessage(arrayOfValuesToLookForIsEmpty());
+  }
+
+  @Test
+  void should_throw_error_if_sequence_has_null_item() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] sequence = { "A Game of ", null, "Thrones" };
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSequence(someInfo(), actual, sequence);
+    thenThrownBy(assertionCall).isInstanceOf(NullPointerException.class)
+                               .hasMessage("Expecting CharSequence elements not to be null but found one at index 1");
+  }
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSubsequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSubsequence_Test.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.tests.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.internal.Strings;
+import org.assertj.tests.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.assertj.core.error.ShouldNotContainSubsequenceOfCharSequence.shouldNotContainSubsequence;
+import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsEmpty;
+import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsNull;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.tests.core.testkit.TestData.someInfo;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+/**
+ * Tests for {@link Strings#assertDoesNotContainSubsequence(AssertionInfo, CharSequence, CharSequence[])}.
+ */
+class Strings_assertDoesNotContainSubsequence_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_does_not_contain_all_subsequence_items() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "A Game of ", "Shadows" };
+
+    strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_subsequence_items_but_some_of_them_overlap_with_some_others() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "A Game", "Game of Thrones", "George Martin" };
+
+    strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_subsequence_items_but_not_in_the_correct_order() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "George Martin", "A Game of Thrones" };
+
+    strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_subsequence_contains_non_empty_strings() {
+    String actual = "";
+    String[] subsequence = { "A", "Game", "of", "Thrones" };
+
+    strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+  }
+
+  @Test
+  void should_fail_if_actual_contains_subsequence_without_characters_between() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "A Game of ", "Thrones" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 11, 21 }).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_subsequence_without_characters_between_according_to_the_custom_strategy() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "A GAME OF ", "THRONES" };
+
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSubsequence(someInfo(),
+                                                                                                                                            actual,
+                                                                                                                                            subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 11, 21 },
+                                                                comparisonStrategy).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_subsequence_with_characters_between() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "{", "A Game of ", "George Martin", "}" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 0, 11, 41, 56 }).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_subsequence_with_characters_between_according_to_the_custom_strategy() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "{", "A GAME OF ", "GEORGE MARTIN", "}" };
+
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertDoesNotContainSubsequence(someInfo(),
+                                                                                                                                            actual,
+                                                                                                                                            subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 0, 11, 41, 56 },
+                                                                comparisonStrategy).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_subsequence_and_subsequence_has_empty_strings() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "", "", "A Game of ", "", "George Martin", "" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence,
+                                                                new int[] { 0, 0, 11, 21, 41, 54 }).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_empty_and_subsequence_contains_only_empty_strings() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "", "", "" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 0, 0, 0 }).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty_and_subsequence_contains_only_empty_strings() {
+    String actual = "";
+    String[] subsequence = { "", "" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(shouldNotContainSubsequence(actual, subsequence, new int[] { 0, 0 }).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    String actual = null;
+    String[] subsequence = { "A Game of Thrones" };
+
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotContainSubsequence(someInfo(), actual,
+                                                                                                       subsequence));
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_throw_error_if_subsequence_is_null() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = null;
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+    thenThrownBy(assertionCall).isInstanceOf(NullPointerException.class)
+                               .hasMessage(arrayOfValuesToLookForIsNull());
+  }
+
+  @Test
+  void should_throw_error_if_subsequence_is_empty() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = {};
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+    thenThrownBy(assertionCall).isInstanceOf(IllegalArgumentException.class)
+                               .hasMessage(arrayOfValuesToLookForIsEmpty());
+  }
+
+  @Test
+  void should_throw_error_if_subsequence_has_null_item() {
+    String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin' }";
+    String[] subsequence = { "A Game of ", null, "Thrones" };
+
+    ThrowingCallable assertionCall = () -> strings.assertDoesNotContainSubsequence(someInfo(), actual, subsequence);
+    thenThrownBy(assertionCall).isInstanceOf(NullPointerException.class)
+                               .hasMessage("Expecting CharSequence elements not to be null but found one at index 1");
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/assertj/assertj/issues/3813.

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)
