### PR TITLE
Fix: Apply IndentWrapper to `contains CharSequence` error messages

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldBeSubstring.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldBeSubstring.java
@@ -32,6 +32,7 @@ public class ShouldBeSubstring extends BasicErrorMessageFactory {
   }
 
   private ShouldBeSubstring(CharSequence actual, CharSequence expected, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto be a substring of:%n  %s%n%s", actual, expected, comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto be a substring of:%n  %s%n%s",
+          IndentWrapper.of(actual), IndentWrapper.of(expected), comparisonStrategy);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
@@ -203,12 +203,12 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
 
   private ShouldContainCharSequence(String format, CharSequence actual, CharSequence sequence,
                                     ComparisonStrategy comparisonStrategy) {
-    super(format, actual, sequence, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(sequence), comparisonStrategy);
   }
 
   private ShouldContainCharSequence(String format, CharSequence actual, CharSequence[] values,
                                     Set<? extends CharSequence> notFound,
                                     ComparisonStrategy comparisonStrategy) {
-    super(format, actual, values, notFound, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(values), notFound, comparisonStrategy);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce.java
@@ -57,13 +57,12 @@ public class ShouldContainCharSequenceOnlyOnce extends BasicErrorMessageFactory 
 
   private ShouldContainCharSequenceOnlyOnce(CharSequence actual, CharSequence expected, int occurrences,
                                             ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it appeared %s times %s", actual, expected,
-          occurrences,
-          comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it appeared %s times %s",
+          IndentWrapper.of(actual), IndentWrapper.of(expected), occurrences, comparisonStrategy);
   }
 
   private ShouldContainCharSequenceOnlyOnce(CharSequence actual, CharSequence expected, ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it did not appear %s", actual, expected,
-          comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto contain:%n  %s%nonly once but it did not appear %s",
+          IndentWrapper.of(actual), IndentWrapper.of(expected), comparisonStrategy);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSequenceOfCharSequence.java
@@ -28,7 +28,8 @@ import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
 public class ShouldContainSequenceOfCharSequence extends BasicErrorMessageFactory {
   private ShouldContainSequenceOfCharSequence(CharSequence actual, CharSequence[] sequence,
                                               ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto contain sequence:%n  %s%n%s", actual, sequence, comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto contain sequence:%n  %s%n%s",
+          IndentWrapper.of(actual), IndentWrapper.of(sequence), comparisonStrategy);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence.java
@@ -130,11 +130,11 @@ public class ShouldContainSubsequenceOfCharSequence extends BasicErrorMessageFac
                                                  CharSequence foundButBadOrder,
                                                  CharSequence foundButBadOrder2,
                                                  ComparisonStrategy comparisonStrategy) {
-    super(format, actual, strings, foundButBadOrder, foundButBadOrder2, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(strings), foundButBadOrder, foundButBadOrder2, comparisonStrategy);
   }
 
   private ShouldContainSubsequenceOfCharSequence(String format, CharSequence actual, CharSequence[] strings,
                                                  ComparisonStrategy comparisonStrategy) {
-    super(format, actual, strings, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(strings), comparisonStrategy);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainCharSequence.java
@@ -35,13 +35,13 @@ public class ShouldNotContainCharSequence extends BasicErrorMessageFactory {
 
   private ShouldNotContainCharSequence(String format, CharSequence actual, CharSequence sequence,
                                        ComparisonStrategy comparisonStrategy) {
-    super(format, actual, sequence, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(sequence), comparisonStrategy);
   }
 
   private ShouldNotContainCharSequence(String format, CharSequence actual, CharSequence[] values,
                                        Set<? extends CharSequence> found,
                                        ComparisonStrategy comparisonStrategy) {
-    super(format, actual, values, found, comparisonStrategy);
+    super(format, IndentWrapper.of(actual), IndentWrapper.of(values), found, comparisonStrategy);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence.java
@@ -52,8 +52,8 @@ public class ShouldNotContainSequenceOfCharSequence extends BasicErrorMessageFac
 
   private ShouldNotContainSequenceOfCharSequence(CharSequence actual, CharSequence[] sequence, int index,
                                                  ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto not contain sequence:%n  %s%nbut was found at index %s%n%s", actual, sequence, index,
-          comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto not contain sequence:%n  %s%nbut was found at index %s%n%s",
+          IndentWrapper.of(actual), IndentWrapper.of(sequence), index, comparisonStrategy);
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence.java
@@ -54,7 +54,7 @@ public class ShouldNotContainSubsequenceOfCharSequence extends BasicErrorMessage
 
   private ShouldNotContainSubsequenceOfCharSequence(CharSequence actual, CharSequence[] subsequence, int[] subsequenceIndexes,
                                                     ComparisonStrategy comparisonStrategy) {
-    super("%nExpecting actual:%n  %s%nto not contain subsequence:%n  %s%nbut was found with indexes:%n  %s%n%s", actual,
-          subsequence, subsequenceIndexes, comparisonStrategy);
+    super("%nExpecting actual:%n  %s%nto not contain subsequence:%n  %s%nbut was found with indexes:%n  %s%n%s",
+          IndentWrapper.of(actual), IndentWrapper.of(subsequence), subsequenceIndexes, comparisonStrategy);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeSubstringOf_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeSubstringOf_create_Test.java
@@ -58,4 +58,21 @@ class ShouldBeSubstringOf_create_Test {
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
 
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "bcd%nefg%nhij".formatted();
+    ErrorMessageFactory factory = shouldBeSubstring(actual, "abcdef", StandardComparisonStrategy.instance());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"bcd%n" +
+                                   "  efg%n" +
+                                   "  hij\"%n" +
+                                   "to be a substring of:%n" +
+                                   "  \"abcdef\"%n"));
+  }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequenceOnlyOnce_create_Test.java
@@ -15,6 +15,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainCharSequenceOnlyOnce.shouldContainOnlyOnce;
 
@@ -73,6 +74,42 @@ class ShouldContainCharSequenceOnlyOnce_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo("[Test] %nExpecting actual:%n  \"aaamotIFmoTifaabbbmotifaaa\"%nto contain:%n  \"MOtif\"%nonly once but it appeared 3 times when comparing values using CaseInsensitiveStringComparator".formatted());
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_when_string_does_not_appear() {
+    // GIVEN
+    String actual = "aaa%nbbb%nccc".formatted();
+    ErrorMessageFactory factory = shouldContainOnlyOnce(actual, "motif", 0);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"aaa%n" +
+                                   "  bbb%n" +
+                                   "  ccc\"%n" +
+                                   "to contain:%n" +
+                                   "  \"motif\"%n" +
+                                   "only once but it did not appear "));
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_when_string_appears_several_times() {
+    // GIVEN
+    String actual = "aaamotifaaa%nbbbmotifbbb%ncccmotifccc".formatted();
+    ErrorMessageFactory factory = shouldContainOnlyOnce(actual, "motif", 3);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"aaamotifaaa%n" +
+                                   "  bbbmotifbbb%n" +
+                                   "  cccmotifccc\"%n" +
+                                   "to contain:%n" +
+                                   "  \"motif\"%n" +
+                                   "only once but it appeared 3 times "));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -173,10 +173,27 @@ class ShouldContainCharSequence_create_Test {
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  \"Yoda%nLuke\"%n" +
+                                   "  \"Yoda%n" +
+                                   "  Luke\"%n" +
                                    "to contain (ignoring new lines):%n" +
                                    "  [\"Vador\", \"Luke\", \"Solo\"]%n" +
                                    "but could not find:%n" +
                                    "  [\"Vador\", \"Solo\"]%n "));
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yo%nda".formatted();
+    ErrorMessageFactory factory = shouldContain(actual, "Luke");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yo%n" +
+                                   "  da\"%n" +
+                                   "to contain:%n" +
+                                   "  \"Luke\" "));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSequenceOfCharSequence_create_Test.java
@@ -17,7 +17,7 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldContainSequence.shouldContainSequence;
+import static org.assertj.core.error.ShouldContainSequenceOfCharSequence.shouldContainSequence;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.description.TextDescription;
@@ -61,5 +61,21 @@ class ShouldContainSequenceOfCharSequence_create_Test {
                                    "to contain sequence:%n" +
                                    "  [\"{\", \"author\", \"title\", \"}\"]%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String[] sequenceValues = { "author", "title" };
+    String actual = "{ 'title':'A Game of Thrones',%n'author':'George Martin'}".formatted();
+    // WHEN
+    String message = shouldContainSequence(actual, sequenceValues).create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"{ 'title':'A Game of Thrones',%n" +
+                                   "  'author':'George Martin'}\"%n" +
+                                   "to contain sequence:%n" +
+                                   "  [\"author\", \"title\"]%n"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainSubsequenceOfCharSequence_create_Test.java
@@ -148,4 +148,23 @@ class ShouldContainSubsequenceOfCharSequence_create_Test {
                                    "- the 2nd occurrence of \"George\" was not found%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String[] sequenceValues = { "{", "author", "title", "}" };
+    String actual = "{ 'title':'A Game of Thrones',%n'author':'George Martin'}".formatted();
+    ErrorMessageFactory factory = shouldContainSubsequence(actual, sequenceValues, 1);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"{ 'title':'A Game of Thrones',%n" +
+                                   "  'author':'George Martin'}\"%n" +
+                                   "to contain the following CharSequences in this order (possibly with other values between them):%n"
+                                   +
+                                   "  [\"{\", \"author\", \"title\", \"}\"]%n" +
+                                   "but \"title\" was found before \"author\"%n"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainCharSequence_create_Test.java
@@ -114,4 +114,20 @@ class ShouldNotContainCharSequence_create_Test {
                                    "  [\"OD\", \"da\"]%n"));
   }
 
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yo%nda".formatted();
+    ErrorMessageFactory factory = shouldNotContain(actual, "od", StandardComparisonStrategy.instance());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yo%n" +
+                                   "  da\"%n" +
+                                   "not to contain:%n" +
+                                   "  \"od\"%n"));
+  }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSequenceOfCharSequence_Test.java
@@ -64,4 +64,21 @@ class ShouldNotContainSequenceOfCharSequence_Test {
                                    "but was found at index 0%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yo%nda".formatted();
+    var factory = shouldNotContainSequence(actual, array("Yo", "da"), 0);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yo%n" +
+                                   "  da\"%n" +
+                                   "to not contain sequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found at index 0%n"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainSubsequenceOfCharSequence_create_Test.java
@@ -66,4 +66,22 @@ class ShouldNotContainSubsequenceOfCharSequence_create_Test {
                                    "  [0, 2]%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yo%nda".formatted();
+    var factory = shouldNotContainSubsequence(actual, array("Yo", "da"), new int[] { 0, 3 });
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yo%n" +
+                                   "  da\"%n" +
+                                   "to not contain subsequence:%n" +
+                                   "  [\"Yo\", \"da\"]%n" +
+                                   "but was found with indexes:%n" +
+                                   "  [0, 3]%n"));
+  }
 }


### PR DESCRIPTION
Related Issue: https://github.com/assertj/assertj/issues/3167

## Summary
  - apply IndentWrapper to `contains CharSequence` error messages
  
## Updated Classes
- ShouldContainCharSequence 
- ShouldContainCharSequenceOnlyOnce 
- ShouldBeSubstring 
- ShouldNotContainCharSequence 
- ShouldContainSequenceOfCharSequence 
- ShouldContainSubsequenceOfCharSequence 
- ShouldNotContainSequenceOfCharSequence 
- ShouldNotContainSubsequenceOfCharSequence 