### PR TITLE
Update EqualsVerifier and fix JDK 26 final field mutation warnings

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.18</version>
+      <version>4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/FieldLocation.java
@@ -61,17 +61,12 @@ public final class FieldLocation implements Comparable<FieldLocation> {
     if (this == obj) return true;
     if (!(obj instanceof FieldLocation)) return false;
     FieldLocation that = (FieldLocation) obj;
-    return Objects.equals(pathToUseInRules, that.pathToUseInRules)
-           && Objects.equals(decomposedPath, that.decomposedPath)
-           && Objects.equals(pathsHierarchyToUseInRules, that.pathsHierarchyToUseInRules);
+    return Objects.equals(decomposedPath, that.decomposedPath);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hashCode(pathToUseInRules);
-    result = 31 * result + Objects.hashCode(decomposedPath);
-    result = 31 * result + Objects.hashCode(pathsHierarchyToUseInRules);
-    return result;
+    return Objects.hashCode(decomposedPath);
   }
 
   @Override

--- a/assertj-core/src/test/java/org/assertj/core/api/Tuple_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/Tuple_Test.java
@@ -85,9 +85,11 @@ class Tuple_Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(Tuple.class)
+                  .withFactory(values -> new Tuple(((List<Object>) values.get("values")).toArray()))
                   .withNonnullFields("values")
                   .verify();
   }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/pom.xml
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <version>3.18</version>
+      <version>4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/FieldLocation_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/FieldLocation_Test.java
@@ -35,6 +35,9 @@ class FieldLocation_Test {
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(FieldLocation.class)
+                  .withFactory(values -> new FieldLocation(values.<List<String>> get("decomposedPath")))
+                  .withNonnullFields("decomposedPath")
+                  .withIgnoredFields("pathToUseInRules", "pathsHierarchyToUseInRules")
                   .verify();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/DualValue_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/DualValue_Test.java
@@ -22,6 +22,7 @@ import static org.assertj.core.util.Lists.list;
 import java.util.Objects;
 
 import org.assertj.core.api.recursive.comparison.DualValue;
+import org.assertj.core.api.recursive.comparison.FieldLocation;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -31,8 +32,10 @@ class DualValue_Test {
   @Test
   void should_honor_equals_contract() {
     EqualsVerifier.forClass(DualValue.class)
+                  .withFactory(values -> new DualValue(values.<FieldLocation> get("fieldLocation"), values.get("actual"),
+                                                       values.get("expected")))
                   .withNonnullFields("fieldLocation")
-                  .withCachedHashCode("hashCode", "computeHashCode", new DualValue(list(), "foo", "bar"))
+                  .withIgnoredFields("hashCode")
                   .verify();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Index_Test.java
@@ -35,6 +35,7 @@ class Index_Test {
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(Index.class)
+                  .withFactory(values -> Index.atIndex(values.getInt("value")))
                   .verify();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/MapEntry_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/MapEntry_Test.java
@@ -32,6 +32,7 @@ class MapEntry_Test {
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(MapEntry.class)
+                  .withFactory(values -> MapEntry.entry(values.get("key"), values.get("value")))
                   .verify();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Offset_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Offset_Test.java
@@ -37,6 +37,9 @@ class Offset_Test {
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(Offset.class)
+                  .withFactory(values -> Offset.offset(values.get("value")))
+                  .withNonnullFields("value")
+                  .withIgnoredFields("strict")
                   .verify();
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Percentage_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Percentage_Test.java
@@ -37,6 +37,7 @@ class Percentage_Test {
   void should_honor_equals_contract() {
     // WHEN/THEN
     EqualsVerifier.forClass(Percentage.class)
+                  .withFactory(v -> Percentage.withPercentage(v.getDouble("value")))
                   .verify();
   }
 


### PR DESCRIPTION
#### Check List:
* Fixes https://github.com/jqno/equalsverifier/issues/1149
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

This PR follows up on @scordio's ticket in EqualsVerifier, about JDK 26's "final means final" warnings.
