### PR TITLE
Issue 3867

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/filter/Filters.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/filter/Filters.java
@@ -29,26 +29,49 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 /**
  * Filters the elements of a given <code>{@link Iterable}</code> or array according to the specified filter criteria.
  * <p>
- * Filter criteria can be expressed either by a {@link Condition} or a pseudo filter language on elements properties.
+ *  Filter criteria can be expressed using {@link Condition} in two different ways:
+ *  <ul>
+ *    <li>
+ *      on the iterable elements themselves using {@link Filters#being(Condition)} or {@link Filters#having(Condition)}.
+ *    </li>
+ *    <li>
+ *      using a pseudo filter language on element properties or fields using {@link Filters#with(String)} followed by
+ *      a call to {@link Filters#matches(Condition)}
+ *    </li>
+ *  </ul>
+ *  Additionally, you can also filter on element properties or fields using {@link Filters#equalsTo(Object)} or
+ *  {@link Filters#notEqualsTo(Object)}.
+ * </p>
  * <p>
- * With fluent filter language on element properties/fields :
- * <pre><code class='java'> assertThat(filter(players).with("pointsPerGame").greaterThan(20)
- *                           .and("assistsPerGame").greaterThan(7).get())
- *                           .containsOnly(james, rose);</code></pre>
+ *   Example of usage filtering on the elements themselves using a {@link Condition}:
+ *   <pre><code class='java'>
+ *      List&lt;Player&gt; players = ...;
  *
- * With {@link Condition} :
- * <pre><code class='java'> List&lt;Player&gt; players = ...;
+ *     Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP") {
+ *       public boolean matches(Player player) {
+ *         return player.getPointsPerGame() &gt; 20 &amp;&amp; player.getAssistsPerGame() &gt; 7;
+ *       };
+ *     };
  *
- * Condition&lt;Player&gt; potentialMVP = new Condition&lt;Player&gt;("is a possible MVP"){
- *   public boolean matches(Player player) {
- *     return player.getPointsPerGame() &gt; 20 &amp;&amp; player.getAssistsPerGame() &gt; 7;
- *   };
- * };
+ *     // use filter static method to build Filters
+ *     assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
+ * </p>
+ * <p>
+ *    Example of usage with selection of and fields using matches:
+ *      <pre><code class='java'>
+ *        Condition&lt;Integer&gt; greaterThan20 = new Condition<>(i -> i > 20, "> 20");
+ *        Condition&lt;Integer&gt; greaterThan7 = new Condition<>(i -> i > 7, "> 7");
  *
- * // use filter static method to build Filters
- * assertThat(filter(players).being(potentialMVP).get()).containsOnly(james, rose);</code></pre>
+ *        assertThat(
+ *          filter(players)
+ *            .with("pointsPerGame").matches(greaterThan20)
+ *            .with("assistsPerGame").matches(greaterThan7)
+ *            .get()
+ *        ).containsOnly(jordan);</code></pre>
+ * </p>
  *
- * @param <E> the type of element of group to filter.
+ *
+ * @param <E> the type of element of the iterable to filter.
  *
  * @author Joel Costigliola
  * @author Mikhail Mazursky
@@ -256,8 +279,8 @@ public class Filters<E> {
   }
 
   /**
-   * Filters the underlying iterable to keep object with property (specified by {@link #with(String)}) <b>equals to</b>
-   * given value.
+   * Filters the underlying iterable to keep elements with the property (specified by {@link #with(String)}) that are
+   * <b>equal to</b> the given value.
    * <p>
    * Typical usage :
    * <pre><code class='java'> filter(employees).with("name").equalsTo("Luke").get();</code></pre>
@@ -268,17 +291,12 @@ public class Filters<E> {
    */
   public Filters<E> equalsTo(Object propertyValue) {
     checkPropertyNameToFilterOnIsNotNull();
-    this.filteredIterable = filteredIterable.stream().filter(element -> {
-      Object propertyValueOfCurrentElement = PROPERTY_OR_FIELD_SUPPORT.getValueOf(propertyOrFieldNameToFilterOn, element);
-      return deepEquals(propertyValueOfCurrentElement, propertyValue);
-    }).collect(toList());
-    return this;
+    return matches(new Condition<>(elem -> deepEquals(elem, propertyValue), "equalsTo(%s)", propertyValue));
   }
 
   /**
-   * Filters the underlying iterable to keep object with property (specified by {@link #with(String)}) <b>not equals
-   * to</b> given
-   * value.
+   * Filters the underlying iterable to keep elements with the property (specified by {@link #with(String)}) that are
+   * <b>not equal to</b> the given value.
    * <p>
    * Typical usage :
    * <pre><code class='java'> filter(employees).with("name").notEqualsTo("Vader").get();</code></pre>
@@ -289,9 +307,35 @@ public class Filters<E> {
    */
   public Filters<E> notEqualsTo(Object propertyValue) {
     checkPropertyNameToFilterOnIsNotNull();
+    return matches(new Condition<>(elem -> !deepEquals(elem, propertyValue), "notEqualsTo(%s)", propertyValue));
+  }
+
+  /**
+   * Filters the underlying iterable to keep elements with the property (specified by {@link #with(String)}) that
+   * <b>match</b> the given condition.
+   * <p>
+   * Typical usage :
+   * <pre><code class='java'>
+   *   Condition&lt;String&gt; minor = new Condition&lt;&gt;(age -> age < 19, "minor");
+   *
+   *   filter(employees).with("age").matches(minor).get();</code></pre>
+   *
+   * @param condition the condition to match
+   * @return this {@link Filters} to chain other filter operation.
+   * @throws IllegalArgumentException if the property name to filter on has not been set.
+   * @throws IllegalArgumentException if the given condition is {@code null} or the type does not match
+   * the type of the selected property.
+   */
+  public <T> Filters<E> matches(Condition<T> condition) {
+    checkPropertyNameToFilterOnIsNotNull();
+    checkArgument(condition != null, "The filter condition should not be null");
     this.filteredIterable = filteredIterable.stream().filter(element -> {
       Object propertyValueOfCurrentElement = PROPERTY_OR_FIELD_SUPPORT.getValueOf(propertyOrFieldNameToFilterOn, element);
-      return !deepEquals(propertyValueOfCurrentElement, propertyValue);
+      try {
+        return condition.matches((T) propertyValueOfCurrentElement);
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException("Condition type does not match the property type.");
+      }
     }).collect(toList());
     return this;
   }

