### PR TITLE
Streamline implementation of assertions returning to navigation origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ We prefer integrating PR by squashing all the commits and rebasing it to `main`;
 
 ## Naming Conventions
 
+### Assertions
+
 Here are some of the `ThrowableAssert` assertions: `hasMessage`, `hasNoCause`, `hasMessageContaining`; for each of them we have a test class, note the naming convention:
 * `ThrowableAssert_hasMessage_Test`
 * `ThrowableAssert_hasNoCause_Test`
@@ -120,6 +122,26 @@ BAD! (not in the same line)
 ```
 
 You can generate the Javadoc and read it in your browser to see what it actually looks like.
+
+### Navigation Methods
+
+In addition to assertions, AssertJ provides methods that change the object under test to a related one (for example, a field, a property, or a derived value), enabling further type-specific assertions.
+Such methods are referred to as _navigation methods_ and are named after the underlying getter or with a meaningful term describing the target element.
+
+Some examples are:
+* `first()` and `last()` in `IterableAssert`, providing assertions for the first and last iterable elements
+* `get()` in `OptionalAssert`, providing assertions for the value contained in the `Optional` (backed by `Optional#get()`)
+* `size()` in `MapAssert`, providing assertions for the size of the `Map` (backed by `Map#size()`)
+* `cause()` in `ThrowableAssert`, providing assertions for the cause of the `Throwable` (backed by `Throwable#getCause()`)
+
+The resulting assertions after navigation may also provide a way to return to the object that initiated the navigation.
+Such methods are named `returnToX`, where `X` is the type of the previous object under test.
+
+Some examples are:
+* `returnToBigDecimal()` in `BigDecimalScaleAssert`
+* `returnToFile()` in `FileSizeAssert`
+* `returnToIterable()` in `IterableSizeAssert`
+* `returnToMap()` in `MapSizeAssert`
 
 ## Binary Compatibility
 

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalAssert.java
@@ -503,7 +503,7 @@ public abstract class AbstractBigDecimalAssert<SELF extends AbstractBigDecimalAs
    * Returns an {@code Assert} object that allows performing assertions on the scale of the {@link BigDecimal} under test.
    * <p>
    * Once this method is called, the object under test is no longer the {@link BigDecimal} but its scale.
