### PR TITLE
Added withFormatter() for Duration assert

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractDurationAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractDurationAssert.java
@@ -22,13 +22,16 @@ import static org.assertj.core.error.ShouldHaveDuration.shouldHaveSeconds;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.time.Duration;
+import java.util.function.Function;
 
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
+import org.assertj.core.presentation.StandardRepresentation;
 
 /**
  * Assertions for {@link Duration} type.
  * @author Filip Hrisafov
+ * @author Eric Rizzo
  * @since 3.15.0
  */
 public abstract class AbstractDurationAssert<SELF extends AbstractDurationAssert<SELF>>
@@ -294,6 +297,44 @@ public abstract class AbstractDurationAssert<SELF extends AbstractDurationAssert
       throw Failures.instance().failure(info, shouldBeCloseTo(actual, expected, allowedDifference, absDiff(actual, expected)));
     }
     return myself;
+  }
+
+  /**
+   * Overrides AssertJ default formatting for <code>Duration</code> objects in failure messages.
+   * <p>
+   * The formatting function is only called if the assertion fails.
+   * <p>
+   * You must set the formatter <b>before</b> calling the assertion, otherwise it is ignored as the failing assertion breaks
+   * the call chain by throwing an {@link AssertionError}.
+   * <p>
+   * Calling this method will override any previous calls to {@link #withRepresentation(org.assertj.core.presentation.Representation)
+   * withRepresentation(Representation)} because this method uses a custom <code>Representation</code> to do the formatting. Similarly,
+   * a <code>Representation</code> specified via {@link #withRepresentation(org.assertj.core.presentation.Representation)
+   * withRepresentation(Representation)} <b>after</b> this method will take precedence over a formatter provided here.
+   * <p>
+   * Example using lambda:
+   * <pre><code class='java'> var formatter = d -> "%s days or %s hours".formatted(d.toDays(), d.toHours());
+   * assertThat(timeSpent)
+   *     .withFormatter(formatter);
+   *     .isTrue();</code></pre>
+   * <p>
+   * Example using <code>org.apache.commons.lang3.time.DurationFormatUtils.formatDuration(long, String)</code>:
+   * <pre><code class='java'> assertThat(timeSpent)
+   *     .withFormatter(d -> DurationFormatUtils.formatDuration(d.toMillis(), "HH:mm:ss"));
+   *     .isTrue();</code></pre>
+   *
+   * @param formatter the function to format all Duration objects that are included in error messages. This can include actual and expected Duration values.
+   * @return this assertion object.
+   */
+  public SELF withFormatter(Function<Duration, String> formatter) {
+    checkArgument(formatter != null, "formatter should not be null");
+
+    return withRepresentation(new StandardRepresentation() {
+      @Override
+      public String toStringOf(Duration duration) {
+        return formatter.apply(duration);
+      }
+    });
   }
 
   private static Duration absDiff(Duration actual, Duration expected) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isCloseTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isCloseTo_Test.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 class DurationAssert_isCloseTo_Test {
 
-  @ParameterizedTest(name = "PT2M should close to {0} withMarginOf {1}")
+  @ParameterizedTest(name = "PT2M should be close to {0} withMarginOf {1}")
   @CsvSource({
       "PT1M, PT70S",
       "PT70S, PT1M",

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_withFormatter_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_withFormatter_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2025 the original author or authors.
+ */
+package org.assertj.tests.core.api.duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Eric Rizzo
+ */
+class DurationAssert_withFormatter_Test {
+
+  @Test
+  void should_throw_IllegalArgumentException_when_formatter_is_null() {
+    // GIVEN
+    Duration actual = Duration.ZERO;
+
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual).withFormatter(null));
+
+    // THEN
+    then(exception).isInstanceOf(IllegalArgumentException.class)
+                   .hasMessage("formatter should not be null");
+  }
+
+  @Test
+  void failure_message_should_use_formatter_function() {
+    // GIVEN
+    Duration actual = Duration.ofDays(3);
+    Function<Duration, String> formatter = d -> "%s days or %s hours".formatted(d.toDays(), d.toHours());
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).withFormatter(formatter).isNull());
+
+    // THEN
+    then(assertionError).hasMessageContaining("3 days or 72 hours");
+  }
+
+  @Test
+  void failure_message_should_use_mock_formatter_function() {
+    // GIVEN
+    Duration actual = Duration.ofDays(3);
+    Function<Duration, String> formatter = mock(Function.class);
+
+    // WHEN
+    expectAssertionError(() -> assertThat(actual).withFormatter(formatter).isNull());
+
+    // THEN
+    verify(formatter, atLeast(2)).apply(actual);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #3976 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES 

This PR adds a method to AbstractDurationAssert to make it easy to override the formatting of `Duration` objects in test failure messages.