### PR TITLE
Honor collections' comparison semantics in `contains` assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -126,13 +126,6 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
 
   protected AbstractIterableAssert(ACTUAL actual, Class<?> selfType) {
     super(actual, selfType);
-
-    if (actual instanceof SortedSet) {
-      @SuppressWarnings("unchecked")
-      SortedSet<ELEMENT> sortedSet = (SortedSet<ELEMENT>) actual;
-      Comparator<? super ELEMENT> comparator = sortedSet.comparator();
-      if (comparator != null) usingElementComparator(sortedSet.comparator());
-    }
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldContainAnyOf.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldContainAnyOf.java
@@ -37,7 +37,8 @@ public class ShouldContainAnyOf extends BasicErrorMessageFactory {
   }
 
   private ShouldContainAnyOf(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
-    super(FORMAT_WITH_COMPARISON_STRATEGY, actual, expected, comparisonStrategy);
+    super(comparisonStrategy.isStandard() ? DEFAULT_FORMAT : FORMAT_WITH_COMPARISON_STRATEGY, actual, expected,
+          comparisonStrategy);
   }
 
   private ShouldContainAnyOf(Object actual, Object expected) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/CommonValidations.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/CommonValidations.java
@@ -26,6 +26,7 @@ import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGre
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
 import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsEmpty;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 import static org.assertj.core.internal.CommonErrors.iterableOfValuesToLookForIsEmpty;
@@ -174,8 +175,8 @@ public final class CommonValidations {
     requireNonNull(expectedType, "The given type should not be null");
   }
 
-  public static void checkIterableIsNotNull(Iterable<?> set) {
-    requireNonNull(set, "The iterable to look for should not be null");
+  public static void checkIterableIsNotNull(Iterable<?> iterable) {
+    requireNonNull(iterable, shouldNotBeNull("iterable")::create);
   }
 
   public static void checkSequenceIsNotNull(Object sequence) {

--- a/assertj-core/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/ComparatorBasedComparisonStrategy.java
@@ -171,7 +171,7 @@ public class ComparatorBasedComparisonStrategy extends AbstractComparisonStrateg
 
   @Override
   public String asText() {
-    return "when comparing values using " + toString();
+    return "when comparing values using " + this;
   }
 
   @Override

--- a/assertj-core/src/main/java/org/assertj/core/internal/IterableDiff.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/IterableDiff.java
@@ -21,10 +21,6 @@ import static org.assertj.core.util.Lists.newArrayList;
 import java.util.ArrayList;
 import java.util.List;
 
-// immutable
-/**
- * @param <T> the type of element to compare.
- */
 class IterableDiff<T> {
 
   private final ComparisonStrategy comparisonStrategy;
@@ -74,7 +70,7 @@ class IterableDiff<T> {
     return unmodifiableList(missingInFirst);
   }
 
-  private boolean isActualElementInExpected(T elementInActual, List<T> copyOfExpected) {
+  private boolean isActualElementInExpected(Object elementInActual, List<?> copyOfExpected) {
     // the order of comparisonStrategy.areEqual is important if element comparison is not symmetrical, we must compare actual to
     // expected but not expected to actual, for ex recursive comparison where:
     // - actual element is PersonDto, expected a list of Person

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -54,6 +54,7 @@ import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubse
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.assertj.core.error.ShouldNotContainSequence.shouldNotContainSequence;
@@ -314,35 +315,22 @@ public class Iterables {
     hasSameSizeAsCheck(info, actual, other, sizeOf(actual));
   }
 
-  /**
-   * Asserts that the given {@code Iterable} contains the given values, in any order.
-   *
-   * @param info contains information about the assertion.
-   * @param actual the given {@code Iterable}.
-   * @param values the values that are expected to be in the given {@code Iterable}.
-   * @throws NullPointerException if the array of values is {@code null}.
-   * @throws IllegalArgumentException if the array of values is empty.
-   * @throws AssertionError if the given {@code Iterable} is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} does not contain the given values.
-   */
   public void assertContains(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    final Collection<?> actualAsCollection = ensureActualCanBeReadMultipleTimes(actual);
-    if (commonCheckThatIterableAssertionSucceeds(info, failures, actualAsCollection, values)) return;
-    // check for elements in values that are missing in actual.
-    assertIterableContainsGivenValues(actual.getClass(), actualAsCollection, values, info);
+    assertNotNull(info, actual);
+    java.util.Objects.requireNonNull(values, shouldNotBeNull("values")::create);
+    assertIterableContainsGivenValues(info, actual.getClass(), ensureActualCanBeReadMultipleTimes(actual), values);
   }
 
   private static Collection<?> ensureActualCanBeReadMultipleTimes(Iterable<?> actual) {
     return actual instanceof Collection<?> ? (Collection<?>) actual : newArrayList(actual);
   }
 
-  private void assertIterableContainsGivenValues(@SuppressWarnings("rawtypes") Class<? extends Iterable> clazz,
-                                                 Iterable<?> actual, Object[] values, AssertionInfo info) {
-    Set<Object> notFound = stream(values).filter(value -> !iterableContains(actual, value))
+  private void assertIterableContainsGivenValues(AssertionInfo info, Class<?> actualType, Iterable<?> iterable, Object[] values) {
+    Set<Object> notFound = stream(values).filter(value -> !iterableContains(iterable, value))
                                          .collect(toCollection(LinkedHashSet::new));
-    if (notFound.isEmpty())
-      return;
-    throw failures.failure(info, shouldContain(clazz, actual, values, notFound, comparisonStrategy));
+    if (!notFound.isEmpty()) {
+      throw failures.failure(info, shouldContain(actualType, iterable, values, notFound, comparisonStrategy));
+    }
   }
 
   private boolean iterableContains(Iterable<?> actual, Object value) {
@@ -1081,38 +1069,15 @@ public class Iterables {
     }
   }
 
-  /**
-   * Asserts that the given {@code Iterable} contains all the elements of the other {@code Iterable}, in any order.
-   *
-   * @param info contains information about the assertion.
-   * @param actual the given {@code Iterable}.
-   * @param other the other {@code Iterable}.
-   * @throws NullPointerException if {@code Iterable} is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} does not contain all the elements of the other
-   *           {@code Iterable}, in any order.
-   */
   public void assertContainsAll(AssertionInfo info, Iterable<?> actual, Iterable<?> other) {
-    final List<?> actualAsList = newArrayList(actual);
+    assertNotNull(info, actual);
     checkIterableIsNotNull(other);
-    assertNotNull(info, actualAsList);
     Object[] values = newArrayList(other).toArray();
-    assertIterableContainsGivenValues(actual.getClass(), actualAsList, values, info);
+    assertIterableContainsGivenValues(info, actual.getClass(), ensureActualCanBeReadMultipleTimes(actual), values);
   }
 
-  /**
-   * Asserts that the given {@code Iterable} contains exactly the given values and nothing else, <b>in order</b>.
-   *
-   * @param info contains information about the assertion.
-   * @param actual the given {@code Iterable}.
-   * @param values the values that are expected to be in the given {@code Iterable} in order.
-   * @throws NullPointerException if the array of values is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} does not contain the given values or if the given
-   *           {@code Iterable} contains values that are not in the given array, in order.
-   */
   public void assertContainsExactly(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    checkIsNotNull(values);
+    java.util.Objects.requireNonNull(values, shouldNotBeNull("values")::create);
     assertNotNull(info, actual);
     // use actualAsList instead of actual in case actual is a singly-passable iterable
     List<Object> actualAsList = newArrayList(actual);
@@ -1351,31 +1316,22 @@ public class Iterables {
                   });
   }
 
-  /**
-   * Asserts that the given {@code Iterable} contains at least one of the given {@code values}.
-   *
-   * @param info contains information about the assertion.
-   * @param actual the given {@code Iterable}.
-   * @param values the values that, at least one of which is expected to be in the given {@code Iterable}.
-   * @throws NullPointerException if the array of values is {@code null}.
-   * @throws IllegalArgumentException if the array of values is empty and given {@code Iterable} is not empty.
-   * @throws AssertionError if the given {@code Iterable} is {@code null}.
-   * @throws AssertionError if the given {@code Iterable} does not contain any of given {@code values}.
-   */
   public void assertContainsAnyOf(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    if (commonCheckThatIterableAssertionSucceeds(info, failures, actual, values))
-      return;
+    assertNotNull(info, actual);
+    java.util.Objects.requireNonNull(values, shouldNotBeNull("values")::create);
 
-    Iterable<Object> valuesToSearchFor = newArrayList(values);
-    for (Object element : actual) {
-      if (iterableContains(valuesToSearchFor, element)) return;
+    if (values.length == 0) return;
+
+    for (Object value : values) {
+      if (comparisonStrategy.iterableContains(actual, value)) return;
     }
+
     throw failures.failure(info, shouldContainAnyOf(actual, values, comparisonStrategy));
   }
 
   public void assertContainsExactlyInAnyOrder(AssertionInfo info, Iterable<?> actual, Object[] values) {
-    checkIsNotNull(values);
     assertNotNull(info, actual);
+    requireNonNull(values, shouldNotBeNull("values")::create);
     List<Object> notExpected = newArrayList(actual);
     List<Object> notFound = newArrayList(values);
 

--- a/assertj-core/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
@@ -61,4 +61,5 @@ public class ObjectArrayElementComparisonStrategy<T> extends StandardComparisonS
   public boolean isStandard() {
     return false;
   }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
@@ -126,6 +126,9 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
     if (iterable == null) {
       return false;
     }
+    if (iterable instanceof Collection) {
+      return ((Collection<?>) iterable).contains(value);
+    }
     return Streams.stream(iterable).anyMatch(object -> areEqual(object, value));
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_duplicatesFrom_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_duplicatesFrom_Test.java
@@ -24,8 +24,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link StandardComparisonStrategy#duplicatesFrom(Iterable)}.<br>
- * 
  * @author Joel Costigliola
  */
 class StandardComparisonStrategy_duplicatesFrom_Test extends AbstractTest_StandardComparisonStrategy {
@@ -50,7 +48,8 @@ class StandardComparisonStrategy_duplicatesFrom_Test extends AbstractTest_Standa
     @SuppressWarnings("unchecked")
     Iterable<String[]> duplicates = (Iterable<String[]>) standardComparisonStrategy.duplicatesFrom(list);
     // THEN
-    then(duplicates).containsExactly(new String[] { null }, array("Merry"), array("Frodo"));
+    then(duplicates).usingRecursiveFieldByFieldElementComparator().contains(new String[] { null }, array("Merry"),
+                                                                            array("Frodo"));
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_iterableContains_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_iterableContains_Test.java
@@ -15,31 +15,43 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.util.Lists.newArrayList;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Tests for {@link StandardComparisonStrategy#iterableContains(java.util.Collection, Object)}.
- * 
  * @author Joel Costigliola
  */
-class StandardComparisonStrategy_iterableContains_Test extends AbstractTest_StandardComparisonStrategy {
+class StandardComparisonStrategy_iterableContains_Test {
 
-  @Test
-  void should_pass() {
+  private final StandardComparisonStrategy underTest = StandardComparisonStrategy.instance();
+
+  @ParameterizedTest
+  @CsvSource({
+      "Frodo, true",
+      " , true",
+      "Sauron, false"
+  })
+  void should_pass(String value, boolean expected) {
+    // GIVEN
     List<?> list = newArrayList("Sam", "Merry", null, "Frodo");
-    assertThat(standardComparisonStrategy.iterableContains(list, "Frodo")).isTrue();
-    assertThat(standardComparisonStrategy.iterableContains(list, null)).isTrue();
-    assertThat(standardComparisonStrategy.iterableContains(list, "Sauron")).isFalse();
+    // WHEN
+    boolean result = underTest.iterableContains(list, value);
+    // THEN
+    then(result).isEqualTo(expected);
   }
 
   @Test
   void should_return_false_if_iterable_is_null() {
-    assertThat(standardComparisonStrategy.iterableContains(null, "Sauron")).isFalse();
+    // WHEN
+    boolean result = underTest.iterableContains(null, "Sauron");
+    // THEN
+    then(result).isFalse();
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAll_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAll_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.internal.iterables.SinglyIterableFactory.createSinglyIterable;
 import static org.assertj.core.testkit.TestData.someInfo;
@@ -36,8 +37,6 @@ import org.assertj.core.internal.IterablesBaseTest;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link Iterables#assertContainsAll(AssertionInfo, Iterable, Iterable)}</code>.
- * 
  * @author Joel Costigliola
  */
 class Iterables_assertContainsAll_Test extends IterablesBaseTest {
@@ -68,7 +67,7 @@ class Iterables_assertContainsAll_Test extends IterablesBaseTest {
   @Test
   void should_throw_error_if_array_of_values_to_look_for_is_null() {
     assertThatNullPointerException().isThrownBy(() -> iterables.assertContainsAll(someInfo(), actual, null))
-                                    .withMessage(iterableToLookForIsNull());
+                                    .withMessage(shouldNotBeNull("iterable").create());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsAnyOf_Test.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.testkit.Name.name;
 import static org.assertj.core.testkit.ObjectArrays.emptyArray;
@@ -38,8 +39,6 @@ import org.assertj.core.testkit.Name;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link Iterables#assertContainsAnyOf(AssertionInfo, Iterable, Object[])} </code>.
- *
  * @author Marko Bekhta
  */
 class Iterables_assertContainsAnyOf_Test extends IterablesBaseTest {
@@ -90,15 +89,15 @@ class Iterables_assertContainsAnyOf_Test extends IterablesBaseTest {
   }
 
   @Test
-  void should_fail_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> iterables.assertContainsAnyOf(someInfo(), actual,
-                                                                                                   emptyArray()));
+  void should_pass_if_array_of_values_to_look_for_is_empty_and_actual_is_not() {
+    // WHEN/THEN
+    iterables.assertContainsAnyOf(someInfo(), actual, emptyArray());
   }
 
   @Test
   void should_throw_error_if_array_of_values_to_look_for_is_null() {
     assertThatNullPointerException().isThrownBy(() -> iterables.assertContainsAnyOf(someInfo(), actual, null))
-                                    .withMessage(valuesToLookForIsNull());
+                                    .withMessage(shouldNotBeNull("values").create());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.configuration.Configuration.MAX_INDICES_FOR_PRINTING;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactlyWithIndexes;
-import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.iterables.SinglyIterableFactory.createSinglyIterable;
 import static org.assertj.core.testkit.ObjectArrays.emptyArray;
 import static org.assertj.core.util.Arrays.array;
@@ -86,7 +86,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
   @Test
   void should_throw_error_if_array_of_values_to_look_for_is_null() {
     assertThatNullPointerException().isThrownBy(() -> iterables.assertContainsExactly(INFO, emptyList(), null))
-                                    .withMessage(valuesToLookForIsNull());
+                                    .withMessage(shouldNotBeNull("values").create());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContains_Test.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.internal.iterables.SinglyIterableFactory.createSinglyIterable;
 import static org.assertj.core.testkit.TestData.someInfo;
@@ -67,17 +68,15 @@ class Iterables_assertContains_Test extends IterablesBaseTest {
     // WHEN
     Throwable thrown = catchThrowable(() -> iterables.assertContains(someInfo(), actual, values));
     // THEN
-    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(valuesToLookForIsNull());
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
   }
 
   @Test
-  void should_fail_if_given_values_array_is_empty() {
+  void should_pass_if_given_values_array_is_empty() {
     // GIVEN
     String[] values = array();
-    // WHEN
-    AssertionError assertionError = expectAssertionError(() -> iterables.assertContains(someInfo(), actual, values));
-    // THEN
-    then(assertionError).isNotNull();
+    // WHEN/THEN
+    iterables.assertContains(someInfo(), actual, values);
   }
 
   @ParameterizedTest

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertIsSubsetOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertIsSubsetOf_Test.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSubsetOf.shouldBeSubsetOf;
-import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.testkit.TestData.someInfo;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
@@ -87,7 +87,7 @@ class Iterables_assertIsSubsetOf_Test extends IterablesBaseTest {
   void should_throw_error_if_set_is_null() {
     actual = newArrayList("Yoda", "Luke");
     assertThatNullPointerException().isThrownBy(() -> iterables.assertIsSubsetOf(someInfo(), actual, null))
-                                    .withMessage(iterableToLookForIsNull());
+                                    .withMessage(shouldNotBeNull("iterable").create());
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/SinglyIterableFactory.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/SinglyIterableFactory.java
@@ -21,7 +21,6 @@ import java.util.List;
 class SinglyIterableFactory {
 
   static Iterable<String> createSinglyIterable(final List<String> values) {
-    // can't use Iterable<> for anonymous class in java 8
     return new Iterable<String>() {
       private boolean isIteratorCreated = false;
 

--- a/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertContainsExactly_Test.java
@@ -36,8 +36,6 @@ import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link Iterables#assertContainsExactly(AssertionInfo, Iterable, Object[])}</code>.
- *
  * @author Joel Costigliola
  */
 class ObjectArrays_assertContainsExactly_Test extends ObjectArraysBaseTest {

--- a/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSubsetOf_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSubsetOf_Test.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.error.ShouldBeSubsetOf.shouldBeSubsetOf;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.ErrorMessages.iterableToLookForIsNull;
 import static org.assertj.core.testkit.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -81,7 +82,7 @@ class ObjectArrays_assertIsSubsetOf_Test extends ObjectArraysBaseTest {
   void should_throw_error_if_set_is_null() {
     actual = array("Yoda", "Luke");
     assertThatNullPointerException().isThrownBy(() -> arrays.assertIsSubsetOf(someInfo(), actual, null))
-                                    .withMessage(iterableToLookForIsNull());
+                                    .withMessage(shouldNotBeNull("iterable").create());
   }
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/pom.xml
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/pom.xml
@@ -27,9 +27,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.18.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.5.0-jre</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -41,6 +53,12 @@
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>4.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -66,21 +84,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>7.0.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssertBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssertBaseTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import org.springframework.http.HttpHeaders;
+
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static org.assertj.core.util.Arrays.array;
+
+abstract class CollectionAssertBaseTest {
+
+  // https://github.com/assertj/assertj/issues/4175
+  static Stream<?> setContainingArrayElements() {
+    return Stream.of(Set.<String[]> of(array("foo")));
+  }
+
+  static Stream<?> caseInsensitiveSets() {
+    Set<String> caseInsensitiveTreeSet = new TreeSet<>(CASE_INSENSITIVE_ORDER);
+    caseInsensitiveTreeSet.add("foo");
+
+    // https://github.com/assertj/assertj/issues/4157
+    HttpHeaders springHttpHeaders = new HttpHeaders();
+    springHttpHeaders.add("foo", "value");
+    Set<String> springHttpHeaderNames = springHttpHeaders.headerNames();
+
+    return Stream.of(caseInsensitiveTreeSet, springHttpHeaderNames);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAll_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAll_Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionAssert_containsAll_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    Iterable<String> iterable = List.of("foo");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAll(iterable));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_iterable_is_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> iterable = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsAll(iterable));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("iterable").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    Iterable<String[]> iterable = List.of(array("foo"), array("bar"));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAll(iterable));
+    // THEN
+    then(assertionError).hasMessage(shouldContain(actual, iterable, iterable).create());
+  }
+
+  @Test
+  void should_pass_if_given_iterable_is_empty() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> iterable = List.of();
+    // WHEN/THEN
+    assertThat(actual).containsAll(iterable);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsAll(List.of("fOo"));
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAnyElementsOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAnyElementsOf_Test.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+class CollectionAssert_containsAnyElementsOf_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    Iterable<String> values = List.of("foo", "bar");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAnyElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsAnyElementsOf(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    Iterable<String[]> values = List.of(array("foo"), array("bar"));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAnyElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainAnyOf(actual, values).create());
+  }
+
+  @Test
+  void should_pass_if_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> iterable = List.of();
+    // WHEN/THEN
+    assertThat(actual).containsAnyElementsOf(iterable);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsAnyElementsOf(List.of("fOo", "bar"));
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAnyOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsAnyOf_Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionAssert_containsAnyOf_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    String[] values = { "foo", "bar" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAnyOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsAnyOf(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    String[][] values = { { "foo" }, { "bar" } };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsAnyOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainAnyOf(actual, values).create());
+  }
+
+  @Test
+  void should_pass_if_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = {};
+    // WHEN/THEN
+    assertThat(actual).containsAnyOf(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsAnyOf("fOo", "bar");
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyElementsOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyElementsOf_Test.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionAssert_containsExactlyElementsOf_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    Iterable<String> values = List.of("foo", "bar");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsExactlyElementsOf(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    Iterable<String[]> values = List.<String[]> of(array("foo"));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainExactly(actual, values, values, emptySet()).create());
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = emptyList();
+    Iterable<String> values = emptyList();
+    // WHEN/THEN
+    assertThat(actual).containsExactlyElementsOf(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsExactlyElementsOf(List.of("fOo", "bar"));
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyInAnyOrderElementsOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyInAnyOrderElementsOf_Test.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionAssert_containsExactlyInAnyOrderElementsOf_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    Iterable<String> values = List.of("foo", "bar");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyInAnyOrderElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    Iterable<String> values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsExactlyInAnyOrderElementsOf(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    Iterable<String[]> values = List.<String[]> of(array("foo"));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyInAnyOrderElementsOf(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainExactlyInAnyOrder(actual, values, values, values,
+                                                                   StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = emptyList();
+    Iterable<String> values = emptyList();
+    // WHEN/THEN
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(List.of("fOo", "bar"));
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyInAnyOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactlyInAnyOrder_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.shouldContainExactlyInAnyOrder;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+class CollectionAssert_containsExactlyInAnyOrder_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    String[] values = { "foo" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyInAnyOrder(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsExactlyInAnyOrder(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    String[][] values = { { "foo" } };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactlyInAnyOrder(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainExactlyInAnyOrder(actual, asList(values), asList(values), asList(values),
+                                                                   StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = emptyList();
+    String[] values = {};
+    // WHEN/THEN
+    assertThat(actual).containsExactlyInAnyOrder(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsExactlyInAnyOrder("fOo");
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_containsExactly_Test.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CollectionAssert_containsExactly_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    String[] values = { "foo" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactly(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).containsExactly(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    String[][] values = { { "foo" } };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).containsExactly(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContainExactly(actual, asList(values), asList(values), emptySet()).create());
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty_and_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = emptyList();
+    String[] values = {};
+    // WHEN/THEN
+    assertThat(actual).containsExactly(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).containsExactly("fOo");
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_contains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/collection/CollectionAssert_contains_Test.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+
+class CollectionAssert_contains_Test extends CollectionAssertBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Collection<String> actual = null;
+    String[] values = { "foo" };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).contains(values));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_given_values_are_null() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).contains(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("setContainingArrayElements")
+  void should_fail_with_set_containing_array_elements(Collection<String[]> actual) {
+    // GIVEN
+    String[][] values = { { "foo" } };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).contains(values));
+    // THEN
+    then(assertionError).hasMessage(shouldContain(actual, values, values).create());
+  }
+
+  @Test
+  void should_pass_if_given_values_are_empty() {
+    // GIVEN
+    Collection<String> actual = List.of("foo");
+    String[] values = {};
+    // WHEN/THEN
+    assertThat(actual).contains(values);
+  }
+
+  @ParameterizedTest
+  @MethodSource("caseInsensitiveSets")
+  void should_pass_with_case_insensitive_set(Collection<String> actual) {
+    // WHEN/THEN
+    assertThat(actual).contains("fOo");
+  }
+
+}


### PR DESCRIPTION
* Fixes #4157
* Fixes #4159
* Fixes #4175