### PR TITLE
feat(#3975): support isNotInThePast and isNotInTheFuture 

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
@@ -19,6 +19,7 @@ import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqu
 import static org.assertj.core.error.ShouldBeCurrentYearMonth.shouldBeCurrentYearMonth;
 import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
 import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.error.ShouldBeNotInTheFuture.shouldBeNotInTheFuture;
 import static org.assertj.core.error.ShouldBeNotInThePast.shouldBeNotInThePast;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
@@ -395,6 +396,26 @@ public abstract class AbstractYearMonthAssert<SELF extends AbstractYearMonthAsse
   public SELF isInTheFuture() {
     Objects.instance().assertNotNull(info, actual);
     if (!actual.isAfter(YearMonth.now())) throwAssertionError(shouldBeInTheFuture(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly not in the future.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.now().minusMonths(1)).isNotInTheFuture();
+   * // assertion also succeeds:
+   * assertThat(YearMonth.now()).isNotInTheFuture();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is not in the future.
+   */
+  public SELF isNotInTheFuture() {
+    Objects.instance().assertNotNull(info, actual);
+    if (actual.isAfter(YearMonth.now())) throwAssertionError(shouldBeNotInTheFuture(actual));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractYearMonthAssert.java
@@ -19,6 +19,7 @@ import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqu
 import static org.assertj.core.error.ShouldBeCurrentYearMonth.shouldBeCurrentYearMonth;
 import static org.assertj.core.error.ShouldBeInTheFuture.shouldBeInTheFuture;
 import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.error.ShouldBeNotInThePast.shouldBeNotInThePast;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
 import static org.assertj.core.error.ShouldHaveDateField.shouldHaveMonth;
 import static org.assertj.core.util.Preconditions.checkArgument;
@@ -337,6 +338,26 @@ public abstract class AbstractYearMonthAssert<SELF extends AbstractYearMonthAsse
   public SELF isInThePast() {
     Objects.instance().assertNotNull(info, actual);
     if (!actual.isBefore(YearMonth.now())) throwAssertionError(shouldBeInThePast(actual));
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code YearMonth} is strictly not in the past, ie it can be either in the future or now.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion succeeds:
+   * assertThat(YearMonth.now().plusMonths(1)).isNotInThePast();
+   * // assertion also succeeds:
+   *    * assertThat(YearMonth.now()).isNotInThePast();
+   * </code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code YearMonth} is {@code null}.
+   * @throws AssertionError if the actual {@code YearMonth} is in the past.
+   */
+  public SELF isNotInThePast() {
+    Objects.instance().assertNotNull(info, actual);
+    if (actual.isBefore(YearMonth.now())) throwAssertionError(shouldBeNotInThePast(actual));
     return myself;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNotInTheFuture.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNotInTheFuture.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.time.temporal.Temporal;
+import java.util.Date;
+
+import org.assertj.core.api.comparisonstrategy.ComparisonStrategy;
+import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@link Date} or a {@link Temporal} is not in the future failed.
+ * 
+ * @author Alban Dericbourg
+ */
+public class ShouldBeNotInTheFuture extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInTheFuture}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInTheFuture(Date actual, ComparisonStrategy comparisonStrategy) {
+    return new ShouldBeNotInTheFuture(actual, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInTheFuture}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInTheFuture(Date actual) {
+    return new ShouldBeNotInTheFuture(actual, StandardComparisonStrategy.instance());
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInTheFuture}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInTheFuture(Temporal actual) {
+    return new ShouldBeNotInTheFuture(actual);
+  }
+
+  private ShouldBeNotInTheFuture(Date actual, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto be in the past or now %s but was not.", actual, comparisonStrategy);
+  }
+
+  private ShouldBeNotInTheFuture(Temporal actual) {
+    super("%nExpecting actual:%n  %s%nto be in the past or now but was not.", actual);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNotInThePast.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeNotInThePast.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.time.temporal.Temporal;
+import java.util.Date;
+
+import org.assertj.core.api.comparisonstrategy.ComparisonStrategy;
+import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a {@link Date} or a {@link Temporal} is in the past failed.
+ * 
+ * @author Alban Dericbourg
+ */
+public class ShouldBeNotInThePast extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInThePast}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInThePast(Date actual, ComparisonStrategy comparisonStrategy) {
+    return new ShouldBeNotInThePast(actual, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInThePast}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInThePast(Date actual) {
+    return new ShouldBeNotInThePast(actual, StandardComparisonStrategy.instance());
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldBeNotInThePast}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeNotInThePast(Temporal actual) {
+    return new ShouldBeNotInThePast(actual);
+  }
+
+  private ShouldBeNotInThePast(Date actual, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto be in the future or now %s but was not.", actual, comparisonStrategy);
+  }
+
+  private ShouldBeNotInThePast(Temporal actual) {
+    super("%nExpecting actual:%n  %s%nto be in the future or now but was not.", actual);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInTheFuture_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeNotInTheFuture.shouldBeNotInTheFuture;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.YearMonth;
+
+import org.junit.jupiter.api.Test;
+
+class YearMonthAssert_isNotInTheFuture_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_in_the_future() {
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(AFTER).isNotInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNotInTheFuture(AFTER).create());
+  }
+
+  @Test
+  void should_pass_if_actual_is_today() {
+     assertThat(REFERENCE).isNotInTheFuture();
+  }
+
+  @Test
+  void should_pass_if_actual_is_in_the_past() {
+    assertThat(BEFORE).isNotInTheFuture();
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).isNotInTheFuture());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInTheFuture_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInTheFuture_Test.java
@@ -34,7 +34,7 @@ class YearMonthAssert_isNotInTheFuture_Test extends YearMonthAssertBaseTest {
 
   @Test
   void should_pass_if_actual_is_today() {
-     assertThat(REFERENCE).isNotInTheFuture();
+    assertThat(REFERENCE).isNotInTheFuture();
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInThePast_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/yearmonth/YearMonthAssert_isNotInThePast_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.core.api.yearmonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeInThePast.shouldBeInThePast;
+import static org.assertj.core.error.ShouldBeNotInThePast.shouldBeNotInThePast;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.time.YearMonth;
+
+import org.junit.jupiter.api.Test;
+
+class YearMonthAssert_isNotInThePast_Test extends YearMonthAssertBaseTest {
+
+  @Test
+  void should_pass_if_actual_is_the_future() {
+    assertThat(AFTER).isNotInThePast();
+  }
+
+  @Test
+  void should_pass_if_actual_is_today() {
+    assertThat(REFERENCE).isNotInThePast();
+  }
+
+  @Test
+  void should_fail_if_actual_is_in_the_past() {
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(BEFORE).isNotInThePast());
+    // THEN
+    then(assertionError).hasMessage(shouldBeNotInThePast(BEFORE).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    YearMonth actual = null;
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).isNotInThePast());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #3975
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Support `isNotInThePast` and `isNotInTheFuture`, as opposition to respectively ` isInThePast` and `isInTheFuture`.

*  `isNotInThePast` matches current or future
* `isNotInTheFuture` matches current or past