-   * To perform assertions on the {@link BigDecimal}, call {@link AbstractBigDecimalScaleAssert#returnToBigDecimal()}.
+   * To perform further assertions on the {@link BigDecimal}, call {@link AbstractBigDecimalScaleAssert#returnToBigDecimal()}.
    * <p>
    * Example:
    * <pre><code class='java'> BigDecimal bgDecimal = new BigDecimal(&quot;9.3231&quot;);

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalScaleAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractBigDecimalScaleAssert.java
@@ -15,18 +15,38 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
+
 /**
  * Base class for BigDecimal scale assertions.
  */
 public abstract class AbstractBigDecimalScaleAssert<SELF extends AbstractBigDecimalAssert<SELF>>
     extends AbstractIntegerAssert<AbstractBigDecimalScaleAssert<SELF>> {
 
-  protected AbstractBigDecimalScaleAssert(Integer actualScale, Class<?> selfType) {
-    super(actualScale, selfType);
+  private final AbstractBigDecimalAssert<SELF> originAssert;
+
+  /**
+   * Creates a new instance from an origin {@link AbstractBigDecimalAssert} instance.
+   *
+   * @param originAssert the origin {@link AbstractBigDecimalAssert} that initiated the navigation.
+   * @since 3.28.0
+   */
+  protected AbstractBigDecimalScaleAssert(AbstractBigDecimalAssert<SELF> originAssert) {
+    super(originAssert.actual.scale(), AbstractBigDecimalScaleAssert.class);
+    this.originAssert = originAssert;
   }
 
   /**
-   * Returns to the BigDecimal on which we ran scale assertions on.
+   * @deprecated use {@link #AbstractBigDecimalScaleAssert(AbstractBigDecimalAssert)} instead.
+   */
+  @Deprecated
+  protected AbstractBigDecimalScaleAssert(Integer actualScale, Class<?> selfType) {
+    super(actualScale, selfType);
+    this.originAssert = null;
+  }
+
+  /**
+   * Returns to the origin {@link AbstractBigDecimalAssert} instance that initiated the navigation.
    * <p>
    * Example:
    * <pre><code class='java'> assertThat(new BigDecimal(&quot;2.313&quot;)).scale()
@@ -35,8 +55,14 @@ public abstract class AbstractBigDecimalScaleAssert<SELF extends AbstractBigDeci
    *                                    .returnToBigDecimal()
    *                                      .isPositive();</code></pre>
    *
-   * @return BigDecimal assertions.
+   * @return the origin {@link AbstractBigDecimalAssert} instance.
    */
-  public abstract AbstractBigDecimalAssert<SELF> returnToBigDecimal();
+  @CheckReturnValue
+  public AbstractBigDecimalAssert<SELF> returnToBigDecimal() {
+    if (originAssert == null) {
+      throw new IllegalStateException("No origin available. Was this assert created from its deprecated constructor?");
+    }
+    return originAssert;
+  }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -1451,8 +1451,8 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   /**
    * Returns an {@code Assert} object that allows performing assertions on the size of the {@link File} under test.
    * <p>
-   * Once this method is called, the object under test is no longer the {@link File} but its size,
-   * to perform assertions on the {@link File}, call {@link AbstractFileSizeAssert#returnToFile()}.
+   * Once this method is called, the object under test is no longer the {@link File} but its size;
+   * to perform further assertions on the {@link File}, call {@link AbstractFileSizeAssert#returnToFile()}.
    * <p>
    * Example:
    * <pre><code class='java'> File file = File.createTempFile(&quot;tmp&quot;, &quot;bin&quot;);

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractFileSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractFileSizeAssert.java
@@ -15,6 +15,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
+
 /**
  * Base class for file size assertions.
  * 
@@ -23,12 +25,30 @@ package org.assertj.core.api;
 public abstract class AbstractFileSizeAssert<SELF extends AbstractFileAssert<SELF>>
     extends AbstractLongAssert<AbstractFileSizeAssert<SELF>> {
 
-  protected AbstractFileSizeAssert(Long actualFileSize, Class<?> selfType) {
-    super(actualFileSize, selfType);
+  private final AbstractFileAssert<SELF> originAssert;
+
+  /**
+   * Creates a new instance from an origin {@link AbstractFileAssert} instance.
+   *
+   * @param originAssert the origin {@link AbstractFileAssert} that initiated the navigation.
+   * @since 3.28.0
+   */
+  protected AbstractFileSizeAssert(AbstractFileAssert<SELF> originAssert) {
+    super(originAssert.actual.length(), AbstractFileSizeAssert.class);
+    this.originAssert = originAssert;
   }
 
   /**
-   * Returns to the file on which we ran size assertions on.
+   * @deprecated use {@link #AbstractFileSizeAssert(AbstractFileAssert)} instead.
+   */
+  @Deprecated
+  protected AbstractFileSizeAssert(Long actualFileSize, Class<?> selfType) {
+    super(actualFileSize, selfType);
+    this.originAssert = null;
+  }
+
+  /**
+   * Returns to the origin {@link AbstractFileAssert} instance that initiated the navigation.
    * <p>
    * Example:
    * <pre><code class='java'> File file = File.createTempFile(&quot;tmp&quot;, &quot;bin&quot;);
@@ -36,8 +56,15 @@ public abstract class AbstractFileSizeAssert<SELF extends AbstractFileAssert<SEL
    *
    * assertThat(file).size().isGreaterThan(1L).isLessThan(5L)
    *                 .returnToFile().hasBinaryContent(new byte[] {1, 1});</code></pre>
-   *    
-   * @return file assertions. 
+   *
+   * @return the origin {@link AbstractFileAssert} instance.
    */
-  public abstract AbstractFileAssert<SELF> returnToFile();
+  @CheckReturnValue
+  public AbstractFileAssert<SELF> returnToFile() {
+    if (originAssert == null) {
+      throw new IllegalStateException("No origin available. Was this assert created from its deprecated constructor?");
+    }
+    return originAssert;
+  }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -4077,19 +4077,19 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * assertThat(elvesRings).size().isGreaterThan(1)
    *                              .isLessThanOrEqualTo(3)
    *                       .returnToIterable().contains(narya)
-   *                                          .doesNotContain(oneRing);
+   *                                        .doesNotContain(oneRing);
    *
    * // assertion will fail:
    * assertThat(elvesRings).size().isGreaterThan(3);</code></pre>
    *
    * @return AbstractIterableSizeAssert built with the {@code Iterable}'s size.
-   * @throws NullPointerException if the given {@code Iterable} is {@code null}.
+   * @throws AssertionError if actual is {@code null}.
    */
-  @SuppressWarnings({ "rawtypes" })
+  @SuppressWarnings({ "unchecked", "rawtypes" }) // FIXME gh-4210
   @CheckReturnValue
   public AbstractIterableSizeAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> size() {
-    requireNonNull(actual, "Can not perform assertions on the size of a null iterable.");
-    return new IterableSizeAssert(this, IterableUtil.sizeOf(actual));
+    isNotNull();
+    return new IterableSizeAssert(this);
   }
 
   // lazy init TypeComparators

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableSizeAssert.java
@@ -15,6 +15,9 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
+import org.assertj.core.util.IterableUtil;
+
 //@format:off
 public abstract class AbstractIterableSizeAssert<SELF extends AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT>, 
                                                  ACTUAL extends Iterable<? extends ELEMENT>, 
@@ -23,9 +26,39 @@ public abstract class AbstractIterableSizeAssert<SELF extends AbstractIterableAs
     extends AbstractIntegerAssert<AbstractIterableSizeAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT>> {
 //@format:on
 
-  protected AbstractIterableSizeAssert(Integer actual, Class<?> selfType) {
-    super(actual, selfType);
+  private final AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> originAssert;
+
+  /**
+   * Creates a new instance from an origin {@link AbstractIterableAssert} instance.
+   *
+   * @param originAssert the origin {@link AbstractIterableAssert} that initiated the navigation.
+   * @since 3.28.0
+   */
+  protected AbstractIterableSizeAssert(AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> originAssert) {
+    super(IterableUtil.sizeOf(originAssert.actual), AbstractIterableSizeAssert.class);
+    this.originAssert = originAssert;
   }
 
-  public abstract AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> returnToIterable();
+  /**
+   * @deprecated use {@link #AbstractIterableSizeAssert(AbstractIterableAssert)} instead.
+   */
+  @Deprecated
+  protected AbstractIterableSizeAssert(Integer actual, Class<?> selfType) {
+    super(actual, selfType);
+    this.originAssert = null;
+  }
+
+  /**
+   * Returns to the origin {@link AbstractIterableAssert} instance that initiated the navigation.
+   *
+   * @return the origin {@link AbstractIterableAssert} instance.
+   */
+  @CheckReturnValue
+  public AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> returnToIterable() {
+    if (originAssert == null) {
+      throw new IllegalStateException("No origin available. Was this assert created from its deprecated constructor?");
+    }
+    return originAssert;
+  }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1692,7 +1692,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * // assertion will pass:
    * assertThat(ringBearers).size().isGreaterThan(1)
    *                               .isLessThanOrEqualTo(3)
-   *                        returnToMap().contains(entry(oneRing, frodo),
+   *                        .returnToMap().contains(entry(oneRing, frodo),
    *                                               entry(nenya, galadriel),
    *                                               entry(narya, gandalf));
    *
@@ -1702,11 +1702,11 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * @return a {@link AbstractMapSizeAssert} to allow assertions on the number of key-value mappings in this map
    * @throws NullPointerException if the given map is {@code null}.
    */
-  @SuppressWarnings({ "rawtypes" })
+  @SuppressWarnings({ "unchecked", "rawtypes" }) // FIXME gh-4210
   @CheckReturnValue
   public AbstractMapSizeAssert<SELF, ACTUAL, K, V> size() {
     requireNonNull(actual, "Can not perform assertions on the size of a null map.");
-    return new MapSizeAssert(this, actual.size());
+    return new MapSizeAssert(this);
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractMapSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractMapSizeAssert.java
@@ -15,14 +15,46 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
+
 import java.util.Map;
 
 public abstract class AbstractMapSizeAssert<SELF extends AbstractMapAssert<SELF, A, KEY, VALUE>, A extends Map<KEY, VALUE>, KEY, VALUE>
     extends AbstractIntegerAssert<AbstractMapSizeAssert<SELF, A, KEY, VALUE>> {
 
-  protected AbstractMapSizeAssert(Integer actual, Class<?> selfType) {
-    super(actual, selfType);
+  private final AbstractMapAssert<SELF, A, KEY, VALUE> originAssert;
+
+  /**
+   * Creates a new instance from an origin {@link AbstractMapAssert} instance.
+   *
+   * @param originAssert the origin {@link AbstractMapAssert} that initiated the navigation.
+   * @since 3.28.0
+   */
+  protected AbstractMapSizeAssert(AbstractMapAssert<SELF, A, KEY, VALUE> originAssert) {
+    super(originAssert.actual.size(), AbstractMapSizeAssert.class);
+    this.originAssert = originAssert;
   }
 
-  public abstract AbstractMapAssert<SELF, A, KEY, VALUE> returnToMap();
+  /**
+   * @deprecated use {@link #AbstractMapSizeAssert(AbstractMapAssert)} instead.
+   */
+  @Deprecated
+  protected AbstractMapSizeAssert(Integer actual, Class<?> selfType) {
+    super(actual, selfType);
+    this.originAssert = null;
+  }
+
+  /**
+   * Returns to the origin {@link AbstractMapAssert} instance that initiated the navigation.
+   *
+   * @return the origin {@link AbstractMapAssert} instance.
+   */
+  @CheckReturnValue
+  public AbstractMapAssert<SELF, A, KEY, VALUE> returnToMap() {
+    if (originAssert == null) {
+      throw new IllegalStateException("No origin available. Was this assert created from its deprecated constructor?");
+    }
+    return originAssert;
+  }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/BigDecimalScaleAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/BigDecimalScaleAssert.java
@@ -15,17 +15,18 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
+
 public class BigDecimalScaleAssert<T> extends AbstractBigDecimalScaleAssert<BigDecimalAssert> {
 
-  private AbstractBigDecimalAssert<BigDecimalAssert> bigDecimalAssert;
-
-  public BigDecimalScaleAssert(AbstractBigDecimalAssert<BigDecimalAssert> bigDecimalAssert) {
-    super(bigDecimalAssert.actual.scale(), BigDecimalScaleAssert.class);
-    this.bigDecimalAssert = bigDecimalAssert;
+  public BigDecimalScaleAssert(AbstractBigDecimalAssert<BigDecimalAssert> originAssert) {
+    super(originAssert);
   }
 
   @Override
+  @CheckReturnValue
   public AbstractBigDecimalAssert<BigDecimalAssert> returnToBigDecimal() {
-    return bigDecimalAssert;
+    return super.returnToBigDecimal();
   }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/FileSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/FileSizeAssert.java
@@ -19,16 +19,14 @@ import org.assertj.core.annotation.CheckReturnValue;
 
 public class FileSizeAssert<T> extends AbstractFileSizeAssert<FileAssert> {
 
-  private AbstractFileAssert<FileAssert> fileAssert;
-
-  public FileSizeAssert(AbstractFileAssert<FileAssert> fileAssert) {
-    super(fileAssert.actual.length(), FileSizeAssert.class);
-    this.fileAssert = fileAssert;
+  public FileSizeAssert(AbstractFileAssert<FileAssert> originAssert) {
+    super(originAssert);
   }
 
   @Override
   @CheckReturnValue
   public AbstractFileAssert<FileAssert> returnToFile() {
-    return fileAssert;
+    return super.returnToFile();
   }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/IterableSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/IterableSizeAssert.java
@@ -17,21 +17,26 @@ package org.assertj.core.api;
 
 import org.assertj.core.annotation.CheckReturnValue;
 
-//@format:off
-public class IterableSizeAssert<T> extends AbstractIterableSizeAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> {
-//@format:on
+public class IterableSizeAssert<ELEMENT>
+    extends AbstractIterableSizeAssert<IterableAssert<ELEMENT>, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
 
-  private AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> source;
+  public IterableSizeAssert(AbstractIterableAssert<IterableAssert<ELEMENT>, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> originAssert) {
+    super(originAssert);
+  }
 
-  public IterableSizeAssert(AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> source,
-                            Integer i) {
-    super(i, IterableSizeAssert.class);
-    this.source = source;
+  /**
+   * @deprecated use {@link #IterableSizeAssert(AbstractIterableAssert)} instead.
+   */
+  @Deprecated
+  public IterableSizeAssert(AbstractIterableAssert<IterableAssert<ELEMENT>, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> originAssert,
+                            @SuppressWarnings("unused") Integer size) {
+    this(originAssert);
   }
 
   @Override
   @CheckReturnValue
-  public AbstractIterableAssert<IterableAssert<T>, Iterable<? extends T>, T, ObjectAssert<T>> returnToIterable() {
-    return source;
+  public AbstractIterableAssert<IterableAssert<ELEMENT>, Iterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> returnToIterable() {
+    return super.returnToIterable();
   }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/MapSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/MapSizeAssert.java
@@ -15,22 +15,29 @@
  */
 package org.assertj.core.api;
 
-import java.util.Map;
-
 import org.assertj.core.annotation.CheckReturnValue;
+
+import java.util.Map;
 
 public class MapSizeAssert<KEY, VALUE> extends AbstractMapSizeAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> {
 
-  private AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> source;
+  public MapSizeAssert(AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> originAssert) {
+    super(originAssert);
+  }
 
-  public MapSizeAssert(AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> source, Integer i) {
-    super(i, MapSizeAssert.class);
-    this.source = source;
+  /**
+   * @deprecated use {@link #MapSizeAssert(AbstractMapAssert)} instead.
+   */
+  @Deprecated
+  public MapSizeAssert(AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> originAssert,
+                       @SuppressWarnings("unused") Integer size) {
+    this(originAssert);
   }
 
   @Override
   @CheckReturnValue
   public AbstractMapAssert<MapAssert<KEY, VALUE>, Map<KEY, VALUE>, KEY, VALUE> returnToMap() {
-    return source;
+    return super.returnToMap();
   }
+
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
@@ -101,13 +101,11 @@ public class ProxifyMethodChangingTheObjectUnderTest {
 
   private MapSizeAssert<?, ?> createMapSizeAssertProxy(Object currentAssert) {
     MapSizeAssert<?, ?> mapSizeAssert = (MapSizeAssert<?, ?>) currentAssert;
-    // can't use the usual way of building soft proxy since MapSizeAssert takes 2 parameters
     return proxies.createMapSizeAssertProxy(mapSizeAssert);
   }
 
   private IterableSizeAssert<?> createIterableSizeAssertProxy(Object currentAssert) {
     IterableSizeAssert<?> iterableSizeAssert = (IterableSizeAssert<?>) currentAssert;
-    // can't use the usual way of building soft proxy since IterableSizeAssert takes 2 parameters
     return proxies.createIterableSizeAssertProxy(iterableSizeAssert);
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -171,9 +171,8 @@ class SoftProxies {
   IterableSizeAssert<?> createIterableSizeAssertProxy(IterableSizeAssert<?> iterableSizeAssert) {
     Class<?> proxyClass = createSoftAssertionProxyClass(IterableSizeAssert.class);
     try {
-      Constructor<?> constructor = proxyClass.getConstructor(AbstractIterableAssert.class, Integer.class);
-      IterableSizeAssert<?> proxiedAssert = (IterableSizeAssert<?>) constructor.newInstance(iterableSizeAssert.returnToIterable(),
-                                                                                            iterableSizeAssert.actual);
+      Constructor<?> constructor = proxyClass.getConstructor(AbstractIterableAssert.class);
+      IterableSizeAssert<?> proxiedAssert = (IterableSizeAssert<?>) constructor.newInstance(iterableSizeAssert.returnToIterable());
       ((AssertJProxySetup) proxiedAssert).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
       return proxiedAssert;
     } catch (Exception e) {
@@ -184,9 +183,8 @@ class SoftProxies {
   MapSizeAssert<?, ?> createMapSizeAssertProxy(MapSizeAssert<?, ?> mapSizeAssert) {
     Class<?> proxyClass = createSoftAssertionProxyClass(MapSizeAssert.class);
     try {
-      Constructor<?> constructor = proxyClass.getConstructor(AbstractMapAssert.class, Integer.class);
-      MapSizeAssert<?, ?> proxiedAssert = (MapSizeAssert<?, ?>) constructor.newInstance(mapSizeAssert.returnToMap(),
-                                                                                        mapSizeAssert.actual);
+      Constructor<?> constructor = proxyClass.getConstructor(AbstractMapAssert.class);
+      MapSizeAssert<?, ?> proxiedAssert = (MapSizeAssert<?, ?>) constructor.newInstance(mapSizeAssert.returnToMap());
       ((AssertJProxySetup) proxiedAssert).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
       return proxiedAssert;
     } catch (Exception e) {

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1219,7 +1219,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
           .size()
           .isGreaterThan(22)
           .returnToIterable()
-          .as("shoud not be empty") // TODO returnToIterable() does not yet propagate assertion info
+          .as("should not be empty") // TODO returnToIterable() does not yet propagate assertion info
           .overridingErrorMessage("error message 2")
           .isEmpty();
     softly.assertThat(names)
@@ -1262,7 +1262,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     then(errorsCollected).hasSize(10);
     then(errorsCollected.get(0)).hasMessage("[size isGreaterThan(10)] error message");
     then(errorsCollected.get(1)).hasMessage("[size isGreaterThan(22)] error message");
-    then(errorsCollected.get(2)).hasMessage("[shoud not be empty] error message 2");
+    then(errorsCollected.get(2)).hasMessage("[should not be empty] error message 2");
     then(errorsCollected.get(3)).hasMessage("[first element] error message");
     then(errorsCollected.get(4)).hasMessage("[first element as Name] error message");
     then(errorsCollected.get(5)).hasMessage("[element(0)] error message");

--- a/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_size_Test.java
@@ -17,7 +17,9 @@ package org.assertj.core.api.iterable;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.HashSet;
 
@@ -37,14 +39,18 @@ class IterableAssert_size_Test {
     assertThat(integers).size().isGreaterThan(0)
                                .isLessThanOrEqualTo(3)
                         .returnToIterable().contains(1)
-                                           .doesNotContain(4);
+                                         .doesNotContain(4);
     // @format:on
   }
 
   @Test
-  void should_have_an_helpful_error_message_when_size_is_used_on_a_null_iterable() {
-    Iterable<Integer> nullList = null;
-    assertThatNullPointerException().isThrownBy(() -> assertThat(nullList).size().isGreaterThan(1))
-                                    .withMessage("Can not perform assertions on the size of a null iterable.");
+  void should_have_helpful_error_message_when_size_is_used_on_null_iterable() {
+    // GIVEN
+    Iterable<Integer> actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).size().isGreaterThan(1));
+    // THEN
+    then(assertionError).hasMessage(shouldNotBeNull().create());
   }
+
 }


### PR DESCRIPTION
This change streamlines the implementation of assertion types that allow returning to the navigation origin.

Constructors in concrete and abstract classes that don't align with storing the origin instance in the abstract class have been deprecated and will be removed in version 4.

### Scope

* `AbstractBigDecimalScaleAssert`
* `AbstractFileSizeAssert`
* `AbstractIterableSizeAssert`
* `AbstractMapSizeAssert`