### PR TITLE
Fix: Apply IndentWrapper to `Equal-related` error message factories

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringCase.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringCase.java
@@ -34,6 +34,7 @@ public class ShouldBeEqualIgnoringCase extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringCase(CharSequence actual, CharSequence expected) {
-    super("%nexpected: %s%n but was: %s%nignoring case considerations", expected, actual);
+    super("%nexpected: %s%n but was: %s%nignoring case considerations",
+          IndentWrapper.of(expected), IndentWrapper.of(actual));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLineDifferences.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLineDifferences.java
@@ -23,6 +23,6 @@ public class ShouldBeEqualIgnoringNewLineDifferences extends BasicErrorMessageFa
 
   private ShouldBeEqualIgnoringNewLineDifferences(CharSequence actual, CharSequence expected) {
     super("%nExpecting actual:%n  %s%nto be equal to:%n  %s%nwhen ignoring newline differences ('\\r\\n' == '\\n')",
-          actual, expected);
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringNewLines.java
@@ -28,7 +28,7 @@ public class ShouldBeEqualIgnoringNewLines extends BasicErrorMessageFactory {
           "to be equal to:%n" +
           "  %s%n" +
           "when ignoring newlines (\\n, \\r\\n).",
-          actual, expected);
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingPunctuationAndWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingPunctuationAndWhitespace.java
@@ -41,6 +41,6 @@ public class ShouldBeEqualNormalizingPunctuationAndWhitespace extends BasicError
           "  %s%n" +
           "after punctuation and whitespace differences are normalized.%n" +
           "Punctuation is any of the following character !\"#$%%&'()*+,-./:;<=>?@[\\]^_`{|}~",
-          actual, expected);
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingUnicode.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingUnicode.java
@@ -44,6 +44,6 @@ public class ShouldBeEqualNormalizingUnicode extends BasicErrorMessageFactory {
           "The normalized strings should be equal.%n" +
           "Normalized actual  : %s%n" +
           "Normalized expected: %s",
-          actual, expected, normalizedActual, normalizedExpected);
+          IndentWrapper.of(actual), IndentWrapper.of(expected), normalizedActual, normalizedExpected);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeEqualNormalizingWhitespace.java
@@ -34,6 +34,7 @@ public class ShouldBeEqualNormalizingWhitespace extends BasicErrorMessageFactory
   }
 
   private ShouldBeEqualNormalizingWhitespace(CharSequence actual, CharSequence expected) {
-    super("%nExpecting actual:%n  %s%nto be equal to:%n  %s%nafter whitespace differences are normalized", actual, expected);
+    super("%nExpecting actual:%n  %s%nto be equal to:%n  %s%nafter whitespace differences are normalized",
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualIgnoringCase.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualIgnoringCase.java
@@ -36,6 +36,7 @@ public class ShouldNotBeEqualIgnoringCase extends BasicErrorMessageFactory {
   }
 
   private ShouldNotBeEqualIgnoringCase(CharSequence actual, CharSequence expected) {
-    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nignoring case considerations", actual, expected);
+    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nignoring case considerations",
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualIgnoringWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualIgnoringWhitespace.java
@@ -34,6 +34,7 @@ public class ShouldNotBeEqualIgnoringWhitespace extends BasicErrorMessageFactory
   }
 
   private ShouldNotBeEqualIgnoringWhitespace(CharSequence actual, CharSequence expected) {
-    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nignoring whitespace differences", actual, expected);
+    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nignoring whitespace differences",
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualNormalizingWhitespace.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotBeEqualNormalizingWhitespace.java
@@ -34,6 +34,7 @@ public class ShouldNotBeEqualNormalizingWhitespace extends BasicErrorMessageFact
   }
 
   private ShouldNotBeEqualNormalizingWhitespace(CharSequence actual, CharSequence expected) {
-    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nafter whitespace differences are normalized", actual, expected);
+    super("%nExpecting actual:%n  %s%nnot to be equal to:%n  %s%nafter whitespace differences are normalized",
+          IndentWrapper.of(actual), IndentWrapper.of(expected));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringCase_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringCase_create_Test.java
@@ -42,4 +42,23 @@ class ShouldBeEqualIgnoringCase_create_Test {
     // THEN
     then(message).isEqualTo(format(shouldBeEqualMessage("Test", "\"Yoda\"", "\"Luke\"") + "%nignoring case considerations"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqual(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "expected: \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   " but was: \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "ignoring case considerations"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNewlineDifferences_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNewlineDifferences_create_Test.java
@@ -39,4 +39,25 @@ class ShouldBeEqualIgnoringNewlineDifferences_create_Test {
                                    "  \"bar\"%n" +
                                    "when ignoring newline differences ('\\r\\n' == '\\n')"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqualIgnoringNewLineDifferences(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "when ignoring newline differences ('\\r\\n' == '\\n')"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNewlines_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualIgnoringNewlines_create_Test.java
@@ -39,4 +39,25 @@ class ShouldBeEqualIgnoringNewlines_create_Test {
                                    "  \"bar\"%n" +
                                    "when ignoring newlines (\\n, \\r\\n)."));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqualIgnoringNewLines(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "when ignoring newlines (\\n, \\r\\n)."));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingPunctuationAndWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingPunctuationAndWhitespace_create_Test.java
@@ -43,4 +43,26 @@ class ShouldBeEqualNormalizingPunctuationAndWhitespace_create_Test {
                                    "after punctuation and whitespace differences are normalized.%n" +
                                    "Punctuation is any of the following character !\"#$%%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "after punctuation and whitespace differences are normalized.%n" +
+                                   "Punctuation is any of the following character !\"#$%%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingUnicode_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingUnicode_create_Test.java
@@ -48,4 +48,32 @@ class ShouldBeEqualNormalizingUnicode_create_Test {
                                    "Normalized actual  : \"Ä\"%n" +
                                    "Normalized expected: \"A\""));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqualNormalizingUnicode(actual, expected, actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "after they have been normalized according to the Normalizer.Form.NFC form.%n" +
+                                   "The normalized strings should be equal.%n" +
+                                   "Normalized actual  : \"foo%n" +
+                                   "bar%n" +
+                                   "baz\"%n" +
+                                   "Normalized expected: \"moreFoo%n" +
+                                   "bar%n" +
+                                   "baz\""));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeEqualNormalizingWhitespace_create_Test.java
@@ -48,4 +48,25 @@ class ShouldBeEqualNormalizingWhitespace_create_Test {
                                    "  \" myfoo bar \"%n" +
                                    "after whitespace differences are normalized"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldBeEqualNormalizingWhitespace(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "after whitespace differences are normalized"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualIgnoringCase_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualIgnoringCase_create_Test.java
@@ -45,4 +45,25 @@ class ShouldNotBeEqualIgnoringCase_create_Test {
                                    "  \"Luke\"%n" +
                                    "ignoring case considerations"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "moreFoo%nbar%nbaz".formatted();
+    ErrorMessageFactory factory = shouldNotBeEqualIgnoringCase(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"));
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "not to be equal to:%n" +
+                                   "  \"moreFoo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "ignoring case considerations"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualIgnoringWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualIgnoringWhitespace_create_Test.java
@@ -46,4 +46,25 @@ class ShouldNotBeEqualIgnoringWhitespace_create_Test {
                                    "  \" my  foo bar \"%n" +
                                    "ignoring whitespace differences"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "foo%nbar %nbaz".formatted();
+    ErrorMessageFactory factory = shouldNotBeEqualIgnoringWhitespace(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "not to be equal to:%n" +
+                                   "  \"foo%n" +
+                                   "  bar %n" +
+                                   "  baz\"%n" +
+                                   "ignoring whitespace differences"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualNormalizingWhitespace_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotBeEqualNormalizingWhitespace_create_Test.java
@@ -46,4 +46,25 @@ class ShouldNotBeEqualNormalizingWhitespace_create_Test {
                                    "  \" my  foo bar \"%n" +
                                    "after whitespace differences are normalized"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_values_correctly_indented() {
+    // GIVEN
+    String actual = "foo%nbar%nbaz".formatted();
+    String expected = "foo%nbar %nbaz".formatted();
+    ErrorMessageFactory factory = shouldNotBeEqualNormalizingWhitespace(actual, expected);
+    // WHEN
+    String message = factory.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"foo%n" +
+                                   "  bar%n" +
+                                   "  baz\"%n" +
+                                   "not to be equal to:%n" +
+                                   "  \"foo%n" +
+                                   "  bar %n" +
+                                   "  baz\"%n" +
+                                   "after whitespace differences are normalized"));
+  }
 }


### PR DESCRIPTION
Related Issue: https://github.com/assertj/assertj/issues/3167

## Summary
  - apply IndentWrapper to Equal-related error message
  
## Updated Classes
- ShouldBeEqualIgnoringWhitespace
- ShouldNotBeEqualIgnoringWhitespace
- ShouldBeEqualNormalizingWhitespace
- ShouldNotBeEqualNormalizingWhitespace
- ShouldBeEqualNormalizingUnicode
- ShouldBeEqualIgnoringNewLineDifferences
- ShouldBeEqualIgnoringCase
- ShouldNotBeEqualIgnoringCase
- ShouldBeEqualIgnoringNewLines
- ShouldBeEqualNormalizingPunctuationAndWhitespace

As the number of affected files grew larger than expected, I decided to split the task into multiple PRs to ensure a smoother review process. This first PR focuses specifically on updating the Equals-related classes.