### PR TITLE
Replace `synchronizedMap` with `ConcurrentHashMap`

### DIFF
--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtension_PER_CLASS_Concurrency_Test.java
@@ -89,7 +89,6 @@ class SoftAssertionsExtension_PER_CLASS_Concurrency_Test {
       flags[2].countDown();
       waitForFlag(3);
       softly.assertThat(5).isEqualTo(6);
-      map.put(context.getTestMethod().get().getName(), SoftAssertionsExtension.getAssertionErrorCollector(context));
     }
 
     @Test


### PR DESCRIPTION
This hopefully fixes the flaky test that recently resurfaced (reported initially at #1996).
