### PR TITLE
Expose FileInfo as actual/expected for file/path diff assertions (3.x)

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/AssertionErrorCreator.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/AssertionErrorCreator.java
@@ -18,6 +18,7 @@ package org.assertj.core.error;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Throwables.describeErrors;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import org.assertj.core.api.SoftAssertionError;
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.FileContent;
 import org.assertj.core.internal.UnambiguousRepresentation;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.VisibleForTesting;
@@ -38,6 +40,7 @@ public class AssertionErrorCreator {
 
   private static final Class<?>[] MULTIPLE_FAILURES_ERROR_ARGUMENT_TYPES = array(String.class, List.class);
   private Method valueWrapperCreateMethod;
+  private Constructor<?> fileInfoConstructor;
 
   @VisibleForTesting
   ConstructorInvoker constructorInvoker;
@@ -53,6 +56,12 @@ public class AssertionErrorCreator {
       valueWrapperCreateMethod = valueWrapperClass.getMethod("create", Object.class, String.class);
     } catch (Exception e) {
       valueWrapperCreateMethod = null;
+    }
+    try {
+      Class<?> fileInfoClass = Class.forName("org.opentest4j.FileInfo");
+      fileInfoConstructor = fileInfoClass.getConstructor(String.class, byte[].class);
+    } catch (Exception e) {
+      fileInfoConstructor = null;
     }
   }
 
@@ -82,6 +91,14 @@ public class AssertionErrorCreator {
   }
 
   private Object valueWrapper(Object value, Representation representation) {
+    if (value instanceof FileContent && fileInfoConstructor != null) {
+      try {
+        FileContent fileContent = (FileContent) value;
+        return fileInfoConstructor.newInstance(fileContent.path(), fileContent.contents());
+      } catch (Exception e) {
+        return value; // best effort
+      }
+    }
     if (valueWrapperCreateMethod == null) return value;
     try {
       return valueWrapperCreateMethod.invoke(null, value, representation.toStringOf(value));

--- a/assertj-core/src/main/java/org/assertj/core/internal/FileContent.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/FileContent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Carries the absolute path and full byte contents of a file so that, on assertion failure,
+ * {@link org.assertj.core.error.AssertionErrorCreator} can reflectively build an
+ * {@code org.opentest4j.FileInfo} for IDE file-diff rendering. Holds no opentest4j dependency.
+ */
+public final class FileContent {
+
+  private final String path;
+  private final byte[] contents;
+
+  public FileContent(String path, byte[] contents) {
+    this.path = path;
+    this.contents = contents;
+  }
+
+  public String path() {
+    return path;
+  }
+
+  public byte[] contents() {
+    return contents;
+  }
+
+  public static FileContent of(File file) throws IOException {
+    return new FileContent(file.getAbsolutePath(), java.nio.file.Files.readAllBytes(file.toPath()));
+  }
+
+  public static FileContent of(Path path) throws IOException {
+    return new FileContent(path.toAbsolutePath().toString(), java.nio.file.Files.readAllBytes(path));
+  }
+
+  @Override
+  public String toString() {
+    return path;
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Files.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Files.java
@@ -129,7 +129,8 @@ public class Files {
     try {
       List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
       if (diffs.isEmpty()) return;
-      throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
+      throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs),
+                             FileContent.of(actual), FileContent.of(expected));
     } catch (MalformedInputException e) {
       try {
         // MalformedInputException is thrown by readLine() called in diff
@@ -139,7 +140,8 @@ public class Files {
           // fall back to the UncheckedIOException : not throwing an error is wrong as there was one in the first place.
           throw e;
         }
-        throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult));
+        throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult),
+                               FileContent.of(actual), FileContent.of(expected));
       } catch (IOException ioe) {
         throw new UncheckedIOException(format(UNABLE_TO_COMPARE_FILE_CONTENTS, actual, expected), ioe);
       }
