### PR TITLE
docs: clarify isSameAs checks reference equality, not equals

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assert.java
@@ -106,7 +106,8 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
   SELF isNotNull();
 
   /**
-   * Verifies that the actual value is the same as the given one, i.e., using == comparison.
+   * Verifies that the actual value is the same as the given one
+   * (reference equality, not {@link Object#equals(Object) equals}).
    * <p>
    * Example:
    * <pre><code class='java'> // Name is a class with first and last fields, two Names are equals if both first and last are equals.
@@ -128,7 +129,8 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
   SELF isSameAs(Object expected);
 
   /**
-   * Verifies that the actual value is not the same as the given one, i.e., using == comparison.
+   * Verifies that the actual value is not the same as the given one
+   * (reference equality, not {@link Object#equals(Object) equals}).
    * <p>
    * Example:
    * <pre><code class='java'> // Name is a class with first and last fields, two Names are equals if both first and last are equals.


### PR DESCRIPTION
## Summary

  Make `isSameAs` and `isNotSameAs` JavaDoc language-agnostic by replacing
  "using == comparison" with "reference equality" terminology.

  ## Motivation

  When using AssertJ from Kotlin, the current documentation can be confusing:

  | Language | Reference Equality | Value Equality |
  |----------|-------------------|----------------|
  | Java     | `==`              | `.equals()`    |
  | Kotlin   | `===`             | `==`           |

  The statement "using == comparison" is Java-specific. Kotlin developers may
  misinterpret this since `==` in Kotlin translates to `.equals()`.

  ## Changes

  - `isSameAs`: Changed "i.e., using == comparison" → "(reference equality, not equals)"
  - `isNotSameAs`: Changed "i.e., using == comparison" → "(reference equality, not equals)"

  ## Check List

  * Fixes #2819 (ignore if not applicable)
  * Unit tests: **NA** (documentation only)
  * Javadoc with a code example (on API only): **YES**
  * PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md): **YES**
