### PR TITLE
Improve InputStream assertions with binary and textual comparison APIs

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -24,6 +24,7 @@ import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.internal.Digests.digestDiff;
+import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -60,8 +61,40 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
   private final Diff diff = new Diff();
   private final BinaryDiff binaryDiff = new BinaryDiff();
 
+  /**
+   * The charset to use for text-based assertions on the InputStream's content.
+   */
+  protected Charset charset = Charset.defaultCharset();
+
   protected AbstractInputStreamAssert(ACTUAL actual, Class<?> selfType) {
     super(actual, selfType);
+  }
+
+  /**
+   * Specifies the name of the charset to use for text-based assertions on the InputStream's content.
+   *
+   * @param charsetName the name of the charset to use.
+   * @return {@code this} assertion object.
+   * @throws IllegalArgumentException if the given encoding is not supported on this platform.
+   */
+  @CheckReturnValue
+  public SELF usingCharset(String charsetName) {
+    requireNonNull(charsetName, shouldNotBeNull("charsetName")::create);
+    checkArgument(Charset.isSupported(charsetName), "Charset:<'%s'> is not supported on this system", charsetName);
+    return usingCharset(Charset.forName(charsetName));
+  }
+
+  /**
+   * Specifies the charset to use for text-based assertions on the InputStream's content.
+   *
+   * @param charset the charset to use.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given charset is {@code null}.
+   */
+  @CheckReturnValue
+  public SELF usingCharset(Charset charset) {
+    this.charset = requireNonNull(charset, shouldNotBeNull("charset")::create);
+    return myself;
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -178,8 +178,7 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
   /**
    * Verifies that the content of the actual {@code InputStream} is equal to the content of the given one, the comparison is done at the binary level.
    * <p>
-   * <b>Warning: this will consume the whole input streams in case the underlying
-   * implementations do not support {@link InputStream#markSupported() marking}.</b>
+   * <b>Warning: this will consume the input streams in case the underlying implementations do not support {@link InputStream#markSupported() marking} (the consumption may be partial if a difference is found).</b>
    * <p>
    * Example:
    * <pre><code class='java'> // assertion will pass

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -133,7 +133,10 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    * @throws AssertionError if the actual {@code InputStream} is {@code null}.
    * @throws AssertionError if the content of the actual {@code InputStream} is not equal to the content of the given one.
    * @throws UncheckedIOException if an I/O error occurs.
+   * @deprecated use {@link #hasSameBinaryContentAs(InputStream)} for byte-to-byte comparison, 
+   *             or {@link #hasSameTextualContentAs(InputStream, Charset)} for text-based comparison.
    */
+  @Deprecated
   public SELF hasSameContentAs(InputStream expected) {
     isNotNull();
     assertHasSameContentAs(expected);

--- a/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
@@ -82,6 +82,10 @@ public class Diff {
     return new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()));
   }
 
+  private BufferedReader readerFor(InputStream stream, Charset charset) {
+    return new BufferedReader(new InputStreamReader(stream, charset));
+  }
+
   private BufferedReader readerFor(String string) {
     return new BufferedReader(new StringReader(string));
   }

--- a/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
@@ -58,6 +58,11 @@ public class Diff {
     return diff(readerFor(actual), readerFor(expected));
   }
 
