### PR TITLE
Add Eclipse compiler CI Job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,23 @@ jobs:
       - name: Test
         run: ./mvnw $MAVEN_ARGS verify
 
+  # https://github.com/assertj/assertj/issues/3996
+  eclipse-compiler:
+
+    name: Java 25 (Eclipse Compiler)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: 'zulu'
+          java-version: '25'
+          cache: 'maven'
+      - name: Test
+        run: ./mvnw $MAVEN_ARGS -Peclipse-compiler verify
+
   groovy:
 
     name: Groovy ${{ matrix.groovy }}

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,34 @@ limitations under the License.
 
   <profiles>
     <profile>
+      <id>eclipse-compiler</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <compilerId>eclipse</compilerId>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.codehaus.plexus</groupId>
+                  <artifactId>plexus-compiler-eclipse</artifactId>
+                  <version>2.16.2</version>
+                </dependency>
+                <dependency>
+                  <groupId>org.eclipse.jdt</groupId>
+                  <artifactId>ecj</artifactId>
+                  <version>3.46.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
       <id>publish</id>
       <build>
         <plugins>


### PR DESCRIPTION
* Fixes #3996

---

Related to:

* eclipse-jdt/eclipse.jdt.core#2778

---

```
Co-authored-by: Eric Rizzo <erizzo@users.noreply.github.com>
```