### PR TITLE
Improve Javadoc regarding default `Charset` usage

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractByteArrayAssert.java
@@ -1270,7 +1270,8 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
    * Converts the actual byte[] under test to a String and returns assertions for the computed String
    * allowing String specific assertions from this call.
    * <p>
-   * The byte[] conversion to a String by decoding the specified bytes using the platform's default charset.
+   * The byte[] conversion to a String by decoding the specified bytes using the platform's
+   * {@link Charset#defaultCharset() default charset}.
    * <p>
    * Example :
    * <pre><code class='java'> byte[] bytes = new byte[] { -1, 0, 1 };
@@ -1300,8 +1301,6 @@ public abstract class AbstractByteArrayAssert<SELF extends AbstractByteArrayAsse
    * Converts the actual byte[] under test to a String by decoding the specified bytes using the given charset
    * and returns assertions for the computed String
    * allowing String specific assertions from this call.
-   * <p>
-   * The byte[] conversion to a String by decoding the specified bytes using the platform's default charset.
    * <p>
    * Example :
    * <pre><code class='java'> byte[] bytes = new byte[] { -1, 0, 1 };

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -228,6 +228,9 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * This will change in AssertJ 4.0 where newlines will be taken into account, in the meantime, to get this behavior
    * one can use {@link #asString(Charset)} and then chain with {@link AbstractStringAssert#isEqualTo(String)}.
    * <p>
+   * The {@link Charset#defaultCharset() default charset} is used for decoding the bytes of the stream to a String.
+   * To use a different charset for decoding, use {@link #asString(Charset)}.
+   * <p>
    * <b>Warning: this will consume the whole input stream in case the underlying
    * implementation does not support {@link InputStream#markSupported() marking}.</b>
    * <p>

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -180,7 +180,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    *
    * // The following assertion succeeds:
    * String expectedContent = "Gerçek Başka bir yerde mi" + org.assertj.core.util.Compatibility.System.lineSeparator();
-   * byte[] binaryContent = expectedContent.getBytes(turkishCharset.name());
+   * byte[] binaryContent = expectedContent.getBytes(turkishCharset);
    * assertThat(xFileTurkish).hasBinaryContent(binaryContent);
    *
    * // The following assertion fails ... unless you are in Turkey ;-):

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractStringAssert.java
@@ -479,7 +479,8 @@ public class AbstractStringAssert<SELF extends AbstractStringAssert<SELF>> exten
   }
 
   /**
-   * Encodes the actual value as byte array using the platform's default charset, the encoded byte array becoming the new value under test.
+   * Encodes the actual value as byte array using the platform's {@link Charset#defaultCharset() default charset},
+   * the encoded byte array becoming the new value under test.
    * <p>
    * Examples:
    * <pre><code class='java'> assertThat("abc").bytes()

--- a/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assertions.java
@@ -2778,8 +2778,8 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file with the default character set, so that it can be passed to
-   * {@link #assertThat(String)}.
+   * Loads the text content of a file with the {@link Charset#defaultCharset() default charset},
+   * so that it can be passed to {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files, there might be a more efficient alternative
    * with {@link #assertThat(File)}.
@@ -2794,8 +2794,8 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param file the file.
@@ -2836,8 +2836,8 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file at a given path into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
@@ -2920,7 +2920,7 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a URL with the default character set, so that it can be passed to
+   * Loads the text content of a URL with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files.
@@ -2935,8 +2935,8 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a URL into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a URL into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param url the URL.

--- a/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -1647,7 +1647,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Loads the text content of a file with the default character set, so that it can be passed to
+   * Loads the text content of a file with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files, there might be a more efficient alternative
@@ -1663,8 +1663,8 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Loads the text content of a file into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param file the file.
@@ -1705,8 +1705,8 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a path into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
@@ -1789,7 +1789,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Loads the text content of a URL with the default character set, so that it can be passed to
+   * Loads the text content of a URL with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files.
@@ -1804,8 +1804,8 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Loads the text content of a URL into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a URL into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param url the URL.

--- a/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -3206,7 +3206,7 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Loads the text content of a file with the default character set, so that it can be passed to
+   * Loads the text content of a file with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files, there might be a more efficient alternative
@@ -3223,8 +3223,8 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Loads the text content of a file into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param file the file.
@@ -3268,8 +3268,8 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file at a given path into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
@@ -3351,7 +3351,7 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Loads the text content of a URL with the default character set, so that it can be passed to
+   * Loads the text content of a URL with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files.
@@ -3367,8 +3367,8 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
-   * Loads the text content of a URL into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a URL into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param url the URL.

--- a/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -1962,7 +1962,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file with the default character set, so that it can be passed to
+   * Loads the text content of a file with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files, there might be a more efficient alternative
@@ -1995,8 +1995,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param file the file.
@@ -2037,8 +2037,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a file at a given path into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
@@ -3457,7 +3457,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a URL with the default character set, so that it can be passed to
+   * Loads the text content of a URL with the {@link Charset#defaultCharset() default charset}, so that it can be passed to
    * {@link #assertThat(String)}.
    * <p>
    * Note that this will load the entire file in memory; for larger files.
@@ -3473,8 +3473,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a URL into a list of strings with the default charset, each string corresponding to a
-   * line.
+   * Loads the text content of a URL into a list of strings with the {@link Charset#defaultCharset() default charset},
+   * each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param url the URL.


### PR DESCRIPTION
- Fixed missing mention of default Charset usage (see review comment)
- Fixed wrong mention of default Charset usage
- Added `{@link ...}` to all default Charset references, for consistency
- Changed "default character set" to "default charset", for consistency