+  public List<Delta<String>> diff(InputStream actual, Charset actualCharset, InputStream expected,
+                                  Charset expectedCharset) throws IOException {
+    return diff(readerFor(actual, actualCharset), readerFor(expected, expectedCharset));
+  }
+
   // TODO reduce the visibility of the fields annotated with @VisibleForTesting
   public List<Delta<String>> diff(File actual, Charset actualCharset, File expected, Charset expectedCharset) throws IOException {
     return diff(actual.toPath(), actualCharset, expected.toPath(), expectedCharset);

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameBinaryContentAs_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameBinaryContentAs_Test.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.assertj.tests.core.api.inputstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import org.assertj.core.internal.BinaryDiff;
+import org.assertj.core.internal.BinaryDiffResult;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jaeung Ha
+ *
+ */
+public class InputStreamAssert_hasSameBinaryContentAs_Test {
+  private static BinaryDiffResult diff(String actual, String expected) {
+    try {
+      return new BinaryDiff().diff(new ByteArrayInputStream(actual.getBytes()), new ByteArrayInputStream(expected.getBytes()));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    InputStream actual = null;
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_expected_is_null() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream(new byte[0]);
+    InputStream expected = null;
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(exception).isInstanceOf(NullPointerException.class)
+                   .hasMessage(shouldNotBeNull("expected").create());
+  }
+
+  @Test
+  void should_rethrow_IOException() throws Exception {
+    // GIVEN
+    @SuppressWarnings("resource")
+    InputStream actual = mock();
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+    IOException cause = new IOException();
+    given(actual.read()).willThrow(cause);
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(exception).isInstanceOf(UncheckedIOException.class)
+                   .hasCause(cause);
+  }
+
+  @Test
+  void should_pass_resetting_actual_and_expected_if_actual_has_expected_content_and_both_support_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameBinaryContentAs(expected);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_pass_resetting_actual_if_actual_has_expected_content_and_actual_supports_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameBinaryContentAs(expected);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isEmpty();
+  }
+
+  @Test
+  void should_pass_resetting_expected_if_actual_has_expected_content_and_expected_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameBinaryContentAs(expected);
+    // THEN
+    then(actual).isEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_pass_without_resetting_if_actual_has_expected_content_and_none_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameBinaryContentAs(expected);
+    // THEN
+    then(actual).isEmpty();
+    then(expected).isEmpty();
+  }
+
+  @Test
+  void should_fail_resetting_actual_and_expected_if_actual_does_not_have_expected_content_and_both_support_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("67890".getBytes());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveBinaryContent(actual, diff("12345", "67890")).create());
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_fail_resetting_actual_if_actual_does_not_have_expected_content_and_actual_supports_marking() throws IOException {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("67890".getBytes());
+    int available = expected.available();
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveBinaryContent(actual, diff("12345", "67890")).create());
+    then(actual).isNotEmpty();
+    then(expected.available()).isLessThan(available);
+    then(expected.available()).isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  void should_fail_resetting_expected_if_actual_does_not_have_expected_content_and_expected_supports_marking() throws IOException {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("67890".getBytes());
+    int available = actual.available();
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveBinaryContent(actual, diff("12345", "67890")).create());
+    then(expected).isNotEmpty();
+    then(actual.available()).isLessThan(available);
+    then(actual.available()).isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  void should_fail_without_resetting_if_actual_does_not_have_expected_content_and_none_supports_marking() throws IOException {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("67890".getBytes());
+    int actualAvailable = actual.available();
+    int expectedAvailable = expected.available();
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameBinaryContentAs(expected));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveBinaryContent(actual, diff("12345", "67890")).create());
+    then(expected.available()).isLessThan(expectedAvailable);
+    then(expected.available()).isGreaterThanOrEqualTo(0);
+    then(actual.available()).isLessThan(actualAvailable);
+    then(actual.available()).isGreaterThanOrEqualTo(0);
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameBinaryContentAs_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameBinaryContentAs_Test.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
  * @author Jaeung Ha
  *
  */
