### PR TITLE
Fix `ShouldContainCharSequenceOnlyOnce` error message format

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce.java
@@ -57,13 +57,13 @@ public class ShouldContainCharSequenceOnlyOnce extends BasicErrorMessageFactory 
 
   private ShouldContainCharSequenceOnlyOnce(CharSequence actual, CharSequence expected, int occurrences,
                                             ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto appear only once in:%n  %s%nbut it appeared %s times %s", expected, actual,
+    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it appeared %s times %s", actual, expected,
           occurrences,
           comparisonStrategy);
   }
 
   private ShouldContainCharSequenceOnlyOnce(CharSequence actual, CharSequence expected, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto appear only once in:%n  %s%nbut it did not appear %s", expected, actual,
+    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it did not appear %s", actual, expected,
           comparisonStrategy);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce_create_Test.java
@@ -42,7 +42,7 @@ class ShouldContainCharSequenceOnlyOnce_create_Test {
     // WHEN
     String message = factoryWithSeveralOccurrences.create(new TestDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"motif\"%nto appear only once in:%n  \"aaamotifmotifaabbbmotifaaa\"%nbut it appeared 3 times ".formatted());
+    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"aaamotifmotifaabbbmotifaaa\"%nto contain:%n  \"motif\"%nonly once but it appeared 3 times ".formatted());
   }
 
   @Test
@@ -50,7 +50,7 @@ class ShouldContainCharSequenceOnlyOnce_create_Test {
     // WHEN
     String message = factoryWithNoOccurrence.create(new TestDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"motif\"%nto appear only once in:%n  \"aaamodifmoifaabbbmotfaaa\"%nbut it did not appear ".formatted());
+    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"aaamodifmoifaabbbmotfaaa\"%nto contain:%n  \"motif\"%nonly once but it did not appear ".formatted());
   }
 
   @Test
@@ -61,7 +61,7 @@ class ShouldContainCharSequenceOnlyOnce_create_Test {
     // WHEN
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"MOtif\"%nto appear only once in:%n  \"aaamoDifmoifaabbbmotfaaa\"%nbut it did not appear when comparing values using CaseInsensitiveStringComparator".formatted());
+    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"aaamoDifmoifaabbbmotfaaa\"%nto contain:%n  \"MOtif\"%nonly once but it did not appear when comparing values using CaseInsensitiveStringComparator".formatted());
   }
 
   @Test
@@ -72,7 +72,7 @@ class ShouldContainCharSequenceOnlyOnce_create_Test {
     // WHEN
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"MOtif\"%nto appear only once in:%n  \"aaamotIFmoTifaabbbmotifaaa\"%nbut it appeared 3 times when comparing values using CaseInsensitiveStringComparator".formatted());
+    then(message).isEqualTo("[Test] %nExpecting actual:%n  \"aaamotIFmoTifaabbbmotifaaa\"%nto contain:%n  \"MOtif\"%nonly once but it appeared 3 times when comparing values using CaseInsensitiveStringComparator".formatted());
   }
 
 }


### PR DESCRIPTION
Related Issue: https://github.com/assertj/assertj/issues/4112
## Summary
  - Standardize ShouldContainCharSequenceOnlyOnce error message format

| | Case 1 | Case 2 |
| :---: | :---: | :---: |
| **Before** | <img width="251" alt="수정 전1" src="https://github.com/user-attachments/assets/4e275e79-1a7f-4a33-a98a-e46d62872564"> | <img width="238" alt="수정 전2" src="https://github.com/user-attachments/assets/ec0bd81c-64bd-443b-a33a-251026f19603"> |
| **After** | <img width="280" alt="수정 후 1" src="https://github.com/user-attachments/assets/84a295df-af80-4a0a-9fc6-c30caff952c4"> | <img width="257" alt="수정 후 2" src="https://github.com/user-attachments/assets/a1f83f5d-b63f-42f5-b29e-9dc213c6ef6f"> |
