### PR TITLE
Fix ignoringCollectionOrder false positives with duplicate elements

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -652,15 +652,14 @@ public class RecursiveComparisonDifferenceCalculator {
   private static void doCompareUnorderedIterables(DualValue dualValue, Iterable<?> actual, Iterable<?> expected,
                                                   ComparisonState comparisonState) {
     List<Object> expectedElementsNotFound = list();
+    // speed up comparison by selecting actual elements matching expected hash code, note that the hash code might not be
+    // relevant if fields used to compute it are ignored in the recursive comparison, it's a good heuristic though to check
+    // the first actual elements that could match the expected one, worst case we compare all actual elements.
+    // the map is built once before the loop so that actual elements removed via Iterator.remove() when matched stay
+    // removed across iterations, ensuring one-to-one matching between actual and expected elements.
+    Map<Integer, ? extends List<?>> actualElementsGroupedByHashCode = actualElementsGroupedByHashCode(actual);
     for (Object expectedElement : expected) {
       boolean expectedElementMatched = false;
-      // speed up comparison by selecting actual elements matching expected hash code, note that the hash code might not be
-      // relevant if fields used to compute it are ignored in the recursive comparison, it's a good heuristic though to check
-      // the first actual elements that could match the expected one, worst case we compare all actual elements.
-      // actualElementsGroupedByHashCode must be initialized for each expectedElement, as we remove elements from its
-      // entries when a match with expectedElement is found, the next expectedElement comparison is done on a smaller
-      // set of entries which leads to incorrect results.
-      Map<Integer, ? extends List<?>> actualElementsGroupedByHashCode = actualElementsGroupedByHashCode(actual);
       Integer expectedHash = Objects.hashCode(expectedElement);
       List<?> actualHashBucket = actualElementsGroupedByHashCode.get(expectedHash);
       if (actualHashBucket != null) {
@@ -699,8 +698,8 @@ public class RecursiveComparisonDifferenceCalculator {
     while (actualIterator.hasNext()) {
       Object actualElement = actualIterator.next();
       // we need to get the currently visited dual values otherwise a cycle would cause an infinite recursion.
-      List<ComparisonDifference> differences = determineDifferences(new DualValue(dualValue.fieldLocation, actualElement,
-                                                                                  expectedElement),
+      DualValue elementDualValue = new DualValue(dualValue.fieldLocation, actualElement, expectedElement);
+      List<ComparisonDifference> differences = determineDifferences(elementDualValue,
                                                                     comparisonState.visitedDualValues,
                                                                     comparisonState.recursiveComparisonConfiguration);
       if (differences.isEmpty()) {
@@ -708,6 +707,11 @@ public class RecursiveComparisonDifferenceCalculator {
         actualIterator.remove();
         return true;
       }
+
+      // add the differences to this pair's visited entry; otherwise they are added only to
+      // child dual values, and a later cycle-cache hit would falsely resolve the pair as "equal".
+      differences.forEach(difference -> comparisonState.visitedDualValues.registerComparisonDifference(elementDualValue,
+                                                                                                       difference));
     }
     return false;
   }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -103,6 +103,44 @@ class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
     compareRecursivelyFailsWithDifferences(actual, expected, comparisonDifference);
   }
 
+  @Test
+  void should_fail_when_expected_contains_duplicate_elements_not_present_in_actual_while_ignoring_collection_order() {
+    // GIVEN
+    List<String> actual = List.of("a", "b");
+    List<String> expected = List.of("a", "a");
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                                                                      .ignoringCollectionOrder()
+                                                                      .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContaining(format("The following expected elements were not matched in the actual List12:%n" +
+                                                     "  [\"a\"]"));
+  }
+
+  @Test
+  void should_fail_when_unmatched_pair_with_leaf_difference_is_compared_twice() {
+    // GIVEN
+    FriendlyPerson alice = new FriendlyPerson("Alice");
+    alice.add(friend("Charlie"));
+    alice.add(friend("Dave"));
+    FriendlyPerson bob = new FriendlyPerson("Bob");
+    bob.add(friend("Eve"));
+    bob.add(friend("Frank"));
+    List<FriendlyPerson> actual = List.of(alice, alice);
+    List<FriendlyPerson> expected = List.of(bob, bob);
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                                                                      .ignoringCollectionOrder()
+                                                                      .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContaining("The following expected elements were not matched")
+                        .hasMessageContaining("name=Bob");
+  }
+
   @ParameterizedTest(name = "{0}: actual={1} / expected={2} / ignore collection order in fields={3}")
   @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields_source")
   @SuppressWarnings("unused")

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -103,6 +103,43 @@ class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
     compareRecursivelyFailsWithDifferences(actual, expected, comparisonDifference);
   }
 
+  @Test
+  void should_fail_when_expected_contains_duplicate_elements_not_present_in_actual_while_ignoring_collection_order() {
+    // GIVEN
+    List<String> actual = List.of("a", "b");
+    List<String> expected = List.of("a", "a");
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                                                                      .ignoringCollectionOrder()
+                                                                      .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContaining(format("The following expected elements were not matched in the actual List12:%n" +
+                                                     "  [\"a\"]"));
+  }
+
+  @Test
+  void should_fail_when_unmatched_pair_with_leaf_difference_is_compared_twice() {
+    // GIVEN
+    FriendlyPerson alice = new FriendlyPerson("Alice");
+    alice.add(friend("Charlie"));
+    alice.add(friend("Dave"));
+    FriendlyPerson bob = new FriendlyPerson("Bob");
+    bob.add(friend("Eve"));
+    bob.add(friend("Frank"));
+    List<FriendlyPerson> actual = List.of(alice, alice);
+    List<FriendlyPerson> expected = List.of(bob, bob);
+
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                                                                      .ignoringCollectionOrder()
+                                                                      .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContaining("The following expected elements were not matched")
+                        .hasMessageContaining("name=Bob");
+  }
+
   @ParameterizedTest(name = "{0}: actual={1} / expected={2} / ignore collection order in fields={3}")
   @MethodSource("should_pass_for_objects_with_the_same_data_when_collection_order_is_ignored_in_specified_fields_source")
   @SuppressWarnings("unused")


### PR DESCRIPTION
#### Check List:
* Fixes #4228
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.

#### Summary
`usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(...)` produces a false positive when `expected` contains duplicate elements that are not all present in `actual`.
There are two distinct bugs in `doCompareUnorderedIterables` / `searchExpectedElementIn`, detailed below.

#### Bug 1 — hash buckets rebuilt every iteration
In `doCompareUnorderedIterables`, the `actualElementsGroupedByHashCode(actual)` map was rebuilt inside the loop over `expected`. Although individual bucket entries are removed via `Iterator.remove()` when an `actual` element is matched, rebuilding the map at the start of each iteration restored every previously matched element, breaking the one-to-one matching guarantee.

**Fix**: the map is now built once before the loop, so removals persist across iterations.

#### Bug 2 — visited cache not storing differences for unmatched pairs
In `searchExpectedElementIn`, when a candidate `(actualElement, expectedElement)` pair is compared and differences are found, those differences are recorded against child dual values (typically a leaf field), not against the parent pair itself. The corresponding `VisitedDualValues` entry for the parent pair stays empty.

If the same pair is encountered again (e.g. when `actual` contains the same reference twice), the cycle-detection cache returns an empty differences list, which `searchExpectedElementIn` interprets as "match found" — producing a false positive.

**Fix**: when a candidate fails to match, the differences found during the sub-comparison are added to this pair's visited entry, so that subsequent cache lookups correctly resolve as "different".

#### Other changes
Updated the in-line comment in `doCompareUnorderedIterables` describing the hash-bucket optimisation.

P.S. @joel-costigliola Could you please reassign issue #4228 to me? Thank you!