### PR TITLE
Clarify `isEqualTo` limitations on testing `equals` and `hashCode`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assert.java
@@ -39,7 +39,7 @@ import org.assertj.core.presentation.StandardRepresentation;
 public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descriptable<SELF>, ExtensionPoints<SELF, ACTUAL> {
 
   /**
-   * Verifies that the actual value is equal to the given one.
+   * Verifies that the actual value is equal to the expected one.
    * <p>
    * Example:
    * <pre><code class='java'> // assertions succeed
@@ -50,7 +50,37 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * assertThat(&quot;abc&quot;).isEqualTo(&quot;123&quot;);
    * assertThat(new ArrayList&lt;String&gt;()).isEqualTo(1);</code></pre>
    *
-   * @param expected the given value to compare the actual value to.
+   * <b>Note on testing {@link Object#equals(Object) equals} and {@link Object#hashCode() hashCode}
+   * contracts</b>
+   * <p>
+   * {@code isEqualTo} uses a comparison strategy to determine equality and is <b>not</b> designed
+   * to validate the correctness of {@code equals} or {@code hashCode} implementations. By default,
+   * the comparison strategy delegates to the object's {@code equals} method (or performs deep
+   * equality for arrays).
+   * This means {@code isEqualTo} only verifies the <i>outcome</i> of a single equality check;
+   * it does not validate that the full {@code equals} contract (reflexivity, symmetry,
+   * transitivity, consistency, and null-handling) is satisfied.
+   * <p>
+   * If the {@code equals} implementation returns an incorrect result, {@code isEqualTo} will
+   * accept that result without detecting the bug.
+   * <p>
+   * Additionally, the comparison strategy can be customized via
+   * {@link #usingComparator(Comparator)} or {@link #usingEquals(BiPredicate)}.
+   * In these cases, {@code isEqualTo} bypasses {@code equals} entirely in favor of the provided
+   * logic.
+   * <p>
+   * For comprehensive testing of the {@code equals} and {@code hashCode} contracts, consider using
+   * dedicated libraries such as:
+   *
+   *  <ul>
+   * <li><a href="https://jqno.nl/equalsverifier/">EqualsVerifier</a></li>
+   * <li>Guava's <a href="https://javadoc.io/doc/com.google.guava/guava-testlib/latest/com/google/common/testing/EqualsTester.html">EqualsTester</a></li>
+   * </ul>
+   *
+   * To verify that two objects have the same field values without relying on {@code equals}, use
+   * the {@link AbstractObjectAssert#usingRecursiveComparison() recursive comparison}.
+   *
+   * @param expected the expected value to compare the actual value to.
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual value is not equal to the given one.
    */


### PR DESCRIPTION
* Closes #3865

Rendered version:

<img width="1112" height="880" alt="image" src="https://github.com/user-attachments/assets/0ce186f1-4c58-4479-8e86-c5ce2d15290f" />

---

```
Co-authored-by: Paul Potaczała <centrumek@users.noreply.github.com>
Co-authored-by: Krisztian Zsolt Sallai <skazsi@users.noreply.github.com>
```
