### PR TITLE
Define comparator `toString` in `AssertWithComparator.usingEquals`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AssertWithComparator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AssertWithComparator.java
@@ -93,7 +93,17 @@ public interface AssertWithComparator<SELF extends Assert<SELF, ACTUAL>, ACTUAL>
    */
   @SuppressWarnings("ComparatorMethodParameterNotUsed")
   default SELF usingEquals(BiPredicate<? super ACTUAL, ? super ACTUAL> predicate, String customEqualsDescription) {
-    return usingComparator((o1, o2) -> predicate.test(o1, o2) ? 0 : -1, customEqualsDescription);
+    return usingComparator(new Comparator<>() {
+      @Override
+      public int compare(ACTUAL o1, ACTUAL o2) {
+        return predicate.test(o1, o2) ? 0 : -1;
+      }
+
+      @Override
+      public String toString() {
+        return predicate.toString();
+      }
+    }, customEqualsDescription);
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/object/ObjectAssert_usingEquals_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/object/ObjectAssert_usingEquals_Test.java
@@ -24,6 +24,8 @@ import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import org.assertj.core.testkit.Jedi;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.BiPredicate;
+
 class ObjectAssert_usingEquals_Test {
 
   @Test
@@ -50,6 +52,31 @@ class ObjectAssert_usingEquals_Test {
                                                                     .isEqualTo(luke));
     // THEN
     then(assertionError).hasMessageContaining("comparing names");
+  }
+
+  @Test
+  void should_include_bi_predicate_to_string() {
+    // GIVEN
+    Jedi yoda = new Jedi("Yoda", "green");
+    Jedi luke = new Jedi("Luke", "green");
+
+    var jediEquals = new BiPredicate<Jedi, Jedi>() {
+      @Override
+      public boolean test(Jedi jedi, Jedi jedi2) {
+        return jedi.equals(jedi2);
+      }
+
+      @Override
+      public String toString() {
+        return "Jedi equals";
+      }
+    };
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(yoda).usingEquals(jediEquals)
+                                                                    .isEqualTo(luke));
+    // THEN
+    then(assertionError).hasMessageContaining("Jedi equals");
   }
 
   @Test


### PR DESCRIPTION
If `customEqualsDescription` is not set, the comparator `toString` is used in the exception message. As it's a lambda, the message look like this:

```
when comparing values using AssertWithComparator$$Lambda/0x000003800027c098"
```

Even if the predicate does not have meaningful `toString`, using it is more logical.

#### Check List:
* Fixes NA
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)