@@ -165,7 +167,9 @@ public class Files {
     assertIsFile(info, actual);
     try {
       BinaryDiffResult binaryDiffResult = binaryDiff.diff(actual, readAllBytes(expected.toPath()));
-      if (binaryDiffResult.hasDiff()) throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult));
+      if (binaryDiffResult.hasDiff())
+        throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult),
+                               FileContent.of(actual), FileContent.of(expected));
     } catch (IOException ioe) {
       throw new UncheckedIOException(format(UNABLE_TO_COMPARE_FILE_CONTENTS, actual, expected), ioe);
     }

--- a/assertj-core/src/main/java/org/assertj/core/internal/Paths.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Paths.java
@@ -269,7 +269,9 @@ public class Paths {
     assertIsReadable(info, actual);
     try {
       BinaryDiffResult binaryDiffResult = binaryDiff.diff(actual, readAllBytes(expected));
-      if (binaryDiffResult.hasDiff()) throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult));
+      if (binaryDiffResult.hasDiff())
+        throw failures.failure(info, shouldHaveBinaryContent(actual, binaryDiffResult),
+                               FileContent.of(actual), FileContent.of(expected));
     } catch (IOException ioe) {
       throw new UncheckedIOException(format(UNABLE_TO_COMPARE_PATH_CONTENTS, actual, expected), ioe);
     }
@@ -283,7 +285,8 @@ public class Paths {
     assertIsReadable(info, actual);
     try {
       List<Delta<String>> diffs = diff.diff(actual, actualCharset, expected, expectedCharset);
-      if (!diffs.isEmpty()) throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs));
+      if (!diffs.isEmpty()) throw failures.failure(info, shouldHaveSameContent(actual, expected, diffs),
+                                                   FileContent.of(actual), FileContent.of(expected));
     } catch (IOException e) {
       throw new UncheckedIOException(format(UNABLE_TO_COMPARE_PATH_CONTENTS, actual, expected), e);
     }

