### PR TITLE
Fix `catchThrowableOfType` Javadoc examples

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -1276,8 +1276,8 @@ public class Assertions implements InstanceOfAssertFactories {
    *   }
    * }
    *
-   * TextException textException = catchThrowableOfType(() -&gt; { throw new TextException("boom!", 1, 5); },
-   *                                                    TextException.class);
+   * TextException textException = catchThrowableOfType(TextException.class,
+   *                                                    () -&gt; { throw new TextException("boom!", 1, 5); });
    * // assertions succeed:
    * assertThat(textException).hasMessage("boom!");
    * assertThat(textException.line).isEqualTo(1);

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -937,8 +937,8 @@ public class AssertionsForClassTypes {
    *   }
    * }
    *
-   * TextException textException = catchThrowableOfType(() -&gt; { throw new TextException("boom!", 1, 5); },
-   *                                                    TextException.class);
+   * TextException textException = catchThrowableOfType(TextException.class,
+   *                                                    () -&gt; { throw new TextException("boom!", 1, 5); });
    * // assertions succeed:
    * assertThat(textException).hasMessage("boom!");
    * assertThat(textException.line).isEqualTo(1);

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -1769,8 +1769,8 @@ public class BDDAssertions extends Assertions {
    *   }
    * }
    *
-   * TextException textException = catchThrowableOfType(() -&gt; { throw new TextException("boom!", 1, 5); },
-   *                                                    TextException.class);
+   * TextException textException = catchThrowableOfType(TextException.class,
+   *                                                    () -&gt; { throw new TextException("boom!", 1, 5); });
    * // assertions succeed:
    * then(textException).hasMessage("boom!");
    * then(textException.line).isEqualTo(1);

--- a/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ThrowableAssert.java
@@ -117,8 +117,8 @@ public class ThrowableAssert<ACTUAL extends Throwable> extends AbstractThrowable
    *   }
    * }
    *
-   * TextException textException = catchThrowableOfType(() -&gt; { throw new TextException("boom!", 1, 5); },
-   *                                                    TextException.class);
+   * TextException textException = catchThrowableOfType(TextException.class,
+   *                                                    () -&gt; { throw new TextException("boom!", 1, 5); });
    * // assertions succeed:
    * assertThat(textException).hasMessage("boom!");
    * assertThat(textException.line).isEqualTo(1);

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -117,7 +117,6 @@ import org.assertj.core.presentation.UnicodeRepresentation;
  * <a href="http://blog.javabien.net/2014/04/23/what-if-assertj-used-java-8/">http://blog.javabien.net/2014/04/23/what-if-assertj-used-java-8/</a>
  *
  * @author Alan Rothkopf
- *
  */
 @CheckReturnValue
 public interface WithAssertions extends InstanceOfAssertFactories {
@@ -2831,8 +2830,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    *   }
    * }
    *
-   * TextException textException = catchThrowableOfType(() -&gt; { throw new TextException("boom!", 1, 5); },
-   *                                                    TextException.class);
+   * TextException textException = catchThrowableOfType(TextException.class,
+   *                                                    () -&gt; { throw new TextException("boom!", 1, 5); });
    * // assertions succeed:
    * assertThat(textException).hasMessage("boom!");
    * assertThat(textException.line).isEqualTo(1);


### PR DESCRIPTION
Hello!

I spotted a small problem when looking at `catchThrowableOfType()` javadoc: it references the now deprecated method.
By permuting the argument, the javadoc now references the method it is documenting :)

Thanks a lot for AssertJ!

#### Check List:
* Fixes #??? : NA
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md): YES