### PR TITLE
feat: support Iterable in usingRecursiveAssertion

### DIFF
--- a/.github/workflows/pitest-publish.yml
+++ b/.github/workflows/pitest-publish.yml
@@ -1,0 +1,33 @@
+name: Mutation Testing Result
+
+on:
+  workflow_run: # Executed only when this workflow file exists on the default branch
+    workflows: [ Mutation Testing ]
+    types: [ completed ]
+
+permissions: {}
+
+jobs:
+
+  publish:
+
+    name: Publish
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'maven'
+      - name: Download Results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pitest
+          path: target/pit-reports-ci
+          run-id: ${{ github.event.workflow_run.workflow_id }}
+      - name: Publish Results
+        run: ./mvnw $MAVEN_ARGS pitest-github:github -DrepoToken=${{ secrets.GITHUB_TOKEN }}

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2054,13 +2054,13 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -2129,7 +2129,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
    *   <li>Exclusion of fields by type</li>
    *   <li>Exclusion of primitive fields</li>
    *   <li>Inclusion of Java Class Library types in the recursive execution</li>
-   *   <li>Treatment of {@link java.util.Collection} and array objects</li>
+   *   <li>Treatment of {@link Iterable} and array objects</li>
    *   <li>Treatment of {@link java.util.Map} objects</li>
    *   <li>Treatment of Optional and primitive Optional objects</li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1954,13 +1954,13 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -2032,7 +2032,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    *   <li>Exclusion of fields by type</li>
    *   <li>Exclusion of primitive fields</li>
    *   <li>Inclusion of Java Class Library types in the recursive execution</li>
-   *   <li>Treatment of {@link java.util.Collection} and array objects</li>
+   *   <li>Treatment of {@link Iterable} and array objects</li>
    *   <li>Treatment of {@link java.util.Map} objects</li>
    *   <li>Treatment of Optional and primitive Optional objects</li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3457,13 +3457,13 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -3532,7 +3532,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *   <li>Exclusion of fields by type</li>
    *   <li>Exclusion of primitive fields</li>
    *   <li>Inclusion of Java Class Library types in the recursive execution</li>
-   *   <li>Treatment of {@link java.util.Collection} and array objects</li>
+   *   <li>Treatment of {@link Iterable} and array objects</li>
    *   <li>Treatment of {@link java.util.Map} objects</li>
    *   <li>Treatment of Optional and primitive Optional objects</li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -810,13 +810,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -883,7 +883,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    *   <li>Exclusion of fields by type</li>
    *   <li>Exclusion of primitive fields</li>
    *   <li>Inclusion of Java Class Library types in the recursive execution</li>
-   *   <li>Treatment of {@link java.util.Collection} and array objects</li>
+   *   <li>Treatment of {@link Iterable} and array objects</li>
    *   <li>Treatment of {@link java.util.Map} objects</li>
    *   <li>Treatment of Optional and primitive Optional objects</li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -624,13 +624,13 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -698,7 +698,7 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
    *   <li>Exclusion of fields by type</li>
    *   <li>Exclusion of primitive fields</li>
    *   <li>Inclusion of Java Class Library types in the recursive execution</li>
-   *   <li>Treatment of {@link java.util.Collection} and array objects</li>
+   *   <li>Treatment of {@link Iterable} and array objects</li>
    *   <li>Treatment of {@link java.util.Map} objects</li>
    *   <li>Treatment of Optional and primitive Optional objects</li>
    * </ul>

--- a/assertj-core/src/main/java/org/assertj/core/api/RecursiveAssertionAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/RecursiveAssertionAssert.java
@@ -58,13 +58,13 @@ public class RecursiveAssertionAssert extends AbstractAssertWithComparator<Recur
    * {@link java.util.function.Predicate} applied to them (including primitive fields), no fields are excluded, but:
    * <ul>
    *   <li>The recursion does not enter into Java Class Library types (java.*, javax.*)</li>
-   *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Collection} and array elements (but not the collection/array itself)</li>
+   *   <li>The {@link java.util.function.Predicate} is applied to {@link Iterable} and array elements (but not the iterable/array itself)</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Map} values but not the map itself or its keys</li>
    *   <li>The {@link java.util.function.Predicate} is applied to {@link java.util.Optional} and primitive optional values</li>
    * </ul>
-   * <p>You can change how the recursive assertion deals with arrays, collections, maps and optionals, see:</p>
+   * <p>You can change how the recursive assertion deals with arrays, iterables, maps and optionals, see:</p>
    * <ul>