--- a/assertj-core/src/test/java/org/assertj/core/error/AssertionErrorCreator_assertionError_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/AssertionErrorCreator_assertionError_Test.java
@@ -24,11 +24,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import org.assertj.core.internal.FileContent;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.ComparisonFailure;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 
 class AssertionErrorCreator_assertionError_Test {
 
@@ -108,6 +110,26 @@ class AssertionErrorCreator_assertionError_Test {
     AssertionFailedError assertionFailedError = (AssertionFailedError) assertionError;
     then(assertionFailedError.getActual().toString()).contains("actual");
     then(assertionFailedError.getExpected().toString()).contains("expected");
+  }
+
+  @Test
+  void should_use_FileInfo_as_actual_and_expected_for_FileContent_values() {
+    // GIVEN
+    FileContent actual = new FileContent("/tmp/actual.txt", "actual".getBytes());
+    FileContent expected = new FileContent("/tmp/expected.txt", "expected".getBytes());
+    // WHEN
+    AssertionError assertionError = assertionErrorCreator.assertionError("boom", actual, expected, STANDARD_REPRESENTATION);
+    // THEN
+    then(assertionError).isInstanceOf(AssertionFailedError.class);
+    AssertionFailedError assertionFailedError = (AssertionFailedError) assertionError;
+    then(assertionFailedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+      then(fileInfo.getPath()).isEqualTo("/tmp/actual.txt");
+      then(fileInfo.getContents()).isEqualTo("actual".getBytes());
+    });
+    then(assertionFailedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+      then(fileInfo.getPath()).isEqualTo("/tmp/expected.txt");
+      then(fileInfo.getContents()).isEqualTo("expected".getBytes());
+    });
   }
 
   static class Item {

--- a/assertj-core/src/test/java/org/assertj/core/internal/FileContent_of_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/FileContent_of_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.internal;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileContent_of_Test {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void should_create_file_content_from_file() throws IOException {
+    // GIVEN
+    byte[] bytes = "hello".getBytes();
+    File file = Files.write(tempDir.resolve("actual.txt"), bytes).toFile();
+    // WHEN
+    FileContent fileContent = FileContent.of(file);
+    // THEN
+    then(fileContent.path()).isEqualTo(file.getAbsolutePath());
+    then(fileContent.contents()).isEqualTo(bytes);
+  }
+
+  @Test
+  void should_create_file_content_from_path() throws IOException {
+    // GIVEN
+    byte[] bytes = "hello".getBytes();
+    Path path = Files.write(tempDir.resolve("actual.txt"), bytes);
+    // WHEN
+    FileContent fileContent = FileContent.of(path);
+    // THEN
+    then(fileContent.path()).isEqualTo(path.toAbsolutePath().toString());
+    then(fileContent.contents()).isEqualTo(bytes);
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasSameBinaryContentAs_Test.java
@@ -24,6 +24,8 @@ import static org.assertj.core.error.ShouldHaveBinaryContent.shouldHaveBinaryCon
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Files.newFile;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -36,6 +38,8 @@ import org.assertj.core.internal.BinaryDiffResult;
 import org.assertj.core.internal.FilesBaseTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 
 class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
 
@@ -125,6 +129,25 @@ class Files_assertHasSameBinaryContentAs_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertSameBinaryContentAs(INFO, actual, expected));
     // THEN
-    verify(failures).failure(INFO, shouldHaveBinaryContent(actual, diff));
+    verify(failures).failure(eq(INFO), eq(shouldHaveBinaryContent(actual, diff)), any(), any());
+  }
+
+  @Test
+  void should_fail_with_file_info_actual_and_expected() throws IOException {
+    // GIVEN
+    byte[] actualBytes = readAllBytes(actual.toPath());
+    // WHEN
+    AssertionError error = expectAssertionError(() -> unMockedFiles.assertSameBinaryContentAs(INFO, actual, expected));
+    // THEN
+    then(error).isInstanceOfSatisfying(AssertionFailedError.class, failedError -> {
+      then(failedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(actual.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(actualBytes);
+      });
+      then(failedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(expected.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(expectedBytes);
+      });
+    });
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertSameContentAs_Test.java
@@ -25,6 +25,8 @@ import static org.assertj.core.error.ShouldBeFile.shouldBeFile;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +44,8 @@ import org.assertj.core.util.Files;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 
 /**
  * Tests for <code>{@link org.assertj.core.internal.Files#assertSameContentAs(org.assertj.core.api.AssertionInfo, java.io.File, java.nio.charset.Charset, java.io.File,  java.nio.charset.Charset)}</code>.
@@ -125,7 +129,50 @@ class Files_assertSameContentAs_Test extends FilesBaseTest {
     // WHEN
     expectAssertionError(() -> unMockedFiles.assertSameContentAs(INFO, actual, defaultCharset(), expected, defaultCharset()));
     // THEN
-    verify(failures).failure(INFO, shouldHaveSameContent(actual, expected, diffs));
+    verify(failures).failure(eq(INFO), eq(shouldHaveSameContent(actual, expected, diffs)), any(), any());
+  }
+
+  @Test
+  void should_fail_with_file_info_actual_and_expected() throws IOException {
+    // GIVEN
+    byte[] actualBytes = java.nio.file.Files.readAllBytes(actual.toPath());
+    byte[] expectedBytes = java.nio.file.Files.readAllBytes(expected.toPath());
+    // WHEN
+    AssertionError error = expectAssertionError(() -> unMockedFiles.assertSameContentAs(INFO, actual, defaultCharset(),
+                                                                                        expected, defaultCharset()));
+    // THEN
+    then(error).isInstanceOfSatisfying(AssertionFailedError.class, failedError -> {
+      then(failedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(actual.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(actualBytes);
+      });
+      then(failedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(expected.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(expectedBytes);
+      });
+    });
+  }
+
+  @Test
+  void should_fail_with_file_info_actual_and_expected_for_binary_fallback() throws IOException {
+    // GIVEN
+    File actual = createFileWithNonUTF8Character();
+    byte[] actualBytes = java.nio.file.Files.readAllBytes(actual.toPath());
+    byte[] expectedBytes = java.nio.file.Files.readAllBytes(expected.toPath());
+    // WHEN
+    AssertionError error = expectAssertionError(() -> unMockedFiles.assertSameContentAs(INFO, actual, StandardCharsets.UTF_8,
+                                                                                        expected, StandardCharsets.UTF_8));
+    // THEN
+    then(error).isInstanceOfSatisfying(AssertionFailedError.class, failedError -> {
+      then(failedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(actual.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(actualBytes);
+      });
+      then(failedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(expected.getAbsolutePath());
+        then(fileInfo.getContents()).isEqualTo(expectedBytes);
+      });
+    });
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameBinaryContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameBinaryContentAs_Test.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 
 class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
 
@@ -159,6 +161,28 @@ class Paths_assertHasSameBinaryContentAs_Test extends PathsBaseTest {
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
+  }
+
+  @Test
+  void should_fail_with_file_info_actual_and_expected() throws IOException {
+    // GIVEN
+    Path actual = Files.write(tempDir.resolve("actual"), "actual".getBytes());
+    Path expected = Files.write(tempDir.resolve("expected"), "expected".getBytes());
+    byte[] actualBytes = Files.readAllBytes(actual);
+    byte[] expectedBytes = Files.readAllBytes(expected);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameBinaryContentAs(INFO, actual, expected));
+    // THEN
+    then(error).isInstanceOfSatisfying(AssertionFailedError.class, failedError -> {
+      then(failedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(actual.toAbsolutePath().toString());
+        then(fileInfo.getContents()).isEqualTo(actualBytes);
+      });
+      then(failedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(expected.toAbsolutePath().toString());
+        then(fileInfo.getContents()).isEqualTo(expectedBytes);
+      });
+    });
   }
 
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameTextualContentAs_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSameTextualContentAs_Test.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.opentest4j.AssertionFailedError;
+import org.opentest4j.FileInfo;
 
 class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
 
@@ -167,6 +169,29 @@ class Paths_assertHasSameTextualContentAs_Test extends PathsBaseTest {
     // THEN
     then(thrown).isInstanceOf(UncheckedIOException.class)
                 .hasCause(exception);
+  }
+
+  @Test
+  void should_fail_with_file_info_actual_and_expected() throws IOException {
+    // GIVEN
+    Path actual = Files.write(tempDir.resolve("actual"), "actual".getBytes());
+    Path expected = Files.write(tempDir.resolve("expected"), "expected".getBytes());
+    byte[] actualBytes = Files.readAllBytes(actual);
+    byte[] expectedBytes = Files.readAllBytes(expected);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> underTest.assertHasSameTextualContentAs(INFO, actual, CHARSET, expected,
+                                                                                              CHARSET));
+    // THEN
+    then(error).isInstanceOfSatisfying(AssertionFailedError.class, failedError -> {
+      then(failedError.getActual().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(actual.toAbsolutePath().toString());
+        then(fileInfo.getContents()).isEqualTo(actualBytes);
+      });
+      then(failedError.getExpected().getValue()).isInstanceOfSatisfying(FileInfo.class, fileInfo -> {
+        then(fileInfo.getPath()).isEqualTo(expected.toAbsolutePath().toString());
+        then(fileInfo.getContents()).isEqualTo(expectedBytes);
+      });
+    });
   }
 
 }


### PR DESCRIPTION
When file-vs-file content assertions fail, pass both files as opentest4j FileInfo actual/expected values on the thrown AssertionFailedError so IDEs can render a side-by-side file diff.

A new internal FileContent carrier (path + bytes, no opentest4j dependency) flows through the existing 4-arg Failures.failure overload; AssertionErrorCreator reflectively converts it to org.opentest4j.FileInfo when opentest4j is present, keeping the opentest4j dependency optional.

----
This was inspired by some work I was doing for MapStruct in https://github.com/mapstruct/mapstruct/pull/4063. Keep in mind that in the existing tests if `expectAssertionError` is removed IntelliJ **will not** render what is there in the MapStruct PR, and that is due to the fact that once the test is done the temporary directories are removed. To really see it, a test is needed where the files won't be deleted if the test is done.

---

This is the same as PR #4285, but for 3.x