### PR TITLE
Change `assertj-core` Javadoc link to offline link

### DIFF
--- a/assertj-guava/pom.xml
+++ b/assertj-guava/pom.xml
@@ -161,8 +161,13 @@
         <configuration>
           <links>
             <link>https://javadoc.io/static/com.google.guava/guava/${guava.version}</link>
-            <link>https://javadoc.io/static/org.assertj/assertj-core/${project.version}</link>
           </links>
+          <offlineLinks>
+            <offlineLink>
+              <url>https://javadoc.io/static/org.assertj/assertj-core/${project.version}</url>
+              <location>${project.basedir}/../assertj-core/target/site/apidocs</location>
+            </offlineLink>
+          </offlineLinks>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Prior to this change, hovering on the `Assert` hyperlink from the `org.assertj.guava.api.OptionalAssert` Javadoc page pointed to:

```
https://javadoc.io/doc/org.assertj/assertj-core/4.0.0-M1/org.assertj.core/org/assertj/core/api/Assert.html
```

while now it points to:

```
https://javadoc.io/static/org.assertj/assertj-core/3.27.7-SNAPSHOT/org/assertj/core/api/Assert.html
```

* Fixes #3478
