### PR TITLE
Fix: Apply IndentWrapper to `pattern-match` error messages

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainOnlyDigits.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainOnlyDigits.java
@@ -44,10 +44,10 @@ public class ShouldContainOnlyDigits extends BasicErrorMessageFactory {
 
   private ShouldContainOnlyDigits(CharSequence actual, char character, int index) {
     super("%nExpecting actual:%n  %s%nto contain only digits%nbut found non-digit character %s at index <%s>",
-          actual, character, index);
+          IndentWrapper.of(actual), character, index);
   }
 
   private ShouldContainOnlyDigits(CharSequence actual) {
-    super("%nExpecting actual:%n  %s%nto contain only digits%nbut could not found any digits at all", actual);
+    super("%nExpecting actual:%n  %s%nto contain only digits%nbut could not found any digits at all", IndentWrapper.of(actual));
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainPattern.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainPattern.java
@@ -33,6 +33,6 @@ public class ShouldContainPattern extends BasicErrorMessageFactory {
   }
 
   private ShouldContainPattern(CharSequence actual, CharSequence pattern) {
-    super("%nExpecting actual:%n  %s%nto contain pattern:%n  %s", actual, pattern);
+    super("%nExpecting actual:%n  %s%nto contain pattern:%n  %s", IndentWrapper.of(actual), pattern);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldMatchPattern.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldMatchPattern.java
@@ -34,6 +34,6 @@ public class ShouldMatchPattern extends BasicErrorMessageFactory {
   }
 
   private ShouldMatchPattern(CharSequence actual, CharSequence pattern) {
-    super("%nExpecting actual:%n  %s%nto match pattern:%n  %s", actual, pattern);
+    super("%nExpecting actual:%n  %s%nto match pattern:%n  %s", IndentWrapper.of(actual), pattern);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainPattern.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotContainPattern.java
@@ -37,6 +37,6 @@ public class ShouldNotContainPattern extends BasicErrorMessageFactory {
           "  %s%n" +
           "not to contain pattern:%n" +
           "  %s",
-          actual, pattern);
+          IndentWrapper.of(actual), pattern);
   }
 }

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldNotMatchPattern.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldNotMatchPattern.java
@@ -34,6 +34,6 @@ public class ShouldNotMatchPattern extends BasicErrorMessageFactory {
   }
 
   private ShouldNotMatchPattern(CharSequence actual, CharSequence pattern) {
-    super("%nExpecting actual:%n  %s%nnot to match pattern:%n  %s", actual, pattern);
+    super("%nExpecting actual:%n  %s%nnot to match pattern:%n  %s", IndentWrapper.of(actual), pattern);
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainOnlyDigits_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainOnlyDigits_create_Test.java
@@ -55,4 +55,36 @@ class ShouldContainOnlyDigits_create_Test {
                                    "to contain only digits%n" +
                                    "but could not found any digits at all"));
   }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "10%n20$".formatted();
+    ErrorMessageFactory factory = shouldContainOnlyDigits(actual, '$', 5);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"10%n" +
+                                   "  20$\"%n" +
+                                   "to contain only digits%n" +
+                                   "but found non-digit character '$' at index <5>"));
+  }
+
+  @Test
+  void should_create_error_message_for_no_digits_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "abc%ndef".formatted();
+    ErrorMessageFactory factory = shouldContainOnlyDigits(actual);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"abc%n" +
+                                   "  def\"%n" +
+                                   "to contain only digits%n" +
+                                   "but could not found any digits at all"));
+  }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldContainPattern_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldContainPattern_create_Test.java
@@ -15,6 +15,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainPattern.shouldContainPattern;
 
@@ -32,6 +33,23 @@ class ShouldContainPattern_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo("[Test] %nExpecting actual:%n  \"Frodo\"%nto contain pattern:%n  \".*Orc.*\"".formatted());
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Frodo%nthe%nhobbit".formatted();
+    ErrorMessageFactory factory = shouldContainPattern(actual, ".*Orc.*");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Frodo%n" +
+                                   "  the%n" +
+                                   "  hobbit\"%n" +
+                                   "to contain pattern:%n" +
+                                   "  \".*Orc.*\""));
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldMatchPattern_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldMatchPattern_create_Test.java
@@ -15,6 +15,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldMatchPattern.shouldMatch;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
@@ -47,5 +48,22 @@ class ShouldMatchPattern_create_Test {
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo("[Test] %nExpecting actual:%n  \"%%%%E\"%nto match pattern:%n  \"fffff\"".formatted());
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yoda%nthe%nmaster".formatted();
+    ErrorMessageFactory factory = shouldMatch(actual, "Luke");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda%n" +
+                                   "  the%n" +
+                                   "  master\"%n" +
+                                   "to match pattern:%n" +
+                                   "  \"Luke\""));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotContainPattern_create_Test.java
@@ -39,4 +39,21 @@ class ShouldNotContainPattern_create_Test {
                                    "  \"Fr.do\""));
   }
 
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Frodo%nthe%nhobbit".formatted();
+    ErrorMessageFactory factory = shouldNotContainPattern(actual, "Fr.do");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), CONFIGURATION_PROVIDER.representation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Frodo%n" +
+                                   "  the%n" +
+                                   "  hobbit\"%n" +
+                                   "not to contain pattern:%n" +
+                                   "  \"Fr.do\""));
+  }
+
 }

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldNotMatchPattern_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldNotMatchPattern_create_Test.java
@@ -15,6 +15,7 @@
  */
 package org.assertj.core.error;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotMatchPattern.shouldNotMatch;
 
@@ -37,5 +38,22 @@ class ShouldNotMatchPattern_create_Test {
     String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo("[Test] %nExpecting actual:%n  \"Yoda\"%nnot to match pattern:%n  \"Luke\"".formatted());
+  }
+
+  @Test
+  void should_create_error_message_with_multiline_actual_correctly_indented() {
+    // GIVEN
+    String actual = "Yoda%nthe%nmaster".formatted();
+    ErrorMessageFactory factory = shouldNotMatch(actual, "Luke");
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Yoda%n" +
+                                   "  the%n" +
+                                   "  master\"%n" +
+                                   "not to match pattern:%n" +
+                                   "  \"Luke\""));
   }
 }


### PR DESCRIPTION
Related Issue: https://github.com/assertj/assertj/issues/3167

## Summary
  - apply IndentWrapper to `pattern-match` error messages
  
## Updated Classes
- ShouldContainOnlyDigits
- ShouldContainPattern
- ShouldMatchPattern
- ShouldNotContainPattern
- ShouldNotMatchPattern