--- a/assertj-core/src/test/java/org/assertj/core/api/filter/Filter_with_matches_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/filter/Filter_with_matches_Test.java
@@ -1,0 +1,40 @@
+package org.assertj.core.api.filter;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.testkit.WithPlayerData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.filter;
+
+class Filter_with_matches_Test extends WithPlayerData {
+  @Test
+  void should_filter_players_that_match_Condition() {
+    Condition<Integer> greaterThan20 = new Condition<>(i -> i > 20, "> 20");
+    Condition<Integer> greaterThan7 = new Condition<>(i -> i > 7, "> 7");
+
+    assertThat(
+               filter(players)
+                              .with("pointsPerGame").matches(greaterThan20)
+                              .with("assistsPerGame").matches(greaterThan7)
+                              .get()).containsOnly(jordan);
+  }
+
+  @Test
+  void should_fail_on_null_condition() {
+    Condition<Integer> nullCondition = null;
+
+    assertThatThrownBy(() -> filter(players).with("pointsPerGame").matches(nullCondition))
+                                                                                          .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void should_fail_on_mismatched_condition_type() {
+    Condition<String> stringCondition = new Condition<>(s -> s.length() > 3, "length > 3");
+
+    assertThatThrownBy(() -> filter(players).with("pointsPerGame").matches(stringCondition))
+                                                                                            .isInstanceOf(IllegalArgumentException.class)
+                                                                                            .hasMessageContaining("Condition type does not match the property type.");
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/filter/Filter_with_matches_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/filter/Filter_with_matches_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
 package org.assertj.core.api.filter;
 
 import org.assertj.core.api.Condition;


### PR DESCRIPTION
I have rewritten the Filters javadoc to reflect how the class should be actually used. As stated in the issue, the example was wrong (and not only in the actual API usage, but the explanation of the class was rather confusing).

I have taken the opportunity to add a matches(Condition) method that allows to filter the selected field (using'with(String)') on any arbitrary condition, and not just equals/notEquals. Since matches is a generic case to those, I have also refactored them to use matches(Condition) internally to avoid some duplication.

I have also added a new test class to test this new behaviour (and make sure that the code in the Javadoc is now correct!).

#### Check List:
* Fixes #3867 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

