### PR TITLE
Add `doesNotHaveValue` to `Optional` assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -12,12 +12,15 @@
  */
 package org.assertj.core.api;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.OptionalShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.OptionalShouldBePresent.shouldBePresent;
 import static org.assertj.core.error.OptionalShouldContain.shouldContain;
 import static org.assertj.core.error.OptionalShouldContain.shouldContainSame;
 import static org.assertj.core.error.OptionalShouldContainInstanceOf.shouldContainInstanceOf;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Comparator;
@@ -220,6 +223,28 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
    */
   public SELF hasValue(VALUE expectedValue) {
     return contains(expectedValue);
+  }
+
+  /**
+   * Verifies that the actual {@link java.util.Optional} does not contain the given value.
+   * <p>
+   * Assertion will pass:
+   * <pre><code class='java'> assertThat(Optional.of("something")).doesNotHaveValue("something else");</code></pre>
+   *
+   * Assertion will fail:
+   * <pre><code class='java'> assertThat(Optional.of("something")).doesNotHaveValue("something");</code></pre>
+   *
+   * @param expectedValue the expected value inside the {@link java.util.Optional}.
+   * @throws NullPointerException if the given value is {@code null}; use {@link #isNotPresent()} or {@link #isNotEmpty()} instead.
+   * @return this assertion object.
+   */
+  public SELF doesNotHaveValue(VALUE expectedValue) {
+    isNotNull();
+    requireNonNull(expectedValue, shouldNotBeNull("value")::create);
+    if (optionalValueComparisonStrategy.areEqual(actual.get(), expectedValue)) {
+      throw Failures.instance().failure(info, shouldNotContainValue(actual.get(), expectedValue));
+    }
+    return myself;
   }
 
   /**

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_doesNotHaveValue_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_doesNotHaveValue_Test.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.error.ShouldNotContainValue.shouldNotContainValue;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class OptionalAssert_doesNotHaveValue_Test {
+
+  @Test
+  void should_fail_when_optional_is_null() {
+    // GIVEN
+    @SuppressWarnings("OptionalAssignedToNull")
+    Optional<String> nullActual = null;
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(nullActual).doesNotHaveValue("something"));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_value_is_null() {
+    // GIVEN
+    Optional<?> actual = Optional.of("something");
+
+    // WHEN
+    var thrown = catchThrowable(() -> assertThat(actual).doesNotHaveValue(null));
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("value").create());
+  }
+
+  @Test
+  void should_fail_if_optional_contains_value() {
+    // GIVEN
+    Optional<String> actual = Optional.of("something");
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).doesNotHaveValue("something"));
+
+    // THEN
+    assertThat(assertionError).hasMessage(shouldNotContainValue("something", "something").create());
+  }
+
+  @Test
+  void should_pass_if_optional_does_not_contain_value() {
+    // GIVEN
+    Optional<String> actual = Optional.of("something");
+
+    // THEN
+    assertThatCode(() -> assertThat(actual).doesNotHaveValue("something else")).doesNotThrowAnyException();
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #3701
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
