### PR TITLE
Set up TestLens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           distribution: 'zulu'
           java-version: '25'
           cache: 'maven'
+      - uses: testlens-app/setup-testlens@cbf46f117aa1b73f2f101616333e9625b46d4b95 # v1.6.1
       - name: Test
         run: ./mvnw $MAVEN_ARGS verify
       - name: Publish Test Report
@@ -54,6 +55,7 @@ jobs:
           website: jdk.java.net
           release: ${{ matrix.java }}
           version: latest
+      - uses: testlens-app/setup-testlens@cbf46f117aa1b73f2f101616333e9625b46d4b95 # v1.6.1
       - name: Test
         run: ./mvnw $MAVEN_ARGS verify
 
@@ -75,6 +77,7 @@ jobs:
           distribution: 'zulu'
           java-version: '25'
           cache: 'maven'
+      - uses: testlens-app/setup-testlens@cbf46f117aa1b73f2f101616333e9625b46d4b95 # v1.6.1
       - name: Test
         run: ./mvnw $MAVEN_ARGS -Dgroovy.version=${{ matrix.groovy }} verify
 
@@ -96,6 +99,7 @@ jobs:
           distribution: 'zulu'
           java-version: '25'
           cache: 'maven'
+      - uses: testlens-app/setup-testlens@cbf46f117aa1b73f2f101616333e9625b46d4b95 # v1.6.1
       - name: Test
         run: ./mvnw $MAVEN_ARGS -Dkotlin.version=${{ matrix.kotlin }} verify
 
@@ -131,6 +135,7 @@ jobs:
           distribution: 'zulu'
           java-version: '25'
           cache: 'maven'
+      - uses: testlens-app/setup-testlens@cbf46f117aa1b73f2f101616333e9625b46d4b95 # v1.6.1
       - name: Test with Sonar
         run: >
           ./mvnw $MAVEN_ARGS verify sonar:sonar


### PR DESCRIPTION
This adds the [`testlens-app/setup-testlens`](https://github.com/marketplace/actions/setup-testlens) action to all workflows running tests.

The app posts a summary of all test failures as a PR comment and provides means to mute unrelated test failures and faster reruns. For more information, please refer to the [announcement](https://testlens.app/blog/2026/02/04/testlens-private-beta-launch) on our website.

Follow-up for #4137