### PR TITLE
Add AbstractOptionalAssert#hasValueSatisfying accepting ThrowingConsumer #3434

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -12,12 +12,14 @@
  */
 package org.assertj.core.api;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
 import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
+import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.error.ShouldMatch.shouldMatch;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
@@ -175,8 +177,25 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
    * @return this assertion object.
    */
   public SELF hasValueSatisfying(Consumer<VALUE> requirement) {
+    return internalHasValueSatisfying(requirement);
+  }
+
+  /**
+   * Verifies that the actual {@link java.util.Optional} contains a value and gives this value to the given
+   * {@link ThrowingConsumer} for further assertions. This is a same assertion as {@link #hasValueSatisfying(Condition)}
+   * except that a {@link ThrowingConsumer} rethrows checked exceptions as {@link RuntimeException}.
+   * <p>
+   *
+   * @param requirement to further assert on the object contained inside the {@link java.util.Optional}.
+   * @return this assertion object.
+   */
+  public SELF hasValueSatisfying(ThrowingConsumer<VALUE> requirement) {
+    return internalHasValueSatisfying(requirement);
+  }
+
+  private SELF internalHasValueSatisfying(Consumer<VALUE> requirements) {
     assertValueIsPresent();
-    requirement.accept(actual.get());
+    requirements.accept(actual.get());
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -12,14 +12,12 @@
  */
 package org.assertj.core.api;
 
-import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
 import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
-import static org.assertj.core.error.ShouldContainValue.shouldContainValue;
 import static org.assertj.core.error.ShouldMatch.shouldMatch;
 import static org.assertj.core.util.Preconditions.checkArgument;
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_hasValueSatisfying_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_hasValueSatisfying_Test.java
@@ -19,10 +19,12 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.ErrorMessagesForTest.shouldBeEqualMessage;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
 
 class OptionalAssert_hasValueSatisfying_Test {
@@ -56,6 +58,20 @@ class OptionalAssert_hasValueSatisfying_Test {
                                                                               .startsWith("some")
                                                                               .endsWith("thing"));
     assertThat(Optional.of(10)).hasValueSatisfying(i -> assertThat(i).isGreaterThan(9));
+  }
+
+  @Test
+  void should_pass_when_throwing_consumer_passes() {
+    // GIVEN
+    Optional<String> optional = Optional.of("something");
+    ThrowingConsumer<String> throwingConsumer = value -> {
+      if (!value.equals("something")) {
+        throw new IOException("Value does not match");
+      }
+    };
+
+    // WHEN/THEN
+    assertThat(optional).hasValueSatisfying(throwingConsumer);
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #3434 
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Hi, 
I have fixed #3434 by this PR.
There was some Kotlin-ambiguity related discussion in the issue—could this cause problems?
This is my first PR, so if there's anything that needs fixing, please let me know in the comments!
