### PR TITLE
fix plain link text to HTML anchor tag

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -145,7 +145,7 @@ import org.assertj.core.util.introspection.Introspection;
  * if that occurred <code>assertThat(List)</code> would also be a possible choice - thus confusing java 8.
  * <p>
  * This why {@link Assertions} have been split in {@link AssertionsForClassTypes} and {@link AssertionsForInterfaceTypes}
- * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
+ * (see <a href="http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why">Ambiguous method in Java 8, why?</a>).
  *
  * @author Alex Ruiz
  * @author Yvonne Wang

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -78,7 +78,7 @@ import org.assertj.core.util.introspection.FieldSupport;
  * if that occurred <code>assertThat(List)</code> would also be a possible choice - thus confusing java 8.
  * <p>
  * This why {@link Assertions} have been split in {@link AssertionsForClassTypes} and {@link AssertionsForInterfaceTypes}
- * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
+ * (see <a href="http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why">Ambiguous method in Java 8, why?</a>).
  */
 @CheckReturnValue
 public class AssertionsForClassTypes {

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -51,7 +51,7 @@ import org.assertj.core.annotation.CheckReturnValue;
  * if that occurred <code>assertThat(List)</code> would also be a possible choice - thus confusing java 8.
  * <p>
  * This why {@link Assertions} have been split in {@link AssertionsForClassTypes} and {@link AssertionsForInterfaceTypes}
- * (see http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why).
+ * (see <a href="http://stackoverflow.com/questions/29499847/ambiguous-method-in-java-8-why">Ambiguous method in Java 8, why?</a>).
  *
  * @author Alex Ruiz
  * @author Yvonne Wang


### PR DESCRIPTION
#### Check List:
* Fixes : NA
* Unit tests :  NA
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Fixed a plain text URL in `Assertions.java`,`AssertionsForClassTypes.java`,`AssertionsForInterfaceTypes.java` Javadoc.
I converted the plain StackOverflow link text into a clickable HTML anchor tag to improve documentation readability and accessibility.

As this is a minor documentation fix, I did not create a separate issue.

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
