### PR TITLE
Fix ClassCastException in SoftAssertions with custom list assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -32,6 +32,7 @@ import static org.assertj.core.internal.Iterables.byPassingAssertions;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.util.Arrays.isArray;
 import static org.assertj.core.util.IterableUtil.toArray;
+import static org.assertj.core.util.IterableUtil.toArrayList;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.core.util.Preconditions.checkNotNull;
@@ -408,14 +409,14 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   @Override
   @SafeVarargs
   public final SELF containsExactlyInAnyOrder(ELEMENT... values) {
-    return containsExactlyInAnyOrderForProxy(values);
+    return containsExactlyInAnyOrderForProxy(newArrayList(values));
   }
 
   // This method is protected in order to be proxied for SoftAssertions / Assumptions.
   // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
   // in order to avoid compiler warning in user code
-  protected SELF containsExactlyInAnyOrderForProxy(ELEMENT[] values) {
-    iterables.assertContainsExactlyInAnyOrder(info, actual, values);
+  protected SELF containsExactlyInAnyOrderForProxy(Collection<? extends ELEMENT> values) {
+    iterables.assertContainsExactlyInAnyOrder(info, actual, values.toArray());
     return myself;
   }
 
@@ -424,7 +425,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    */
   @Override
   public SELF containsExactlyInAnyOrderElementsOf(Iterable<? extends ELEMENT> values) {
-    return containsExactlyInAnyOrder(toArray(values));
+    return containsExactlyInAnyOrderForProxy(toArrayList(values));
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/util/IterableUtil.java
+++ b/assertj-core/src/main/java/org/assertj/core/util/IterableUtil.java
@@ -107,6 +107,18 @@ public final class IterableUtil {
     return iterable instanceof Collection ? (Collection<T>) iterable : newArrayList(iterable);
   }
 
+  /**
+   * Returns a {@link List} containing all elements of the given {@link Iterable}.
+   *
+   * @param iterable the {@link Iterable} to convert to a {@link List}.
+   * @param <T> the type of elements of the {@code Iterable}.
+   * @return a {@link List} containing all elements of the given {@link Iterable}, or {@code null} if the given {@link Iterable} is {@code null}.
+   */
+  public static <T> List<T> toArrayList(Iterable<? extends T> iterable) {
+    if (iterable == null) return null;
+    return newArrayList(iterable);
+  }
+
   @SafeVarargs
   public static <T> Iterable<T> iterable(T... elements) {
     if (elements == null) return null;

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertions_proxied_AbstractListAssert_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertions_proxied_AbstractListAssert_Test.java
@@ -1,0 +1,49 @@
+package org.assertj.core.api;
+
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+import static org.assertj.core.util.Lists.list;
+
+import java.util.List;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SoftAssertions}, to verify that proxied custom assertions inheriting from {@link AbstractListAssert} do not throw {@link ClassCastException}.
+ *
+ * @author HuitaePark
+ */
+public class SoftAssertions_proxied_AbstractListAssert_Test {
+
+  @Test
+  void should_not_throw_class_cast_exception_when_calling_methods_with_array_args_on_proxied_custom_assertion() {
+    // GIVEN
+    List<String> actual = list("a", "b");
+    List<String> expected = list("a", "b");
+
+    // WHEN / THEN
+    thenNoException().isThrownBy(() -> {
+      SoftAssertions.assertSoftly(softly -> {
+        softly.proxy(TestListAssert.class, List.class, actual)
+              .containsExactlyInAnyOrderElementsOf(expected);
+      });
+    });
+  }
+
+  static class TestListAssert extends AbstractListAssert<TestListAssert, List<String>, String, ObjectAssert<String>> {
+
+    public TestListAssert(List<String> actual) {
+      super(actual, TestListAssert.class);
+    }
+
+    @Override
+    protected TestListAssert newAbstractIterableAssert(Iterable<? extends String> iterable) {
+      return new TestListAssert(Lists.newArrayList(iterable));
+    }
+
+    @Override
+    protected ObjectAssert<String> toAssert(String value, String description) {
+      return new ObjectAssert<>(value);
+    }
+  }
+}


### PR DESCRIPTION
Modified `containsExactlyInAnyOrderForProxy` to accept a `Collection` instead of arrays. This prevents `ClassCastException` caused by strict array type checking in proxies.

- **Signature Change**: `ForProxy` method now takes `Collection`.
- **New Utility**: Added `IterableUtil.toArrayList` for safe conversion.
- **Test**: Added `SoftAssertions_proxied_AbstractListAssert_Test` to verify the fix.

I have applied this fix only to `containsExactlyInAnyOrder` as a proof of concept.
Please confirm if this direction is correct. Once approved, I will apply this pattern to all other affected methods (e.g.,`ForProxy`).

#### Check List:
* Fixes #3797 
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)