### PR TITLE
Add size() navigation method to PathAssert

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1979,6 +1979,36 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
     return new StringAssert(pathContent).withAssertionState(myself);
   }
 
+  /**
+   * Returns an {@code Assert} object that allows performing assertions on the size of the {@link Path} under test.
+   * <p>
+   * Once this method is called, the object under test is no longer the {@link Path} but its size;
+   * to perform further assertions on the {@link Path}, call {@link AbstractPathSizeAssert#returnToPath()}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Path path = Files.write(Files.createTempFile(&quot;tmp&quot;, &quot;bin&quot;), new byte[] {1, 1});
+   *
+   * // assertions succeed
+   * assertThat(path).size().isGreaterThan(1L).isLessThan(5L)
+   *                 .returnToPath().hasBinaryContent(new byte[] {1, 1});
+   *
+   * // assertion fails
+   * assertThat(path).size().isBetween(5L, 10L);</code></pre>
+   *
+   * @return AbstractPathSizeAssert built with the {@code Path}'s size.
+   * @throws NullPointerException if the given {@code Path} is {@code null}.
+   * @throws UncheckedIOException when failing to read the size of the actual {@code Path}.
+   * @since 3.28.0
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @CheckReturnValue
+  public AbstractPathSizeAssert<SELF> size() {
+    requireNonNull(actual, "Can not perform assertions on the size of a null path.");
+    PathSizeAssert result = new PathSizeAssert(this);
+    result.withAssertionState(myself);
+    return result;
+  }
+
   private byte[] readPath() {
     try {
       return readAllBytes(actual);

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractPathSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractPathSizeAssert.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.assertj.core.annotation.CheckReturnValue;
+
+/**
+ * Base class for path size assertions.
+ *
+ * @since 3.28.0
+ */
+public abstract class AbstractPathSizeAssert<ORIGIN extends AbstractPathAssert<ORIGIN>>
+    extends AbstractLongAssert<AbstractPathSizeAssert<ORIGIN>> {
+
+  private final AbstractPathAssert<ORIGIN> originAssert;
+
+  /**
+   * Creates a new instance from an origin {@link AbstractPathAssert} instance.
+   *
+   * @param originAssert the origin {@link AbstractPathAssert} that initiated the navigation.
+   */
+  protected AbstractPathSizeAssert(AbstractPathAssert<ORIGIN> originAssert) {
+    super(readSize(originAssert.actual), AbstractPathSizeAssert.class);
+    this.originAssert = originAssert;
+  }
+
+  /**
+   * Returns to the origin {@link AbstractPathAssert} instance that initiated the navigation.
+   * <p>
+   * Example:
+   * <pre><code class='java'> Path path = Files.write(Files.createTempFile(&quot;tmp&quot;, &quot;bin&quot;), new byte[] {1, 1});
+   *
+   * assertThat(path).size().isGreaterThan(1L).isLessThan(5L)
+   *                 .returnToPath().hasBinaryContent(new byte[] {1, 1});</code></pre>
+   *
+   * @return the origin {@link AbstractPathAssert} instance.
+   */
+  @CheckReturnValue
+  public AbstractPathAssert<ORIGIN> returnToPath() {
+    return originAssert;
+  }
+
+  private static long readSize(Path path) {
+    try {
+      return Files.size(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException(format("Failed to read %s size", path), e);
+    }
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/PathSizeAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/PathSizeAssert.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.annotation.CheckReturnValue;
+
+public class PathSizeAssert<T> extends AbstractPathSizeAssert<PathAssert> {
+
+  public PathSizeAssert(AbstractPathAssert<PathAssert> originAssert) {
+    super(originAssert);
+  }
+
+  @Override
+  @CheckReturnValue
+  public AbstractPathAssert<PathAssert> returnToPath() {
+    return super.returnToPath();
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_size_Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+class PathAssert_size_Test {
+
+  @Test
+  void should_be_able_to_use_path_assertions_on_path_size() {
+    // GIVEN
+    Path path = Paths.get("src/test/resources/actual_file.txt");
+    // THEN
+    then(path).size()
+              .isGreaterThan(4L)
+              .isLessThan(20L)
+              .isBetween(1L, 10L)
+              .returnToPath().hasContent("actual");
+  }
+
+  @Test
+  void should_have_a_helpful_error_message_when_size_is_used_on_a_null_path() {
+    // GIVEN
+    Path nullPath = null;
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() -> assertThat(nullPath).size().isGreaterThan(1))
+                                    .withMessage("Can not perform assertions on the size of a null path.");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `size()` navigation method on `AbstractPathAssert`, mirroring the existing `size()` on `AbstractFileAssert`.
- New `AbstractPathSizeAssert` / `PathSizeAssert` classes expose `Long`-style assertions on the path's file size, with `returnToPath()` for chaining further `Path` assertions.

## Example
```java
Path path = Files.write(Files.createTempFile("tmp", "bin"), new byte[] {1, 1});

assertThat(path).size().isGreaterThan(1L).isLessThan(5L)
                .returnToPath().hasBinaryContent(new byte[] {1, 1});
```

## Test plan
- [x] `PathAssert_size_Test` covers the happy path (chained Long assertions + `returnToPath`) and the null-path NPE message
- [x] `./mvnw -pl assertj-core test -Dtest='PathAssert_*,FileAssert_*'` passes
- [x] `./mvnw license:format spotless:apply` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)