-public class InputStreamAssert_hasSameBinaryContentAs_Test {
+class InputStreamAssert_hasSameBinaryContentAs_Test {
   private static BinaryDiffResult diff(String actual, String expected) {
     try {
       return new BinaryDiff().diff(new ByteArrayInputStream(actual.getBytes()), new ByteArrayInputStream(expected.getBytes()));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameTextualContentAs_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameTextualContentAs_Test.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.inputstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.assertj.core.internal.Diff;
+import org.assertj.core.util.diff.Delta;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jaeung Ha
+ */
+class InputStreamAssert_hasSameTextualContentAs_Test {
+
+  private static List<Delta<String>> diff(String actual, String expected) {
+    try {
+      return new Diff().diff(new ByteArrayInputStream(actual.getBytes()), new ByteArrayInputStream(expected.getBytes()));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static List<Delta<String>> diff(InputStream actual, Charset actualCharset, InputStream expected,
+                                          Charset expectedCharset) {
+    try {
+      return new Diff().diff(actual, actualCharset, expected, expectedCharset);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    InputStream actual = null;
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
+  }
+
+  @Test
+  void should_fail_if_expected_is_null() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream(new byte[0]);
+    InputStream expected = null;
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(exception).isInstanceOf(NullPointerException.class)
+                   .hasMessage(shouldNotBeNull("expected").create());
+  }
+
+  @Test
+  void should_rethrow_IOException() throws Exception {
+    // GIVEN
+    @SuppressWarnings("resource")
+    InputStream actual = mock();
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+    IOException cause = new IOException();
+    given(actual.read(any(), anyInt(), anyInt())).willThrow(cause);
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(exception).isInstanceOf(UncheckedIOException.class)
+                   .hasCause(cause);
+  }
+
+  @Test
+  void should_pass_resetting_actual_and_expected_if_actual_has_expected_content_and_both_support_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_pass_resetting_actual_if_actual_has_expected_content_and_actual_supports_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isEmpty();
+  }
+
+  @Test
+  void should_pass_resetting_expected_if_actual_has_expected_content_and_expected_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+    // THEN
+    then(actual).isEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_pass_without_resetting_if_actual_has_expected_content_and_none_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("12345".getBytes());
+    // WHEN
+    assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+    // THEN
+    then(actual).isEmpty();
+    then(expected).isEmpty();
+  }
+
+  @Test
+  void should_fail_resetting_actual_and_expected_if_actual_does_not_have_expected_content_and_both_support_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("67890".getBytes());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveSameContent(actual, expected, diff("12345", "67890")).create());
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_fail_resetting_actual_if_actual_does_not_have_expected_content_and_actual_supports_marking() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes());
+    InputStream expected = new UnmarkableByteArrayInputStream("67890".getBytes());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveSameContent(actual, expected, diff("12345", "67890")).create());
+    then(actual).isNotEmpty();
+    then(expected).isEmpty();
+  }
+
+  @Test
+  void should_fail_resetting_expected_if_actual_does_not_have_expected_content_and_expected_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("67890".getBytes());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveSameContent(actual, expected, diff("12345", "67890")).create());
+    then(actual).isEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_fail_without_resetting_if_actual_does_not_have_expected_content_and_none_supports_marking() {
+    // GIVEN
+    InputStream actual = new UnmarkableByteArrayInputStream("12345".getBytes());
+    InputStream expected = new ByteArrayInputStream("67890".getBytes());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveSameContent(actual, expected, diff("12345", "67890")).create());
+    then(actual).isEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_pass_when_inputStream_use_diff_charset() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("12345".getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream("12345".getBytes(StandardCharsets.ISO_8859_1));
+    // WHEN
+    assertThat(actual)
+                      .usingCharset(StandardCharsets.UTF_8)
+                      .hasSameTextualContentAs(expected, StandardCharsets.ISO_8859_1);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+  @Test
+  void should_fail_when_use_wrong_charset() {
+    // GIVEN
+    String text = "é";
+    InputStream actual = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream(text.getBytes(StandardCharsets.ISO_8859_1));
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual)
+                                                                      .usingCharset(StandardCharsets.ISO_8859_1)
+                                                                      .hasSameTextualContentAs(expected,
+                                                                                               StandardCharsets.ISO_8859_1));
+    // THEN
+    // @format:off
+    List<Delta<String>> diff = diff(new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)), StandardCharsets.ISO_8859_1,
+                                    new ByteArrayInputStream(text.getBytes(StandardCharsets.ISO_8859_1)), StandardCharsets.ISO_8859_1);
+    // @format:on
+    then(assertionError).isInstanceOf(AssertionError.class);
+    then(assertionError).hasMessage(shouldHaveSameContent(actual, expected, diff).create());
+  }
+
+  @Test
+  void should_fail_when_given_unsupported_charset_string() {
+    // GIVEN
+    String charsetName = "foo";
+    String text = "foo";
+    InputStream actual = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual)
+                                                                 .usingCharset(charsetName)
+                                                                 .hasSameTextualContentAs(expected,
+                                                                                          StandardCharsets.UTF_8));
+    // THEN
+    then(exception).isInstanceOf(IllegalArgumentException.class);
+    then(exception).hasMessage("Charset:<'foo'> is not supported on this system");
+  }
+
+  @Test
+  void should_fail_when_given_actual_charset_string_is_null() {
+    // GIVEN
+    String charsetName = null;
+    String text = "foo";
+    InputStream actual = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual)
+                                                                 .usingCharset(charsetName)
+                                                                 .hasSameTextualContentAs(expected,
+                                                                                          StandardCharsets.UTF_8));
+    // THEN
+    then(exception).isInstanceOf(NullPointerException.class);
+    then(exception).hasMessage(shouldNotBeNull("charsetName").create());
+  }
+
+  @Test
+  void should_fail_when_given_actual_charset_instance_is_null() {
+    // GIVEN
+    Charset charset = null;
+    String text = "foo";
+    InputStream actual = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual)
+                                                                 .usingCharset(charset)
+                                                                 .hasSameTextualContentAs(expected,
+                                                                                          StandardCharsets.UTF_8));
+    // THEN
+    then(exception).isInstanceOf(NullPointerException.class);
+    then(exception).hasMessage(shouldNotBeNull("charset").create());
+  }
+
+  @Test
+  void should_fail_when_given_expected_charset_instance_is_null() {
+    // GIVEN
+    Charset charset = null;
+    String text = "foo";
+    InputStream actual = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    // WHEN
+    Exception exception = catchException(() -> assertThat(actual)
+                                                                 .usingCharset(StandardCharsets.UTF_8)
+                                                                 .hasSameTextualContentAs(expected, charset));
+    // THEN
+    then(exception).isInstanceOf(NullPointerException.class);
+    then(exception).hasMessage(shouldNotBeNull("charset").create());
+  }
+
+  @Test
+  void should_pass_if_both_are_empty() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream(new byte[0]);
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+
+    // WHEN & THEN
+    then(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void should_pass_if_line_endings_differ() {
+    // GIVEN
+    InputStream actual = new ByteArrayInputStream("line1\nline2".getBytes(StandardCharsets.UTF_8));
+    InputStream expected = new ByteArrayInputStream("line1\r\nline2".getBytes(StandardCharsets.UTF_8));
+    // WHEN
+    assertThat(actual).hasSameTextualContentAs(expected, StandardCharsets.UTF_8);
+    // THEN
+    then(actual).isNotEmpty();
+    then(expected).isNotEmpty();
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #4146
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

This PR improves InputStream assertions by introducing dedicated methods for binary and textual content comparison, allowing for more precise assertions and better charset handling.

Changes
- New Binary Comparison: Added hasSameBinaryContentAs(InputStream) for byte-to-byte comparison of two input streams.
- New Textual Comparison: Added hasSameTextualContentAs(InputStream, Charset) for character-based comparison, allowing users to specify the expected stream's charset.
- Charset Configuration: Added usingCharset(Charset) and usingCharset(String) to AbstractInputStreamAssert to define the charset for the actual InputStream being asserted.
- Deprecated hasSameContentAs(InputStream) in favor of the more explicit hasSameBinaryContentAs or hasSameTextualContentAs methods.





