### PR TITLE
Update production dependencies

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -28,7 +28,7 @@
     <spotless.skip>false</spotless.skip>
     <jacoco.skip>true</jacoco.skip> <!-- https://github.com/assertj/assertj/issues/3580 -->
     <!-- Dependency versions -->
-    <byte-buddy.version>1.15.11</byte-buddy.version>
+    <byte-buddy.version>1.17.7</byte-buddy.version>
     <hamcrest.version>3.0</hamcrest.version>
     <!-- Plugin versions -->
     <cdg.pitest.version>1.1.4</cdg.pitest.version>

--- a/assertj-guava/pom.xml
+++ b/assertj-guava/pom.xml
@@ -19,7 +19,7 @@
     <rootDirectory>${project.basedir}/../</rootDirectory>
     <spotless.skip>false</spotless.skip>
     <!-- Dependency versions -->
-    <guava.version>33.4.0-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
   </properties>
 
   <dependencies>

--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -26,7 +26,7 @@
     <spotless.skip>true</spotless.skip>
     <!-- Dependency versions -->
     <junit.version>4.13.2</junit.version>
-    <junit-jupiter.version>5.11.4</junit-jupiter.version>
+    <junit-jupiter.version>5.13.4</junit-jupiter.version>
     <mockito.version>4.11.0</mockito.version>
     <opentest4j.version>1.3.0</opentest4j.version>
     <!-- Plugin versions -->


### PR DESCRIPTION
This change bumps:
* `byte-buddy.version` from 1.15.11 to 1.17.7
* `guava.version` from 33.4.0-jre to 33.4.8-jre
* `junit-jupiter.version` from 5.11.4 to 5.13.4

Closes #3946.