### PR TITLE
feat: add isNotEqualTo(String) to BigDecimalAssert

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -40,6 +40,7 @@ import org.assertj.core.api.comparisonstrategy.ComparatorBasedComparisonStrategy
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author chanwon lee
  */
 public abstract class AbstractBigDecimalAssert<SELF extends AbstractBigDecimalAssert<SELF>> extends
     AbstractComparableAssert<SELF, BigDecimal> implements NumberAssert<SELF, BigDecimal> {
@@ -229,6 +230,26 @@ public abstract class AbstractBigDecimalAssert<SELF extends AbstractBigDecimalAs
    */
   public SELF isEqualTo(String expected) {
     return isEqualTo(new BigDecimal(expected));
+  }
+
+  /**
+   * Same as {@link AbstractAssert#isNotEqualTo(Object) isNotEqualTo(BigDecimal)} but takes care of converting given String
+   to
+   * {@link BigDecimal} for you.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualTo(&quot;2.0&quot;);
+   *
+   * // assertion will fail
+   * assertThat(new BigDecimal(&quot;8.0&quot;)).isNotEqualTo(&quot;8.0&quot;);</code></pre>
+   *
+   * @param expected the given number to compare the actual value to.
+   * @return {@code this} assertion object.
+   * @since 4.0.0
+   */
+  public SELF isNotEqualTo(String expected) {
+    return isNotEqualTo(new BigDecimal(expected));
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isNotEqualToWithStringParameter_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/bigdecimal/BigDecimalAssert_isNotEqualToWithStringParameter_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.bigdecimal;
+
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+
+import org.assertj.core.api.BigDecimalAssert;
+import org.assertj.core.api.BigDecimalAssertBaseTest;
+
+class BigDecimalAssert_isNotEqualToWithStringParameter_Test extends BigDecimalAssertBaseTest {
+
+  @Override
+  protected BigDecimalAssert invoke_api_method() {
+    return assertions.isNotEqualTo(ONE_AS_STRING);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertNotEqual(getInfo(assertions), getActual(assertions), new BigDecimal(ONE_AS_STRING));
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #4022
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

### Summary
Add `isNotEqualTo(String)` to `BigDecimalAssert`, which was missed in #4032.

### Question
Should the `@since` tag be `4.0.0` (current version) or `3.28` (same as #4032)?
I used `@since 4.0.0` since the current version is `4.0.0-SNAPSHOT`, but wanted to confirm.