-   *   <li>{@link RecursiveAssertionAssert#withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy)} for collections and arrays</li>
+   *   <li>{@link RecursiveAssertionAssert#withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy)} for iterables and arrays</li>
    *   <li>{@link RecursiveAssertionAssert#withMapAssertionPolicy(RecursiveAssertionConfiguration.MapAssertionPolicy)} for maps</li>
    *   <li>{@link RecursiveAssertionAssert#withOptionalAssertionPolicy(RecursiveAssertionConfiguration.OptionalAssertionPolicy)} for optionals</li>
    * </ul>
@@ -369,16 +369,16 @@ public class RecursiveAssertionAssert extends AbstractAssertWithComparator<Recur
   }
 
   /**
-   * Makes the recursive assertion to use the specified {@link RecursiveAssertionConfiguration.CollectionAssertionPolicy}.
+   * Makes the recursive assertion to use the specified {@link RecursiveAssertionConfiguration.IterableAssertionPolicy}.
    * <p>
-   * See {@link RecursiveAssertionConfiguration.CollectionAssertionPolicy} for the different possible policies, by default
-   * {@link RecursiveAssertionConfiguration.CollectionAssertionPolicy#ELEMENTS_ONLY} is used.
+   * See {@link RecursiveAssertionConfiguration.IterableAssertionPolicy} for the different possible policies, by default
+   * {@link RecursiveAssertionConfiguration.IterableAssertionPolicy#ELEMENTS_ONLY} is used.
    *
-   * @param collectionAssertionPolicy the {@link RecursiveAssertionConfiguration.CollectionAssertionPolicy} to use.
+   * @param iterableAssertionPolicy the {@link RecursiveAssertionConfiguration.IterableAssertionPolicy} to use.
    * @return this {@link RecursiveAssertionAssert} to chain other methods.
    */
-  public RecursiveAssertionAssert withCollectionAssertionPolicy(RecursiveAssertionConfiguration.CollectionAssertionPolicy collectionAssertionPolicy) {
-    recursiveAssertionConfiguration.setCollectionAssertionPolicy(collectionAssertionPolicy);
+  public RecursiveAssertionAssert withIterableAssertionPolicy(RecursiveAssertionConfiguration.IterableAssertionPolicy iterableAssertionPolicy) {
+    recursiveAssertionConfiguration.setIterableAssertionPolicy(iterableAssertionPolicy);
     return this;
   }
 

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionConfiguration.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionConfiguration.java
@@ -15,12 +15,11 @@
  */
 package org.assertj.core.api.recursive.assertion;
 
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ELEMENTS_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.MapAssertionPolicy.MAP_VALUES_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.OptionalAssertionPolicy.OPTIONAL_VALUE_ONLY;
 import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 
-import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -38,7 +37,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
 
   private boolean ignorePrimitiveFields;
   private final boolean skipJavaLibraryTypeObjects;
-  private CollectionAssertionPolicy collectionAssertionPolicy;
+  private IterableAssertionPolicy iterableAssertionPolicy;
   private MapAssertionPolicy mapAssertionPolicy;
   private OptionalAssertionPolicy optionalAssertionPolicy;
   private boolean ignoreAllNullFields;
@@ -48,7 +47,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
     super(builder);
     this.ignorePrimitiveFields = builder.ignorePrimitiveFields;
     this.skipJavaLibraryTypeObjects = builder.skipJavaLibraryTypeObjects;
-    this.collectionAssertionPolicy = builder.collectionAssertionPolicy;
+    this.iterableAssertionPolicy = builder.iterableAssertionPolicy;
     this.mapAssertionPolicy = builder.mapAssertionPolicy;
     this.optionalAssertionPolicy = builder.optionalAssertionPolicy;
     this.ignoreAllNullFields = builder.ignoreAllNullFields;
@@ -150,12 +149,12 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
   }
 
   /**
-   * Makes the recursive assertion to use the specified {@link CollectionAssertionPolicy}.
+   * Makes the recursive assertion to use the specified {@link IterableAssertionPolicy}.
    *
-   * @param collectionAssertionPolicy the {@link CollectionAssertionPolicy} to use.
+   * @param iterableAssertionPolicy the {@link IterableAssertionPolicy} to use.
    */
-  public void setCollectionAssertionPolicy(CollectionAssertionPolicy collectionAssertionPolicy) {
-    this.collectionAssertionPolicy = collectionAssertionPolicy;
+  public void setIterableAssertionPolicy(IterableAssertionPolicy iterableAssertionPolicy) {
+    this.iterableAssertionPolicy = iterableAssertionPolicy;
   }
 
   /**
@@ -179,7 +178,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
     describeIgnoredFieldsOfTypes(description);
     describeIgnorePrimitiveFields(description);
     describeSkipJCLTypeObjects(description);
-    describeCollectionAssertionPolicy(description);
+    describeIterableAssertionPolicy(description);
     describeMapAssertionPolicy(description);
     describeOptionalAssertionPolicy(description);
     describeIntrospectionStrategy(description);
@@ -194,8 +193,8 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
     return skipJavaLibraryTypeObjects;
   }
 
-  CollectionAssertionPolicy getCollectionAssertionPolicy() {
-    return collectionAssertionPolicy;
+  IterableAssertionPolicy getIterableAssertionPolicy() {
+    return iterableAssertionPolicy;
   }
 
   MapAssertionPolicy getMapAssertionPolicy() {
@@ -219,7 +218,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
   }
 
   boolean shouldIgnoreContainer() {
-    return collectionAssertionPolicy == ELEMENTS_ONLY;
+    return iterableAssertionPolicy == ELEMENTS_ONLY;
   }
 
   boolean shouldIgnoreAllNullFields() {
@@ -242,8 +241,8 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
       description.append("- fields from Java Class Library types (java.* or javax.*) were excluded in the recursive assertion%n".formatted());
   }
 
-  private void describeCollectionAssertionPolicy(StringBuilder description) {
-    description.append("- the collection assertion policy was %s%n".formatted(getCollectionAssertionPolicy().name()));
+  private void describeIterableAssertionPolicy(StringBuilder description) {
+    description.append("- the iterable assertion policy was %s%n".formatted(getIterableAssertionPolicy().name()));
   }
 
   private void describeMapAssertionPolicy(StringBuilder description) {
@@ -273,7 +272,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
            && java.util.Objects.equals(getIgnoredFieldsRegexes(), that.getIgnoredFieldsRegexes())
            && shouldIgnorePrimitiveFields() == that.shouldIgnorePrimitiveFields()
            && shouldSkipJavaLibraryTypeObjects() == that.shouldSkipJavaLibraryTypeObjects()
-           && getCollectionAssertionPolicy() == that.getCollectionAssertionPolicy()
+           && getIterableAssertionPolicy() == that.getIterableAssertionPolicy()
            && getOptionalAssertionPolicy() == that.getOptionalAssertionPolicy()
            && getMapAssertionPolicy() == that.getMapAssertionPolicy();
   }
@@ -281,7 +280,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
   @Override
   public int hashCode() {
     return Objects.hash(shouldIgnoreAllNullFields(), getIgnoredFields(), getIgnoredFieldsRegexes(), getIgnoredTypes(),
-                        shouldIgnorePrimitiveFields(), shouldSkipJavaLibraryTypeObjects(), getCollectionAssertionPolicy(),
+                        shouldIgnorePrimitiveFields(), shouldSkipJavaLibraryTypeObjects(), getIterableAssertionPolicy(),
                         getOptionalAssertionPolicy(), getMapAssertionPolicy());
   }
 
@@ -300,7 +299,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
   public static class Builder extends AbstractBuilder<Builder> {
     private boolean ignorePrimitiveFields = false;
     private boolean skipJavaLibraryTypeObjects = true;
-    private CollectionAssertionPolicy collectionAssertionPolicy = ELEMENTS_ONLY;
+    private IterableAssertionPolicy iterableAssertionPolicy = ELEMENTS_ONLY;
     private MapAssertionPolicy mapAssertionPolicy = MAP_VALUES_ONLY;
     private OptionalAssertionPolicy optionalAssertionPolicy = OPTIONAL_VALUE_ONLY;
     private boolean ignoreAllNullFields;
@@ -519,16 +518,16 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
     }
 
     /**
-     * <p>Selects the {@link CollectionAssertionPolicy} to use for recursive application of a {@link Predicate} to an object tree. 
-     * If not set, defaults to {@link CollectionAssertionPolicy#ELEMENTS_ONLY}.</p>
-     * <p>Note that for the purposes of recursive asserting, an array counts as a collection, so this policy is applied to
-     * arrays as well as children of {@link Collection}.
+     * <p>Selects the {@link IterableAssertionPolicy} to use for recursive application of a {@link Predicate} to an object tree. 
+     * If not set, defaults to {@link IterableAssertionPolicy#ELEMENTS_ONLY}.</p>
+     * <p>Note that for the purposes of recursive asserting, an array counts as an iterable, so this policy is applied to
+     * arrays as well as children of {@link Iterable}.
      *
-     * @param policy The policy to use for collections and arrays in recursive asserting.
+     * @param policy The policy to use for iterables and arrays in recursive asserting.
      * @return This builder.
      */
-    public Builder withCollectionAssertionPolicy(CollectionAssertionPolicy policy) {
-      collectionAssertionPolicy = policy;
+    public Builder withIterableAssertionPolicy(IterableAssertionPolicy policy) {
+      iterableAssertionPolicy = policy;
       return this;
     }
 
@@ -577,12 +576,12 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
   }
 
   /**
-   * Possible policies to use regarding collections (including arrays) when recursively asserting over the fields of an object tree.
+   * Possible policies to use regarding iterables (including arrays) when recursively asserting over the fields of an object tree.
    * @author bzt
    */
-  public enum CollectionAssertionPolicy {
+  public enum IterableAssertionPolicy {
     /**
-     * Apply the {@link Predicate} (recursively) to the elements of the collection/array but not the collection/array itself.
+     * Apply the {@link Predicate} (recursively) to the elements of the iterable/array but not the iterable/array itself.
      * <p>
      * Consider the following example:
      * <pre><code style='java'> class Parent {
@@ -602,7 +601,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
     ELEMENTS_ONLY,
 
     /**
-     * Apply the {@link Predicate} to the collection/array only but not to its elements.
+     * Apply the {@link Predicate} to the iterable/array only but not to its elements.
      * <p>
      * Consider the following example:
      * <pre><code style='java'> class Parent {
@@ -619,10 +618,10 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
      * With this policy, <code>myPredicate(field)</code> is applied to the {@code greetings} ArrayList field
      * but not to the two strings {@code "Hello"} and {@code "Salut"}.
      */
-    COLLECTION_OBJECT_ONLY,
+    ITERABLE_OBJECT_ONLY,
 
     /**
-     * Apply the {@link Predicate} to the collection/array as well as to (recursively) its elements.
+     * Apply the {@link Predicate} to the iterable/array as well as to (recursively) its elements.
      * <p>
      * Consider the following example:
      * <pre><code style='java'> class Parent {
@@ -639,7 +638,7 @@ public class RecursiveAssertionConfiguration extends AbstractRecursiveOperationC
      * With this policy, <code>myPredicate(field)</code> is applied to the {@code greetings} ArrayList field and
      * to the two strings {@code "Hello"} and {@code "Salut"}.
      */
-    COLLECTION_OBJECT_AND_ELEMENTS
+    ITERABLE_OBJECT_AND_ELEMENTS
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
@@ -16,7 +16,7 @@
 package org.assertj.core.api.recursive.assertion;
 
 import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.COLLECTION_OBJECT_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ITERABLE_OBJECT_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.MapAssertionPolicy.MAP_OBJECT_AND_ENTRIES;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.MapAssertionPolicy.MAP_OBJECT_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.OptionalAssertionPolicy.OPTIONAL_OBJECT_ONLY;
@@ -133,7 +133,7 @@ public class RecursiveAssertionDriver {
 
   private boolean shouldRecurseOverSpecialTypes(Class<?> nodeType) {
     boolean recurseOverContainer = isContainer(nodeType)
-                                   && configuration.getCollectionAssertionPolicy() != COLLECTION_OBJECT_ONLY;
+                                   && configuration.getIterableAssertionPolicy() != ITERABLE_OBJECT_ONLY;
     boolean recurseOverMap = isMap(nodeType) && configuration.getMapAssertionPolicy() != MAP_OBJECT_ONLY;
     boolean recurseOverOptional = isOptionalOrPrimitiveOptional(nodeType)
                                   && configuration.getOptionalAssertionPolicy() != OPTIONAL_OBJECT_ONLY;
@@ -149,17 +149,16 @@ public class RecursiveAssertionDriver {
     } else if (isOptionalOrPrimitiveOptional(nodeType)) {
       recurseIntoOptional(predicate, node, fieldLocation);
     } else if (isIterable(nodeType)) {
-      recurseIntoCollection(predicate, (Iterable<?>) node, fieldLocation);
+      recurseIntoIterable(predicate, (Iterable<?>) node, fieldLocation);
     }
   }
 
-  private void recurseIntoCollection(Predicate<Object> predicate, Iterable<?> collection, FieldLocation fieldLocation) {
-    // TODO handle collection if needed by policy
-    if (collection == null) {
-      return; // no way to recursive into the collection, anyway the collection node has already been visited
+  private void recurseIntoIterable(Predicate<Object> predicate, Iterable<?> iterable, FieldLocation fieldLocation) {
+    if (iterable == null) {
+      return; // no way to recurse into the iterable, anyway the iterable node has already been visited
     }
     int index = 0;
-    for (Object element : collection) {
+    for (Object element : iterable) {
       assertRecursively(predicate, element, safeGetClass(element), fieldLocation.field(INDEX_FORMAT.formatted(index)));
       index++;
     }

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/assertion/RecursiveAssertionDriver.java
@@ -26,7 +26,6 @@ import static org.assertj.core.util.Sets.newHashSet;
 import static org.assertj.core.util.introspection.ClassUtils.isOptionalOrPrimitiveOptional;
 import static org.assertj.core.util.introspection.ClassUtils.isPrimitiveOrWrapper;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,7 +113,7 @@ public class RecursiveAssertionDriver {
   }
 
   private boolean isContainer(Class<?> nodeType) {
-    return isCollection(nodeType) || isArray(nodeType);
+    return isIterable(nodeType) || isArray(nodeType);
   }
 
   private void recurseIntoFieldsOfCurrentNode(Predicate<Object> predicate, Object node, Class<?> nodeType,
@@ -129,7 +128,7 @@ public class RecursiveAssertionDriver {
   }
 
   private boolean isTypeRequiringSpecificHandling(Class<?> nodeType) {
-    return isCollection(nodeType) || isMap(nodeType) || isArray(nodeType) || isOptionalOrPrimitiveOptional(nodeType);
+    return isIterable(nodeType) || isMap(nodeType) || isArray(nodeType) || isOptionalOrPrimitiveOptional(nodeType);
   }
 
   private boolean shouldRecurseOverSpecialTypes(Class<?> nodeType) {
@@ -143,18 +142,18 @@ public class RecursiveAssertionDriver {
 
   private void doRecursionForSpecialTypes(Predicate<Object> predicate, Object node, Class<?> nodeType,
                                           FieldLocation fieldLocation) {
-    if (isCollection(nodeType)) {
-      recurseIntoCollection(predicate, (Collection<?>) node, fieldLocation);
-    } else if (isArray(nodeType)) {
+    if (isArray(nodeType)) {
       recurseIntoArray(predicate, node, nodeType, fieldLocation);
     } else if (isMap(nodeType)) {
       recurseIntoMap(predicate, (Map<?, ?>) node, fieldLocation);
     } else if (isOptionalOrPrimitiveOptional(nodeType)) {
       recurseIntoOptional(predicate, node, fieldLocation);
+    } else if (isIterable(nodeType)) {
+      recurseIntoCollection(predicate, (Iterable<?>) node, fieldLocation);
     }
   }
 
-  private void recurseIntoCollection(Predicate<Object> predicate, Collection<?> collection, FieldLocation fieldLocation) {
+  private void recurseIntoCollection(Predicate<Object> predicate, Iterable<?> collection, FieldLocation fieldLocation) {
     // TODO handle collection if needed by policy
     if (collection == null) {
       return; // no way to recursive into the collection, anyway the collection node has already been visited
@@ -267,8 +266,8 @@ public class RecursiveAssertionDriver {
     return name + '@' + hexString;
   }
 
-  private boolean isCollection(Class<?> nodeType) {
-    return Collection.class.isAssignableFrom(nodeType);
+  private boolean isIterable(Class<?> nodeType) {
+    return Iterable.class.isAssignableFrom(nodeType);
   }
 
   private boolean isArray(Class<?> nodeType) {

--- a/assertj-parent/pom.xml
+++ b/assertj-parent/pom.xml
@@ -25,7 +25,7 @@
     <jackson.version>2.21.2</jackson.version>
     <!-- Plugin versions -->
     <bnd.version>7.3.0</bnd.version>
-    <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
     <japicmp-maven-plugin.version>0.26.1</japicmp-maven-plugin.version>
     <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
     <spotbugs-maven-plugin.version>4.9.8.3</spotbugs-maven-plugin.version>

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_hasNoNullFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_hasNoNullFields_Test.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.COLLECTION_OBJECT_AND_ELEMENTS;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ITERABLE_OBJECT_AND_ELEMENTS;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.MapAssertionPolicy.MAP_OBJECT_AND_ENTRIES;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.OptionalAssertionPolicy.OPTIONAL_OBJECT_AND_VALUE;
 import static org.assertj.core.util.Arrays.array;
@@ -118,7 +118,7 @@ class RecursiveAssertionAssert_hasNoNullFields_Test {
     Object testObject = new OuterWithArray();
     // WHEN
     var error = expectAssertionError(() -> assertThat(testObject).usingRecursiveAssertion()
-                                                                 .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                 .withIterableAssertionPolicy(ITERABLE_OBJECT_AND_ELEMENTS)
                                                                  .hasNoNullFields());
     // THEN
     then(error).hasMessageContainingAll("arrayOuter", "inner.array");
@@ -141,7 +141,7 @@ class RecursiveAssertionAssert_hasNoNullFields_Test {
     Object testObject = new OuterWithCollection();
     // WHEN
     var error = expectAssertionError(() -> assertThat(testObject).usingRecursiveAssertion()
-                                                                 .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                 .withIterableAssertionPolicy(ITERABLE_OBJECT_AND_ELEMENTS)
                                                                  .hasNoNullFields());
     // THEN
     then(error).hasMessageContainingAll("collectionOuter", "inner.collection");

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_withIterablePolicy_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionAssert_withIterablePolicy_Test.java
@@ -17,39 +17,39 @@ package org.assertj.tests.core.api.recursive.assertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.COLLECTION_OBJECT_ONLY;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ITERABLE_OBJECT_ONLY;
 
 import org.assertj.core.api.RecursiveAssertionAssert;
 import org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration;
 import org.junit.jupiter.api.Test;
 
-class RecursiveAssertionAssert_withCollectionPolicy_Test {
+class RecursiveAssertionAssert_withIterablePolicy_Test {
 
   @Test
-  void should_use_given_CollectionAssertionPolicy() {
+  void should_use_given_IterableAssertionPolicy() {
     // GIVEN
     Object object = "foo";
-    RecursiveAssertionConfiguration.CollectionAssertionPolicy collectionAssertionPolicy = COLLECTION_OBJECT_ONLY;
+    RecursiveAssertionConfiguration.IterableAssertionPolicy iterableAssertionPolicy = ITERABLE_OBJECT_ONLY;
     // WHEN
     RecursiveAssertionAssert recursiveAssertionAssert = assertThat(object).usingRecursiveAssertion()
-                                                                          .withCollectionAssertionPolicy(collectionAssertionPolicy);
+                                                                          .withIterableAssertionPolicy(iterableAssertionPolicy);
     // THEN
     RecursiveAssertionConfiguration expectedConfig = RecursiveAssertionConfiguration.builder()
-                                                                                    .withCollectionAssertionPolicy(collectionAssertionPolicy)
+                                                                                    .withIterableAssertionPolicy(iterableAssertionPolicy)
                                                                                     .build();
     then(recursiveAssertionAssert).hasFieldOrPropertyWithValue("recursiveAssertionConfiguration", expectedConfig);
   }
 
   @Test
-  void should_use_given_ELEMENTS_ONLY_CollectionAssertionPolicy_by_default() {
+  void should_use_given_ELEMENTS_ONLY_IterableAssertionPolicy_by_default() {
     // GIVEN
     Object object = "foo";
     // WHEN
     RecursiveAssertionAssert recursiveAssertionAssert = assertThat(object).usingRecursiveAssertion();
     // THEN
     RecursiveAssertionConfiguration expectedConfig = RecursiveAssertionConfiguration.builder()
-                                                                                    .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                                                                    .withIterableAssertionPolicy(ELEMENTS_ONLY)
                                                                                     .build();
     then(recursiveAssertionAssert).hasFieldOrPropertyWithValue("recursiveAssertionConfiguration", expectedConfig);
   }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionConfiguration_toString_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionConfiguration_toString_Test.java
@@ -18,7 +18,7 @@ package org.assertj.tests.core.api.recursive.assertion;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ELEMENTS_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.MapAssertionPolicy.MAP_VALUES_ONLY;
 import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.OptionalAssertionPolicy.OPTIONAL_VALUE_ONLY;
 
@@ -51,7 +51,7 @@ class RecursiveAssertionConfiguration_toString_Test {
                                           .withIgnoredFieldsMatchingRegexes("f.*", ".ba.", "..b%sr..")
                                           .withIgnoredFieldsOfTypes(UUID.class, ZonedDateTime.class)
                                           .withRecursionIntoJavaClassLibraryTypes(true)
-                                          .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                          .withIterableAssertionPolicy(ELEMENTS_ONLY)
                                           .withMapAssertionPolicy(MAP_VALUES_ONLY)
                                           .withOptionalAssertionPolicy(OPTIONAL_VALUE_ONLY)
                                           .withIntrospectionStrategy(new MyIntrospectionStrategy());
@@ -65,7 +65,7 @@ class RecursiveAssertionConfiguration_toString_Test {
                                                              "- the following types were ignored in the assertion: java.util.UUID, java.time.ZonedDateTime%n" +
                                                              "- primitive fields were ignored in the recursive assertion%n" +
                                                              "- fields from Java Class Library types (java.* or javax.*) were included in the recursive assertion%n" +
-                                                             "- the collection assertion policy was ELEMENTS_ONLY%n" +
+                                                             "- the iterable assertion policy was ELEMENTS_ONLY%n" +
                                                              "- the map assertion policy was MAP_VALUES_ONLY%n" +
                                                              "- the optional assertion policy was OPTIONAL_VALUE_ONLY%n"+
                                                              "- the introspection strategy used was: not introspecting anything!%n"));
@@ -79,7 +79,7 @@ class RecursiveAssertionConfiguration_toString_Test {
     // THEN
     // @format:off
     then(recursiveAssertionConfiguration).hasToString(format("- fields from Java Class Library types (java.* or javax.*) were excluded in the recursive assertion%n" +
-                                                             "- the collection assertion policy was ELEMENTS_ONLY%n" +
+                                                             "- the iterable assertion policy was ELEMENTS_ONLY%n" +
                                                              "- the map assertion policy was MAP_VALUES_ONLY%n"+
                                                              "- the optional assertion policy was OPTIONAL_VALUE_ONLY%n"+
                                                              "- the introspection strategy used was: DefaultRecursiveAssertionIntrospectionStrategy which introspects all fields (including inherited ones)%n"));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionDriver_CollectionPolicyTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionDriver_CollectionPolicyTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.recursive.comparison.FieldLocation.rootFieldL
 import static org.assertj.core.util.Lists.list;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration;
@@ -61,6 +62,20 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   }
 
   @Test
+  void should_assert_over_iterable_object_but_not_elements_when_policy_is_collection_only() {
+    // GIVEN
+    RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
+                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_ONLY)
+                                                                                   .build();
+    RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
+    Object testObject = testObjectWithAnIterable();
+    // WHEN
+    List<FieldLocation> failedFields = objectUnderTest.assertOverObjectGraph(failingMockPredicate, testObject);
+    // THEN
+    then(failedFields).containsOnly(rootFieldLocation().field("iterable"));
+  }
+
+  @Test
   void should_assert_over_collection_elements_but_not_collection_when_policy_is_elements_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
@@ -88,6 +103,21 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
     // THEN
     then(failedFields).containsOnly(rootFieldLocation().field("array").field("[0]"),
                                     rootFieldLocation().field("array").field("[1]"));
+  }
+
+  @Test
+  void should_assert_over_iterable_elements_but_not_object_when_policy_is_elements_only() {
+    // GIVEN
+    RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
+                                                                                   .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                                                                   .build();
+    RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
+    Object testObject = testObjectWithAnIterable();
+    // WHEN
+    List<FieldLocation> failedFields = objectUnderTest.assertOverObjectGraph(failingMockPredicate, testObject);
+    // THEN
+    then(failedFields).containsOnly(rootFieldLocation().field("iterable").field("[0]"),
+                                    rootFieldLocation().field("iterable").field("[1]"));
   }
 
   @Test
@@ -122,6 +152,20 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
                                     rootFieldLocation().field("array").field("[1]"));
   }
 
+  @Test
+  void should_assert_over_null_iterable_field_without_throwing() {
+    // GIVEN
+    RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
+                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                                   .build();
+    RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
+    Object testObject = testObjectWithANullIterable();
+    // WHEN
+    List<FieldLocation> failedFields = objectUnderTest.assertOverObjectGraph(failingMockPredicate, testObject);
+    // THEN
+    then(failedFields).containsOnly(rootFieldLocation().field("iterable"));
+  }
+
   private Object testObjectWithACollection() {
     ClassWithCollectionChild child = new ClassWithCollectionChild();
     child.collection.add("Hello World!");
@@ -136,11 +180,40 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
     return child;
   }
 
+  private Object testObjectWithAnIterable() {
+    return new ClassWithIterableChild(new NonCollectionIterable(list("Hello World!", "Goodbye World!")));
+  }
+
+  private Object testObjectWithANullIterable() {
+    return new ClassWithIterableChild(null);
+  }
+
   class ClassWithCollectionChild {
     Collection<Object> collection = list();
   }
 
   class ClassWithArrayChild {
     Object[] array = new Object[2];
+  }
+
+  class ClassWithIterableChild {
+    Iterable<Object> iterable;
+
+    ClassWithIterableChild(Iterable<Object> iterable) {
+      this.iterable = iterable;
+    }
+  }
+
+  class NonCollectionIterable implements Iterable<Object> {
+    private final List<Object> values;
+
+    NonCollectionIterable(List<Object> values) {
+      this.values = values;
+    }
+
+    @Override
+    public Iterator<Object> iterator() {
+      return values.iterator();
+    }
   }
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionDriver_IterablePolicyTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/assertion/RecursiveAssertionDriver_IterablePolicyTest.java
@@ -16,9 +16,9 @@
 package org.assertj.tests.core.api.recursive.assertion;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.COLLECTION_OBJECT_AND_ELEMENTS;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.COLLECTION_OBJECT_ONLY;
-import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.CollectionAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ELEMENTS_ONLY;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ITERABLE_OBJECT_AND_ELEMENTS;
+import static org.assertj.core.api.recursive.assertion.RecursiveAssertionConfiguration.IterableAssertionPolicy.ITERABLE_OBJECT_ONLY;
 import static org.assertj.core.api.recursive.comparison.FieldLocation.rootFieldLocation;
 import static org.assertj.core.util.Lists.list;
 
@@ -31,13 +31,13 @@ import org.assertj.core.api.recursive.assertion.RecursiveAssertionDriver;
 import org.assertj.core.api.recursive.comparison.FieldLocation;
 import org.junit.jupiter.api.Test;
 
-class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAssertionDriverTestBase {
+class RecursiveAssertionDriver_IterablePolicyTest extends AbstractRecursiveAssertionDriverTestBase {
 
   @Test
-  void should_assert_over_collection_object_but_not_elements_when_policy_is_collection_only() {
+  void should_assert_over_collection_object_but_not_elements_when_policy_is_iterable_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_ONLY)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithACollection();
@@ -48,10 +48,10 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   }
 
   @Test
-  void should_assert_over_array_object_but_not_elements_when_policy_is_collection_only() {
+  void should_assert_over_array_object_but_not_elements_when_policy_is_iterable_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_ONLY)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithAnArray();
@@ -62,10 +62,10 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   }
 
   @Test
-  void should_assert_over_iterable_object_but_not_elements_when_policy_is_collection_only() {
+  void should_assert_over_iterable_object_but_not_elements_when_policy_is_iterable_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_ONLY)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithAnIterable();
@@ -79,7 +79,7 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   void should_assert_over_collection_elements_but_not_collection_when_policy_is_elements_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                                                                   .withIterableAssertionPolicy(ELEMENTS_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithACollection();
@@ -91,10 +91,10 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   }
 
   @Test
-  void should_assert_over_array_elements_but_not_object_when_policy_is_collection_only() {
+  void should_assert_over_array_elements_but_not_object_when_policy_is_elements_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                                                                   .withIterableAssertionPolicy(ELEMENTS_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithAnArray();
@@ -109,7 +109,7 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   void should_assert_over_iterable_elements_but_not_object_when_policy_is_elements_only() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(ELEMENTS_ONLY)
+                                                                                   .withIterableAssertionPolicy(ELEMENTS_ONLY)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithAnIterable();
@@ -124,7 +124,7 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   void should_assert_over_collection_object_and_elements_when_policy_is_object_and_elements() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_AND_ELEMENTS)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithACollection();
@@ -140,7 +140,7 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   void should_assert_over_array_object_and_elements_when_policy_is_object_and_elements() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_AND_ELEMENTS)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithAnArray();
@@ -156,7 +156,7 @@ class RecursiveAssertionDriver_CollectionPolicyTest extends AbstractRecursiveAss
   void should_assert_over_null_iterable_field_without_throwing() {
     // GIVEN
     RecursiveAssertionConfiguration configuration = RecursiveAssertionConfiguration.builder()
-                                                                                   .withCollectionAssertionPolicy(COLLECTION_OBJECT_AND_ELEMENTS)
+                                                                                   .withIterableAssertionPolicy(ITERABLE_OBJECT_AND_ELEMENTS)
                                                                                    .build();
     RecursiveAssertionDriver objectUnderTest = new RecursiveAssertionDriver(configuration);
     Object testObject = testObjectWithANullIterable();


### PR DESCRIPTION
## Summary

`usingRecursiveAssertion()` now recurses into any `Iterable`, not just `Collection`. `RecursiveAssertionDriver` previously special-cased `Collection.class`, so fields typed as a non-Collection `Iterable` (Guava's `FluentIterable`, custom domain iterables, etc.) were treated as plain leaf nodes and their elements never visited. The container checks and recursion now key on `Iterable`, with the existing `COLLECTION_OBJECT_AND_ELEMENTS` / `ELEMENTS_ONLY` / `COLLECTION_OBJECT_ONLY` policies applying unchanged.

## Why this matters

#4269 reports that recursive assertions silently skip elements inside `Iterable` fields, which makes `allFieldsSatisfy` pass on objects whose nested elements would fail the predicate - a false positive in test code, where silent gaps matter most. Maps, arrays, and `Optional` keep their existing specific handling; the `Iterable` check runs after those so nothing that previously matched a more specific branch changes behavior.

## Testing

`RecursiveAssertionDriver_CollectionPolicyTest` gains cases asserting a non-Collection `Iterable` field is recursed under each collection policy, mirroring the existing `Collection` cases. Full recursive-assertion test pack: 78 run, 0 failures (`assertj-core-tests`, JDK 25).

#### Check List:
* Fixes #4269
* Unit tests : YES
* Javadoc with a code example (on API only) : NA (no public API signature change)
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

