### PR TITLE
Convert Javadoc to Markdown on assertj-tests modules

### DIFF
--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inBinary_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inBinary_Test.java
@@ -22,11 +22,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link org.assertj.core.presentation.BinaryRepresentation#toStringOf(Object)}.
- *
- * @author Mariusz Smykula
- */
+/// Tests for [org.assertj.core.presentation.BinaryRepresentation#toStringOf(Object)].
+///
+/// @author Mariusz Smykula
 class Assertions_assertThat_inBinary_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inHexadecimal_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inHexadecimal_Test.java
@@ -25,9 +25,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Mariusz Smykula
- */
+/// @author Mariusz Smykula
 class Assertions_assertThat_inHexadecimal_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inUnicode_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_inUnicode_Test.java
@@ -22,11 +22,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link org.assertj.core.presentation.UnicodeRepresentation#toStringOf(Object)}.
- *
- * @author Mariusz Smykula
- */
+/// Tests for [org.assertj.core.presentation.UnicodeRepresentation#toStringOf(Object)].
+///
+/// @author Mariusz Smykula
 class Assertions_assertThat_inUnicode_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_AssertDelegateTarget_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_AssertDelegateTarget_Test.java
@@ -18,14 +18,11 @@ package org.assertj.tests.core.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AssertDelegateTarget;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Assertions#assertThat(AssertDelegateTarget)}</code>.
- * 
- * @author Christian Rösch
- */
+/// Tests for [Assertions#assertThat(AssertDelegateTarget)].
+///
+/// @author Christian Rösch
 class Assertions_assertThat_with_AssertDelegateTarget_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_AssertProvider_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_AssertProvider_Test.java
@@ -19,16 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AssertProvider;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.internal.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link Assertions#assertThat(AssertProvider)}.
- * 
- * @author Tobias Liefke
- */
+/// Tests for [Assertions#assertThat(AssertProvider)].
+///
+/// @author Tobias Liefke
 class Assertions_assertThat_with_AssertProvider_Test {
 
   private TestedObject object;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BigDecimal_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BigDecimal_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractBigDecimalAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_BigDecimal_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BigInteger_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BigInteger_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractBigIntegerAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_BigInteger_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BooleanArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_BooleanArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractBooleanArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_BooleanArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Boolean_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Boolean_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Boolean_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ByteArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ByteArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractByteArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_ByteArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Byte_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Byte_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractByteAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Byte_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_CharArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_CharArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractCharArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_CharArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_CharSequence_Test.java
@@ -21,10 +21,8 @@ import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_CharSequence_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Character_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Character_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractCharacterAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Character_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Class_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Class_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractClassAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class Assertions_assertThat_with_Class_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_DoubleArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_DoubleArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractDoubleArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_DoubleArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_DoublePredicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_DoublePredicate_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.DoublePredicateAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class Assertions_assertThat_with_DoublePredicate_Test {
 
   private DoublePredicate actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Double_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Double_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Double_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_File_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_File_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- */
+/// @author Yvonne Wang
 class Assertions_assertThat_with_File_Test {
 
   private static File actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_FloatArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_FloatArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractFloatArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_FloatArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Float_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Float_Test.java
@@ -18,14 +18,11 @@ package org.assertj.tests.core.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.AbstractFloatAssert;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Assertions#assertThat(Float)}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [Assertions#assertThat(Float)].
+///
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Float_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_InputStream_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_InputStream_Test.java
@@ -25,9 +25,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Matthieu Baechler
- */
+/// @author Matthieu Baechler
 class Assertions_assertThat_with_InputStream_Test {
 
   private static InputStream actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_IntArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_IntArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractIntArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_IntArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_IntPredicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_IntPredicate_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.IntPredicateAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class Assertions_assertThat_with_IntPredicate_Test {
 
   private IntPredicate actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Integer_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Integer_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Integer_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Iterable_Test.java
@@ -22,10 +22,8 @@ import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Assertions_assertThat_with_Iterable_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Iterator_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Iterator_Test.java
@@ -28,11 +28,9 @@ import java.util.Iterator;
 import org.assertj.core.api.IteratorAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Julien Meddah
- * @author Joel Costigliola
- * @author Mikhail Mazursky
- */
+/// @author Julien Meddah
+/// @author Joel Costigliola
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_Iterator_Test {
 
   private final StringIterator stringIterator = new StringIterator();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_List_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_List_Test.java
@@ -26,11 +26,9 @@ import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// @author Yvonne Wang
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_List_Test {
 
   private static class Person {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LocalDateTime_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LocalDateTime_Test.java
@@ -23,10 +23,8 @@ import org.assertj.core.api.AbstractLocalDateTimeAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- * @author Marcin Zajączkowski
- */
+/// @author Joel Costigliola
+/// @author Marcin Zajączkowski
 class Assertions_assertThat_with_LocalDateTime_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LongArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LongArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractLongArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_LongArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LongPredicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_LongPredicate_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.LongPredicateAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class Assertions_assertThat_with_LongPredicate_Test {
 
   private LongPredicate actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Long_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Long_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Long_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Map_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Map_Test.java
@@ -24,10 +24,8 @@ import org.assertj.core.api.AbstractMapAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Nicolas François
- */
+/// @author Alex Ruiz
+/// @author Nicolas François
 class Assertions_assertThat_with_Map_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ObjectArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ObjectArray_Test.java
@@ -22,10 +22,8 @@ import org.assertj.core.api.AbstractObjectArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_ObjectArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Object_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Object_Test.java
@@ -21,10 +21,8 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_Object_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OffsetDateTime_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OffsetDateTime_Test.java
@@ -23,9 +23,7 @@ import org.assertj.core.api.AbstractOffsetDateTimeAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alexander Bischof
- */
+/// @author Alexander Bischof
 class Assertions_assertThat_with_OffsetDateTime_Test {
 
   private OffsetDateTime actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OffsetTime_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OffsetTime_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alexander Bischof
- */
+/// @author Alexander Bischof
 class Assertions_assertThat_with_OffsetTime_Test {
 
   private OffsetTime actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalDouble_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalDouble_Test.java
@@ -23,11 +23,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- * @author Alexander Bischof
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
+/// @author Alexander Bischof
 class Assertions_assertThat_with_OptionalDouble_Test {
 
   private OptionalDouble actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalInt_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalInt_Test.java
@@ -23,11 +23,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- * @author Alexander Bischof
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
+/// @author Alexander Bischof
 class Assertions_assertThat_with_OptionalInt_Test {
 
   private OptionalInt actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalLong_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_OptionalLong_Test.java
@@ -23,11 +23,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- * @author Alexander Bischof
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
+/// @author Alexander Bischof
 class Assertions_assertThat_with_OptionalLong_Test {
 
   private OptionalLong actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Optional_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Optional_Test.java
@@ -24,11 +24,9 @@ import org.assertj.core.api.OptionalAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- * @author Alexander Bischof
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
+/// @author Alexander Bischof
 class Assertions_assertThat_with_Optional_Test {
 
   private Optional<String> actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Predicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Predicate_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.PredicateAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class Assertions_assertThat_with_Predicate_Test {
 
   private Predicate<String> actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ShortArray_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ShortArray_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractShortArrayAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_ShortArray_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Short_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Short_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractShortAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_Short_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Spliterator_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_Spliterator_Test.java
@@ -23,9 +23,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.SpliteratorAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Bakker
- */
+/// @author William Bakker
 class Assertions_assertThat_with_Spliterator_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_String_Test.java
@@ -21,10 +21,8 @@ import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 class Assertions_assertThat_with_String_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_URI_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_URI_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alexander Bischof
- */
+/// @author Alexander Bischof
 class Assertions_assertThat_with_URI_Test {
 
   private static URI uri;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ZonedDateTime_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_ZonedDateTime_Test.java
@@ -23,10 +23,8 @@ import org.assertj.core.api.AbstractZonedDateTimeAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- * @author Marcin Zajączkowski
- */
+/// @author Joel Costigliola
+/// @author Marcin Zajączkowski
 class Assertions_assertThat_with_ZonedDateTime_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_boolean_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_boolean_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_boolean_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_byte_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_byte_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractByteAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_byte_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_char_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_char_Test.java
@@ -21,11 +21,9 @@ import org.assertj.core.api.AbstractCharacterAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Assertions#assertThat(char)}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [Assertions#assertThat(char)].
+///
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_char_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_double_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_double_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_double_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_float_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_float_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractFloatAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_float_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_int_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_int_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_int_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_long_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_long_Test.java
@@ -21,11 +21,9 @@ import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Assertions#assertThat(long)}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [Assertions#assertThat(long)].
+///
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_long_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_short_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_assertThat_with_primitive_short_Test.java
@@ -21,9 +21,7 @@ import org.assertj.core.api.AbstractShortAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Assertions_assertThat_with_primitive_short_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_from_with_Function_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_from_with_Function_Test.java
@@ -23,11 +23,9 @@ import java.util.function.Function;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Assertions#from(Function)}</code>.
- *
- * @author Stefano Cordio
- */
+/// Tests for [Assertions#from(Function)].
+///
+/// @author Stefano Cordio
 class Assertions_from_with_Function_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_sync_with_BDDAssertions_WithAssertions_and_soft_assertions_variants_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/Assertions_sync_with_BDDAssertions_WithAssertions_and_soft_assertions_variants_Test.java
@@ -35,9 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class Assertions_sync_with_BDDAssertions_WithAssertions_and_soft_assertions_variants_Test extends BaseAssertionsTest {
 
   // Assertions - BDDAssertions sync tests

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/BaseAssertionsTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/BaseAssertionsTest.java
@@ -31,9 +31,7 @@ import org.assertj.core.api.AssertDelegateTarget;
 import org.assertj.core.api.FactoryBasedNavigableIterableAssert;
 import org.assertj.core.api.FactoryBasedNavigableListAssert;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 public abstract class BaseAssertionsTest {
 
   {
@@ -79,13 +77,11 @@ public abstract class BaseAssertionsTest {
     };
   }
 
-  /**
-   * Checks if the methods have same generic parameter types.
-   *
-   * @param method1 the first method
-   * @param method2 the second method
-   * @return {@code true} if the methods have same generic parameters, {@code false} otherwise
-   */
+  /// Checks if the methods have same generic parameter types.
+  ///
+  /// @param method1 the first method
+  /// @param method2 the second method
+  /// @return `true` if the methods have same generic parameters, `false` otherwise
   private static boolean sameGenericParameterTypes(Method method1, Method method2) {
     Type[] pTypes1 = method1.getGenericParameterTypes();
     Type[] pTypes2 = method2.getGenericParameterTypes();
@@ -101,35 +97,29 @@ public abstract class BaseAssertionsTest {
     return true;
   }
 
-  /**
-   * Checks if the methods have the same name.
-   *
-   * @param method1 the first method
-   * @param method2 the second method
-   * @return {@code true} if the methods have the same name, {@code false} otherwise
-   */
+  /// Checks if the methods have the same name.
+  ///
+  /// @param method1 the first method
+  /// @param method2 the second method
+  /// @return `true` if the methods have the same name, `false` otherwise
   private static boolean sameMethodName(Method method1, Method method2) {
     return method1.getName().equals(method2.getName());
   }
 
-  /**
-   * Checks if the methods have same generic return type.
-   *
-   * @param method1 the first method
-   * @param method2 the second method
-   * @return {@code true} if the methods have same generic return type, {@code false} otherwise.
-   */
+  /// Checks if the methods have same generic return type.
+  ///
+  /// @param method1 the first method
+  /// @param method2 the second method
+  /// @return `true` if the methods have same generic return type, `false` otherwise.
   private static boolean sameGenericReturnType(Method method1, Method method2) {
     return sameType(method1.getGenericReturnType(), method2.getGenericReturnType());
   }
 
-  /**
-   * Checks if the types are equal.
-   *
-   * @param type1 the first type
-   * @param type2 the second type
-   * @return {@code true} if the types are equal, {@code false} otherwise
-   */
+  /// Checks if the types are equal.
+  ///
+  /// @param type1 the first type
+  /// @param type2 the second type
+  /// @return `true` if the types are equal, `false` otherwise
   private static boolean sameType(Type type1, Type type2) {
     return canonize(type1).equals(canonize(type2));
   }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/abstract_/AbstractAssert_extracting_with_Function_and_AssertFactory_Test.java
@@ -38,9 +38,7 @@ import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stefano Cordio
- */
+/// @author Stefano Cordio
 class AbstractAssert_extracting_with_Function_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
 
   private TestAssert underTest;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/abstract_/AbstractAssert_extracting_with_String_and_AssertFactory_Test.java
@@ -35,9 +35,7 @@ import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stefano Cordio
- */
+/// @author Stefano Cordio
 class AbstractAssert_extracting_with_String_and_AssertFactory_Test implements NavigationMethodBaseTest<TestAssert> {
 
   private TestAssert underTest;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/charsequence/CharSequenceAssert_isBlank_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/charsequence/CharSequenceAssert_isBlank_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class CharSequenceAssert_isBlank_Test {
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/charsequence/CharSequenceAssert_isNotBlank_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/charsequence/CharSequenceAssert_isNotBlank_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class CharSequenceAssert_isNotBlank_Test {
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasAnnotations_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasAnnotations_Test.java
@@ -41,10 +41,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author William Delanoue
- * @author Joel Costigliola
- */
+/// @author William Delanoue
+/// @author Joel Costigliola
 class ClassAssert_hasAnnotations_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasPackage_with_Package_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasPackage_with_Package_Test.java
@@ -27,9 +27,7 @@ import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Matteo Mirk
- */
+/// @author Matteo Mirk
 class ClassAssert_hasPackage_with_Package_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasPackage_with_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasPackage_with_String_Test.java
@@ -25,9 +25,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Matteo Mirk
- */
+/// @author Matteo Mirk
 class ClassAssert_hasPackage_with_String_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasRecordComponents_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasRecordComponents_Test.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Louis Morgan
- */
+/// @author Louis Morgan
 class ClassAssert_hasRecordComponents_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isAnnotation_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isAnnotation_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class ClassAssert_isAnnotation_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isAssignableTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isAssignableTo_Test.java
@@ -29,10 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * @author Vikram Nithyanandam
- * @author Jessica Hamilton
- */
+/// @author Vikram Nithyanandam
+/// @author Jessica Hamilton
 class ClassAssert_isAssignableTo_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isFinal_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isFinal_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Michal Kordas
- */
+/// @author Michal Kordas
 class ClassAssert_isFinal_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isInterface_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isInterface_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class ClassAssert_isInterface_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotAnnotation_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotAnnotation_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class ClassAssert_isNotAnnotation_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotFinal_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotFinal_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Michal Kordas
- */
+/// @author Michal Kordas
 class ClassAssert_isNotFinal_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotInterface_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotInterface_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class ClassAssert_isNotInterface_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotPrimitive_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotPrimitive_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Manuel Gutierrez
- */
+/// @author Manuel Gutierrez
 class ClassAssert_isNotPrimitive_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotRecord_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isNotRecord_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Louis Morgan
- */
+/// @author Louis Morgan
 class ClassAssert_isNotRecord_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isPrimitive_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isPrimitive_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Manuel Gutierrez
- */
+/// @author Manuel Gutierrez
 class ClassAssert_isPrimitive_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isRecord_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_isRecord_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Louis Morgan
- */
+/// @author Louis Morgan
 class ClassAssert_isRecord_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasDays_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasDays_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasDays_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasHours_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasHours_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasHours_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasMillis_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasMillis_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasMillis_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasMinutes_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasMinutes_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasMinutes_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasNanos_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasNanos_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasNanos_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasSeconds_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_hasSeconds_Test.java
@@ -25,9 +25,7 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_hasSeconds_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isNegative_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isNegative_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_isNegative_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isPositive_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isPositive_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_isPositive_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isZero_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_isZero_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 class DurationAssert_isZero_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_withFormatter_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/duration/DurationAssert_withFormatter_Test.java
@@ -25,9 +25,7 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Eric Rizzo
- */
+/// @author Eric Rizzo
 class DurationAssert_withFormatter_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasContent_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasContent_Test.java
@@ -36,9 +36,7 @@ import org.assertj.core.internal.Diff;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stephan Windmüller
- */
+/// @author Stephan Windmüller
 class InputStreamAssert_hasContent_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasDigest_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasDigest_Test.java
@@ -45,9 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class InputStreamAssert_hasDigest_Test {
 
   @Nested

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/InputStreamAssert_hasSameContentAs_Test.java
@@ -36,10 +36,8 @@ import org.assertj.core.internal.Diff;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Matthieu Baechler
- * @author Joel Costigliola
- */
+/// @author Matthieu Baechler
+/// @author Joel Costigliola
 class InputStreamAssert_hasSameContentAs_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/UnmarkableByteArrayInputStream.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/inputstream/UnmarkableByteArrayInputStream.java
@@ -17,9 +17,7 @@ package org.assertj.tests.core.api.inputstream;
 
 import java.io.ByteArrayInputStream;
 
-/**
-* A {@link ByteArrayInputStream} that does not allow {@link #markSupported() marking}.
-*/
+/// A [ByteArrayInputStream] that does not allow [marking][#markSupported()].
 class UnmarkableByteArrayInputStream extends ByteArrayInputStream {
 
   UnmarkableByteArrayInputStream(byte[] buf) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterable/IterableAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterable/IterableAssert_isEmpty_Test.java
@@ -25,10 +25,8 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class IterableAssert_isEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterable/IterableAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterable/IterableAssert_isNotEmpty_Test.java
@@ -25,11 +25,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Yvonne Wang
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Yvonne Wang
+/// @author Joel Costigliola
 class IterableAssert_isNotEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterator/IteratorAssert_toIterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/iterator/IteratorAssert_toIterable_Test.java
@@ -22,9 +22,7 @@ import org.assertj.core.api.IteratorAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Sára Juhošová
- */
+/// @author Sára Juhošová
 class IteratorAssert_toIterable_Test {
 
   private IteratorAssert<Integer> assertions;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/AbstractSoftAssertionsExtensionIntegrationTests.java
@@ -22,19 +22,16 @@ import static org.junit.platform.testkit.engine.EventConditions.test;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
 import static org.junit.platform.testkit.engine.TestExecutionResultConditions.message;
 
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.assertj.core.error.MultipleAssertionsError;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
-/**
- * Abstract base class for integration tests involving the {@link SoftAssertionsExtension}.
- *
- * @author Sam Brannen
- * @since 3.13
- * @see SoftAssertionsExtensionIntegrationTest
- * @see BDDSoftAssertionsExtensionIntegrationTest
- */
+/// Abstract base class for integration tests involving the [SoftAssertionsExtension].
+///
+/// @author Sam Brannen
+/// @since 3.13
+/// @see SoftAssertionsExtensionIntegrationTest
+/// @see BDDSoftAssertionsExtensionIntegrationTest
 abstract class AbstractSoftAssertionsExtensionIntegrationTests {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/BDDSoftAssertionsExtensionIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 
 import org.assertj.core.api.BDDSoftAssertions;
-import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -34,17 +33,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * Integration tests for {@link SoftAssertionsExtension} with {@link BDDSoftAssertions}.
- *
- * <p>This class is effectively a copy of {@link SoftAssertionsExtensionIntegrationTest}
- * with {@link SoftAssertions} replaced by {@link BDDSoftAssertions}.
- *
- * @author Sam Brannen
- * @since 3.13
- * @see SoftAssertionsExtensionIntegrationTest
- * @see CustomSoftAssertionsExtensionIntegrationTest
- */
+/// Integration tests for [SoftAssertionsExtension] with [BDDSoftAssertions].
+///
+/// This class is effectively a copy of [SoftAssertionsExtensionIntegrationTest]
+/// with [SoftAssertions] replaced by [BDDSoftAssertions].
+///
+/// @author Sam Brannen
+/// @since 3.13
+/// @see SoftAssertionsExtensionIntegrationTest
+/// @see CustomSoftAssertionsExtensionIntegrationTest
 @DisplayName("JUnit Jupiter BDD Soft Assertions extension integration tests (BDD)")
 class BDDSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/CustomSoftAssertionsExtensionIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 
 import java.util.Arrays;
 
-import org.assertj.core.api.SoftAssertionsProvider;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -34,15 +33,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * Integration tests for {@link SoftAssertionsExtension} with a custom implementation of {@link SoftAssertionsProvider}.
- *
- * @author Sam Brannen
- * @author Fr Jeremy Krieg
- * @since 3.16
- * @see SoftAssertionsExtensionIntegrationTest
- * @see BDDSoftAssertionsExtensionIntegrationTest
- */
+/// Integration tests for [SoftAssertionsExtension] with a custom implementation of [SoftAssertionsProvider].
+///
+/// @author Sam Brannen
+/// @author Fr Jeremy Krieg
+/// @since 3.16
+/// @see SoftAssertionsExtensionIntegrationTest
+/// @see BDDSoftAssertionsExtensionIntegrationTest
 @DisplayName("JUnit Jupiter Soft Assertions extension integration tests (custom)")
 class CustomSoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionAPIIntegrationTest.java
@@ -42,12 +42,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
-/**
- * Integration tests for the public API functions of {@link SoftAssertionsExtension}.
- *
- * @author Fr Jeremy Krieg
- * @since 3.18
- */
+/// Integration tests for the public API functions of [SoftAssertionsExtension].
+///
+/// @author Fr Jeremy Krieg
+/// @since 3.18
 class SoftAssertionsExtensionAPIIntegrationTest {
 
   @Disabled("Executed via the JUnit Platform Test Kit")

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionIntegrationTest.java
@@ -33,14 +33,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * Integration tests for {@link SoftAssertionsExtension} with {@link SoftAssertions}.
- *
- * @author Sam Brannen
- * @since 3.13
- * @see BDDSoftAssertionsExtensionIntegrationTest
- * @see CustomSoftAssertionsExtensionIntegrationTest
- */
+/// Integration tests for [SoftAssertionsExtension] with [SoftAssertions].
+///
+/// @author Sam Brannen
+/// @since 3.13
+/// @see BDDSoftAssertionsExtensionIntegrationTest
+/// @see CustomSoftAssertionsExtensionIntegrationTest
 @DisplayName("JUnit Jupiter Soft Assertions extension integration tests (standard)")
 class SoftAssertionsExtensionIntegrationTest extends AbstractSoftAssertionsExtensionIntegrationTests {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/junit/jupiter/SoftAssertionsExtensionUnitTest.java
@@ -35,14 +35,12 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 
-/**
- * Unit tests for {@link SoftAssertionsExtension}.
- *
- * @author Sam Brannen
- * @since 3.13
- * @see SoftAssertionsExtensionIntegrationTest
- * @see BDDSoftAssertionsExtensionIntegrationTest
- */
+/// Unit tests for [SoftAssertionsExtension].
+///
+/// @author Sam Brannen
+/// @since 3.13
+/// @see SoftAssertionsExtensionIntegrationTest
+/// @see BDDSoftAssertionsExtensionIntegrationTest
 @DisplayName("JUnit Jupiter Soft Assertions extension")
 class SoftAssertionsExtensionUnitTest {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test.java
@@ -38,9 +38,7 @@ import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stefano Cordio
- */
+/// @author Stefano Cordio
 class ObjectAssert_extracting_with_Function_and_InstanceOfAssertFactory_Test
     implements NavigationMethodBaseTest<ObjectAssert<Employee>> {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test.java
@@ -41,9 +41,7 @@ import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stefano Cordio
- */
+/// @author Stefano Cordio
 class ObjectAssert_extracting_with_String_and_InstanceOfAssertFactory_Test
     implements NavigationMethodBaseTest<ObjectAssert<Employee>> {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_returns_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/object/ObjectAssert_returns_Test.java
@@ -27,9 +27,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import org.assertj.tests.core.testkit.Jedi;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Takuya "Mura-Mi" Murakami
- */
+/// @author Takuya "Mura-Mi" Murakami
 class ObjectAssert_returns_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_contains_usingDefaultComparator_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_contains_usingDefaultComparator_Test.java
@@ -25,11 +25,9 @@ import java.util.Optional;
 import org.assertj.core.api.OptionalAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link OptionalAssert#usingDefaultComparator()}</code>.
- *
- * @author Sára Juhošová
- */
+/// Tests for [OptionalAssert#usingDefaultComparator()].
+///
+/// @author Sára Juhošová
 class OptionalAssert_contains_usingDefaultComparator_Test {
 
   private final Comparator<String> STRING_COMPARATOR = Comparator.comparing(String::toLowerCase);

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_get_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_get_Test.java
@@ -29,11 +29,9 @@ import org.assertj.core.api.OptionalAssert;
 import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link OptionalAssert#get()}</code>.
- *
- * @author Filip Hrisafov
- */
+/// Tests for [OptionalAssert#get()].
+///
+/// @author Filip Hrisafov
 class OptionalAssert_get_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_get_with_InstanceOfAssertFactory_Test.java
@@ -29,16 +29,13 @@ import java.util.Optional;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.assertj.core.api.OptionalAssert;
 import org.assertj.tests.core.testkit.NavigationMethodBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link OptionalAssert#get(InstanceOfAssertFactory)}</code>.
- *
- * @author Stefano Cordio
- */
+/// Tests for [OptionalAssert#get(InstanceOfAssertFactory)].
+///
+/// @author Stefano Cordio
 class OptionalAssert_get_with_InstanceOfAssertFactory_Test implements NavigationMethodBaseTest<OptionalAssert<String>> {
 
   private final Optional<String> optional = Optional.of("Frodo");

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_hasValueMatching_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/optional/OptionalAssert_hasValueMatching_Test.java
@@ -28,11 +28,9 @@ import java.util.function.Predicate;
 import org.assertj.core.presentation.PredicateDescription;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link org.assertj.core.api.OptionalAssert#hasValueMatching(java.util.function.Predicate)}.
- *
- * @author JongJun Kim
- */
+/// Tests for [org.assertj.core.api.OptionalAssert#hasValueMatching(java.util.function.Predicate)].
+///
+/// @author JongJun Kim
 class OptionalAssert_hasValueMatching_Test {
 
   private static final Predicate<String> ALWAYS_TRUE = s -> true;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasDays_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasDays_Test.java
@@ -25,9 +25,7 @@ import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Hayden Meloche
- */
+/// @author Hayden Meloche
 class PeriodAssert_hasDays_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasMonths_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasMonths_Test.java
@@ -25,9 +25,7 @@ import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Hayden Meloche
- */
+/// @author Hayden Meloche
 class PeriodAssert_hasMonths_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasYears_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_hasYears_Test.java
@@ -25,9 +25,7 @@ import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Hayden Meloche
- */
+/// @author Hayden Meloche
 class PeriodAssert_hasYears_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_isNegative_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_isNegative_Test.java
@@ -25,9 +25,7 @@ import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Hayden Meloche
- */
+/// @author Hayden Meloche
 class PeriodAssert_isNegative_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_isPositive_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/period/PeriodAssert_isPositive_Test.java
@@ -25,9 +25,7 @@ import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Hayden Meloche
- */
+/// @author Hayden Meloche
 class PeriodAssert_isPositive_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringArrayOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringArrayOrder_Test.java
@@ -91,31 +91,32 @@ class RecursiveComparisonAssert_isEqualTo_ignoringArrayOrder_Test extends WithCo
     compareRecursivelyFailsWithDifferences(actual, expected, javaTypeDiff("home.address.number", 1, 2));
   }
 
-  /**
-   * This test shows that we can't track all visited values, only the one with potential cycles.
-   * <p>
-   * Let's run it step by step with tracking all visited values:<br>
-   * array(arrayA, arrayB) vs array(arrayAReverse, arrayBReverse) means trying to find<br>
-   * - arrayA in array(arrayAReverse, arrayBReverse) and then arrayB
-   * <p>
-   * After comparing possible pairs (arrayA element, arrayAReverse element) we conclude that arrayA matches arrayAReverse<br>
-   * - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
-   * <p>
-   * We now try to find arrayB in array(arrayBReverse) - arrayAReverse must not be taken into account as it had already been matched<br>
-   * - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
-   * at this point, we know arrayB won't be found because (1, 1), (2, 2) won't be considered.<br>
-   * We compare dual values but not the location since to track cycles we want to find the same objects at different locations
-   * <p>
-   * Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different objects
-   * for primitive wrapping the same basic value, i.e. {@code new Integer(1) == new Integer(1)}.
-   * <p>
-   * The solution is to avoid adding all pairs to visited values. <br>
-   * Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must ignore them.
-   * <p>
-   * For good measure we don't track pair that include any java.lang values.
-   * <p>
-   * If arrayA and arrayB contained non wrapped basic types then == is enough to differentiate them.
-   */
+  /// This test shows that we can't track all visited values, only the one with potential cycles.
+  ///
+  /// Let's run it step by step with tracking all visited values:<br>
+  /// array(arrayA, arrayB) vs array(arrayAReverse, arrayBReverse) means trying to find<br>
+  /// - arrayA in array(arrayAReverse, arrayBReverse) and then arrayB
+  ///
+  /// After comparing possible pairs (arrayA element, arrayAReverse element) we conclude that arrayA matches arrayAReverse<br>
+  /// - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
+  ///
+  /// We now try to find arrayB in array(arrayBReverse) - arrayAReverse must not be taken into account as it had already been
+  /// matched<br>
+  /// - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
+  /// at this point, we know arrayB won't be found because (1, 1), (2, 2) won't be considered.<br>
+  /// We compare dual values but not the location since to track cycles we want to find the same objects at different locations
+  ///
+  /// Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different
+  /// objects
+  /// for primitive wrapping the same basic value, i.e. `new Integer(1) == new Integer(1)`.
+  ///
+  /// The solution is to avoid adding all pairs to visited values. <br>
+  /// Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must
+  /// ignore them.
+  ///
+  /// For good measure we don't track pair that include any java.lang values.
+  ///
+  /// If arrayA and arrayB contained non wrapped basic types then == is enough to differentiate them.
   @Test
   void should_fix_1854_minimal_test() {
     // GIVEN

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -341,31 +341,32 @@ class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
                                   .isEqualTo(list(listCReverse, listAReverse));
   }
 
-  /**
-   * This test shows that we can't track all visited values, only the one with potential cycles.
-   * <p>
-   * Let's run it step by step with tracking all visited values:<br>
-   * list(listA, listB) vs list(listAReverse, listBReverse) means trying to find<br>
-   * - listA in list(listAReverse, listBReverse) and then listB
-   * <p>
-   * After comparing possible pairs (listA element, listAReverse element) we conclude that listA matches listAReverse<br>
-   * - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
-   * <p>
-   * We now try to find listB in list(listBReverse) - listAReverse must not be taken into account as it had already been matched<br>
-   * - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
-   * at this point, we know listB won't be found because (1, 1), (2, 2) won't be considered.<br>
-   * We compare dual values but not the location since to track cycles we want to find the same objects at different locations
-   * <p>
-   * Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different objects
-   * for primitive wrapping the same basic value, i.e. {@code new Integer(1) == new Integer(1)}.
-   * <p>
-   * The solution is to avoid adding all pairs to visited values. <br>
-   * Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must ignore them.
-   * <p>
-   * For good measure we don't track pair that include any java.lang values.
-   * <p>
-   * If listA and listB contained non wrapped basic types then == is enough to differentiate them.
-   */
+  /// This test shows that we can't track all visited values, only the one with potential cycles.
+  ///
+  /// Let's run it step by step with tracking all visited values:<br>
+  /// list(listA, listB) vs list(listAReverse, listBReverse) means trying to find<br>
+  /// - listA in list(listAReverse, listBReverse) and then listB
+  ///
+  /// After comparing possible pairs (listA element, listAReverse element) we conclude that listA matches listAReverse<br>
+  /// - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
+  ///
+  /// We now try to find listB in list(listBReverse) - listAReverse must not be taken into account as it had already been
+  /// matched<br>
+  /// - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
+  /// at this point, we know listB won't be found because (1, 1), (2, 2) won't be considered.<br>
+  /// We compare dual values but not the location since to track cycles we want to find the same objects at different locations
+  ///
+  /// Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different
+  /// objects
+  /// for primitive wrapping the same basic value, i.e. `new Integer(1) == new Integer(1)`.
+  ///
+  /// The solution is to avoid adding all pairs to visited values. <br>
+  /// Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must
+  /// ignore them.
+  ///
+  /// For good measure we don't track pair that include any java.lang values.
+  ///
+  /// If listA and listB contained non wrapped basic types then == is enough to differentiate them.
   @Test
   void should_fix_1854_minimal_test() {
     // GIVEN

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_with_records_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_with_records_Test.java
@@ -24,9 +24,7 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Emanuel Trandafir
- */
+/// @author Emanuel Trandafir
 class RecursiveComparisonAssert_with_records_Test extends WithComparingFieldsIntrospectionStrategyBaseTest {
 
   @Nested

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test.java
@@ -340,31 +340,32 @@ class RecursiveComparisonAssert_isEqualTo_ignoringCollectionOrder_Test
                                   .isEqualTo(list(listCReverse, listAReverse));
   }
 
-  /**
-   * This test shows that we can't track all visited values, only the one with potential cycles.
-   * <p>
-   * Let's run it step by step with tracking all visited values:<br>
-   * list(listA, listB) vs list(listAReverse, listBReverse) means trying to find<br>
-   * - listA in list(listAReverse, listBReverse) and then listB
-   * <p>
-   * After comparing possible pairs (listA element, listAReverse element) we conclude that listA matches listAReverse<br>
-   * - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
-   * <p>
-   * We now try to find listB in list(listBReverse) - listAReverse must not be taken into account as it had already been matched<br>
-   * - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
-   * at this point, we know listB won't be found because (1, 1), (2, 2) won't be considered.<br>
-   * We compare dual values but not the location since to track cycles we want to find the same objects at different locations
-   * <p>
-   * Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different objects
-   * for primitive wrapping the same basic value, i.e. {@code new Integer(1) == new Integer(1)}.
-   * <p>
-   * The solution is to avoid adding all pairs to visited values. <br>
-   * Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must ignore them.
-   * <p>
-   * For good measure we don't track pair that include any java.lang values.
-   * <p>
-   * If listA and listB contained non wrapped basic types then == is enough to differentiate them.
-   */
+  /// This test shows that we can't track all visited values, only the one with potential cycles.
+  ///
+  /// Let's run it step by step with tracking all visited values:<br>
+  /// list(listA, listB) vs list(listAReverse, listBReverse) means trying to find<br>
+  /// - listA in list(listAReverse, listBReverse) and then listB
+  ///
+  /// After comparing possible pairs (listA element, listAReverse element) we conclude that listA matches listAReverse<br>
+  /// - here are the pairs (1, 2), (1, 1), (2, 2), we add them to the visited ones<br>
+  ///
+  /// We now try to find listB in list(listBReverse) - listAReverse must not be taken into account as it had already been
+  /// matched<br>
+  /// - we would like to try (1, 2), (1, 1), (2, 2) but they have already been visited, so we skip them.<br>
+  /// at this point, we know listB won't be found because (1, 1), (2, 2) won't be considered.<br>
+  /// We compare dual values but not the location since to track cycles we want to find the same objects at different locations
+  ///
+  /// Comparing dualValues actual and expected with == does not solve the issue because Java does not always create different
+  /// objects
+  /// for primitive wrapping the same basic value, i.e. `new Integer(1) == new Integer(1)`.
+  ///
+  /// The solution is to avoid adding all pairs to visited values. <br>
+  /// Visited values are here to track cycles, a pair of wrapped primitive types can't cycle back to itself, we thus can and must
+  /// ignore them.
+  ///
+  /// For good measure we don't track pair that include any java.lang values.
+  ///
+  /// If listA and listB contained non wrapped basic types then == is enough to differentiate them.
   @Test
   void should_fix_1854_minimal_test() {
     // GIVEN

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Index_Test.java
@@ -25,11 +25,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/**
- * Tests for {@link Index}.
- *
- * @author Alex Ruiz
- */
+/// Tests for [Index].
+///
+/// @author Alex Ruiz
 class Index_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/MapEntry_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/MapEntry_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class MapEntry_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Offset_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Offset_Test.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/**
- * Tests for {@link Offset}.
- *
- * @author Alex Ruiz
- */
+/// Tests for [Offset].
+///
+/// @author Alex Ruiz
 class Offset_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Percentage_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/data/Percentage_Test.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-/**
- * Tests for {@link Percentage}.
- *
- * @author Alexander Bischof
- */
+/// Tests for [Percentage].
+///
+/// @author Alexander Bischof
 class Percentage_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/Description_toString_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/Description_toString_Test.java
@@ -22,9 +22,7 @@ import static org.mockito.Mockito.mock;
 import org.assertj.core.description.Description;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- */
+/// @author Yvonne Wang
 class Description_toString_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/EmptyTextDescription_emptyText_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/EmptyTextDescription_emptyText_Test.java
@@ -21,9 +21,7 @@ import static org.assertj.core.description.EmptyTextDescription.emptyDescription
 import org.assertj.core.description.Description;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- */
+/// @author Yvonne Wang
 class EmptyTextDescription_emptyText_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/JoinDescription_value_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/JoinDescription_value_Test.java
@@ -24,9 +24,7 @@ import org.assertj.core.description.JoinDescription;
 import org.assertj.tests.core.testkit.TestDescription;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Edgar Asatryan
- */
+/// @author Edgar Asatryan
 class JoinDescription_value_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_constructor_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_constructor_Test.java
@@ -21,10 +21,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 import org.assertj.core.description.TextDescription;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- * @author Alex Ruiz
- */
+/// @author Yvonne Wang
+/// @author Alex Ruiz
 class TextDescription_constructor_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_equals_hashCode_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_equals_hashCode_Test.java
@@ -25,9 +25,7 @@ import org.assertj.core.description.TextDescription;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class TextDescription_equals_hashCode_Test {
 
   private static TextDescription description;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_toString_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_toString_Test.java
@@ -20,10 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.description.TextDescription;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- * @author Alex Ruiz
- */
+/// @author Yvonne Wang
+/// @author Alex Ruiz
 class TextDescription_toString_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_value_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/description/TextDescription_value_Test.java
@@ -20,10 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.description.TextDescription;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Yvonne Wang
- * @author Alex Ruiz
- */
+/// @author Yvonne Wang
+/// @author Alex Ruiz
 class TextDescription_value_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/groups/Properties_extractProperty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/groups/Properties_extractProperty_Test.java
@@ -24,12 +24,10 @@ import org.assertj.core.groups.Properties;
 import org.assertj.core.util.introspection.FieldSupport;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Properties#extractProperty(String, Class)}</code>.
- *
- * @author Yvonne Wang
- * @author Mikhail Mazursky
- */
+/// Tests for [Properties#extractProperty(String, Class)].
+///
+/// @author Yvonne Wang
+/// @author Mikhail Mazursky
 class Properties_extractProperty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/groups/Properties_ofType_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/groups/Properties_ofType_Test.java
@@ -22,11 +22,9 @@ import org.assertj.core.groups.Properties;
 import org.assertj.core.util.introspection.FieldSupport;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Properties#ofType(Class)}</code>.
- *
- * @author Olivier Michallat
- */
+/// Tests for [Properties#ofType(Class)].
+///
+/// @author Olivier Michallat
 class Properties_ofType_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/ClassesBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/ClassesBaseTest.java
@@ -23,9 +23,7 @@ import java.lang.annotation.Target;
 import org.assertj.core.internal.Classes;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 public abstract class ClassesBaseTest {
 
   protected Classes classes;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_digestDiff_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_digestDiff_Test.java
@@ -30,9 +30,7 @@ import org.assertj.core.internal.DigestDiff;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Digests_digestDiff_Test {
 
   private static final byte[] EXPECTED_MD5_DIGEST = { 58, -63, -81, -94, -88, -101, 126, 79, 24, 102, 80, 40, 119, -65, 29, -59 };

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_fromHex_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_fromHex_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Digests_fromHex_Test {
 
   private static final byte[] DIGEST_TEST_1_BYTES = { -38, 57, -93, -18, 94, 107, 75, 13, 50, 85, -65, -17, -107, 96, 24, -112,

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_toHex_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/Digests_toHex_Test.java
@@ -22,9 +22,7 @@ import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import org.assertj.core.internal.Digests;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Digests_toHex_Test {
 
   private static final byte[] DIGEST_TEST_1_BYTES = { -38, 57, -93, -18, 94, 107, 75, 13, 50, 85, -65, -17, -107, 96, 24, -112,

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/SpliteratorsBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/SpliteratorsBaseTest.java
@@ -26,11 +26,9 @@ import org.assertj.core.internal.Spliterators;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * Base class for {@link Spliterators} tests.
- *
- * @author William Bakker
- */
+/// Base class for [Spliterators] tests.
+///
+/// @author William Bakker
 public class SpliteratorsBaseTest {
 
   protected static final AssertionInfo INFO = someInfo();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertContains_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertContains_at_Index_Test.java
@@ -26,17 +26,12 @@ import static org.assertj.tests.core.testkit.TestData.someIndex;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
-import org.assertj.core.internal.Arrays2D;
-import org.assertj.core.internal.Failures;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Arrays2D#assertContains(AssertionInfo, Failures, Object, Object, Index)}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Arrays2D#assertContains(AssertionInfo, Failures, Object, Object, Index)].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertContains_at_Index_Test extends Arrays2D_BaseTest {
 
   private int[][] actual = new int[][] { { 0, 2, 4 }, { 6, 8, 10 } };

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertDoesNotContain_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertDoesNotContain_at_Index_Test.java
@@ -24,18 +24,13 @@ import static org.assertj.tests.core.testkit.TestData.someIndex;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.Index;
-import org.assertj.core.internal.Arrays2D;
-import org.assertj.core.internal.Failures;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Arrays2D#assertDoesNotContain(AssertionInfo, Failures, Object, Object, Index)}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Arrays2D#assertDoesNotContain(AssertionInfo, Failures, Object, Object, Index)].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertDoesNotContain_at_Index_Test extends Arrays2D_BaseTest {
 
   private int[][] actual = new int[][] { { 0, 2, 4 }, { 6, 8, 10 } };

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertEmpty_Test.java
@@ -21,16 +21,11 @@ import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Arrays2D;
-import org.assertj.core.internal.Failures;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Arrays2D#assertEmpty(AssertionInfo, Failures, Object)}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Arrays2D#assertEmpty(AssertionInfo, Failures, Object)].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertEmpty_Test extends Arrays2D_BaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertHasDimensions_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertHasDimensions_Test.java
@@ -22,15 +22,11 @@ import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Char2DArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Char2DArrays#assertHasDimensions(AssertionInfo, char[][], int, int)}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Char2DArrays#assertHasDimensions(AssertionInfo, char[].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertHasDimensions_Test extends Arrays2D_BaseTest {
 
   private char[][] actual = new char[][] { { 'a', 'b', 'c' }, { 'd', 'e', 'f' } };

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertNotEmpty_Test.java
@@ -23,17 +23,13 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import java.util.stream.Stream;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Int2DArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link Int2DArrays#assertNotEmpty(AssertionInfo, int[][])}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Int2DArrays#assertNotEmpty(AssertionInfo, int[].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertNotEmpty_Test extends Arrays2D_BaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/arrays2d/Arrays2D_assertNullOrEmpty_Test.java
@@ -20,15 +20,11 @@ import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Int2DArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Int2DArrays#assertNullOrEmpty(AssertionInfo, int[][])}</code>.
- *
- * @author Maciej Wajcht
- */
+/// Tests for [Int2DArrays#assertNullOrEmpty(AssertionInfo, int[].
+///
+/// @author Maciej Wajcht
 class Arrays2D_assertNullOrEmpty_Test extends Arrays2D_BaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasDeclaredFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasDeclaredFields_Test.java
@@ -26,13 +26,9 @@ import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Classes#assertHasDeclaredFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
- * .
- * 
- * @author William Delanoue
- */
+/// Tests for [org.assertj.core.internal.Classes#assertHasDeclaredFields(org.assertj.core.api.AssertionInfo, Class, String)].
+///
+/// @author William Delanoue
 class Classes_assertHasDeclaredFields_Test extends ClassesBaseTest {
 
   @BeforeEach

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasDeclaredMethods_Test.java
@@ -22,16 +22,12 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newTreeSet;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.Strings;
 import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Classes#assertHasDeclaredMethods(AssertionInfo, Class, String...)}</code>
- */
+/// Tests for [org.assertj.core.internal.Classes#assertHasDeclaredMethods(AssertionInfo, Class, String)]
 class Classes_assertHasDeclaredMethods_Test extends ClassesBaseTest {
 
   @BeforeEach

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasOnlyDeclaredFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasOnlyDeclaredFields_Test.java
@@ -30,14 +30,9 @@ import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code
- * >{@link org.assertj.core.internal.Classes#assertHasOnlyDeclaredFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
- * .
- *
- * @author Filip Hrisafov
- */
+/// Tests for [org.assertj.core.internal.Classes#assertHasOnlyDeclaredFields(org.assertj.core.api.AssertionInfo, Class, String)].
+///
+/// @author Filip Hrisafov
 class Classes_assertHasOnlyDeclaredFields_Test extends ClassesBaseTest {
 
   private static final LinkedHashSet<String> EMPTY_STRING_SET = Sets.newLinkedHashSet();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasOnlyPublicFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasOnlyPublicFields_Test.java
@@ -29,14 +29,9 @@ import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code
- * >{@link org.assertj.core.internal.Classes#assertHasOnlyPublicFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
- * .
- *
- * @author Filip Hrisafov
- */
+/// Tests for [org.assertj.core.internal.Classes#assertHasOnlyPublicFields(org.assertj.core.api.AssertionInfo, Class, String)].
+///
+/// @author Filip Hrisafov
 class Classes_assertHasOnlyPublicFields_Test extends ClassesBaseTest {
 
   private static final LinkedHashSet<String> EMPTY_STRING_SET = Sets.newLinkedHashSet();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasPublicFields_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertHasPublicFields_Test.java
@@ -27,13 +27,9 @@ import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Classes#assertHasPublicFields(org.assertj.core.api.AssertionInfo, Class, String...)}</code>
- * .
- * 
- * @author William Delanoue
- */
+/// Tests for [org.assertj.core.internal.Classes#assertHasPublicFields(org.assertj.core.api.AssertionInfo, Class, String)].
+///
+/// @author William Delanoue
 class Classes_assertHasPublicFields_Test extends ClassesBaseTest {
 
   @BeforeEach

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertIsAssignableFrom_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/classes/Classes_assertIsAssignableFrom_Test.java
@@ -25,13 +25,9 @@ import org.assertj.core.util.Sets;
 import org.assertj.tests.core.internal.ClassesBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Classes#assertIsAssignableFrom(org.assertj.core.api.AssertionInfo, Class, Class[])}</code>
- * .
- * 
- * @author William Delanoue
- */
+/// Tests for [org.assertj.core.internal.Classes#assertIsAssignableFrom(org.assertj.core.api.AssertionInfo, Class, Class[].
+///
+/// @author William Delanoue
 class Classes_assertIsAssignableFrom_Test extends ClassesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/failures/Failures_failure_with_ErrorMessage_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/failures/Failures_failure_with_ErrorMessage_Test.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.core.description.Description;
 import org.assertj.core.error.ErrorMessageFactory;
@@ -28,11 +27,9 @@ import org.assertj.tests.core.testkit.TestDescription;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Failures#failure(AssertionInfo, ErrorMessageFactory)}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [Failures#failure(AssertionInfo, ErrorMessageFactory)].
+///
+/// @author Alex Ruiz
 class Failures_failure_with_ErrorMessage_Test {
 
   private WritableAssertionInfo info;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/BinaryDiff_diff_InputStream_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/BinaryDiff_diff_InputStream_Test.java
@@ -26,9 +26,7 @@ import org.assertj.core.internal.BinaryDiffResult;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Olivier Michallat
- */
+/// @author Olivier Michallat
 class BinaryDiff_diff_InputStream_Test {
 
   private static BinaryDiff binaryDiff;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/BinaryDiff_diff_InputStream_bytes_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/BinaryDiff_diff_InputStream_bytes_Test.java
@@ -26,9 +26,7 @@ import org.assertj.core.internal.BinaryDiffResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Olivier Michallat, Stefan Birkner
- */
+/// @author Olivier Michallat, Stefan Birkner
 @DisplayName("BinaryDiff diff(InputStream)")
 class BinaryDiff_diff_InputStream_bytes_Test {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/Diff_diff_InputStream_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/Diff_diff_InputStream_Test.java
@@ -29,9 +29,7 @@ import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Matthieu Baechler
- */
+/// @author Matthieu Baechler
 class Diff_diff_InputStream_Test {
 
   private static Diff diff;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArraysBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArraysBaseTest.java
@@ -32,20 +32,16 @@ import org.assertj.tests.core.testkit.CaseInsensitiveStringComparator;
 import org.assertj.tests.core.testkit.TestData;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * Base class for testing <code>{@link ObjectArrays}</code>, set up an instance with {@link StandardComparisonStrategy} and
- * another with {@link ComparatorBasedComparisonStrategy}.
- *
- * @author Joel Costigliola
- * @author Mikhail Mazursky
- */
+/// Base class for testing [ObjectArrays], set up an instance with [StandardComparisonStrategy] and
+/// another with [ComparatorBasedComparisonStrategy].
+///
+/// @author Joel Costigliola
+/// @author Mikhail Mazursky
 public class ObjectArraysBaseTest {
 
   protected static final AssertionInfo INFO = TestData.someInfo();
 
-  /**
-   * is initialized with {@link #initActualArray()}
-   */
+  /// is initialized with [#initActualArray()]
   protected String[] actual;
   protected Failures failures;
   protected ObjectArrays arrays;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreAtLeast_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreAtLeast_Test.java
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertAreAtLeast_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreAtMost_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreAtMost_Test.java
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertAreAtMost_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreExactly_Test.java
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertAreExactly_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreNot_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAreNot_Test.java
@@ -24,11 +24,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertAreNot_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAre_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertAre_Test.java
@@ -24,11 +24,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertAre_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -30,9 +30,7 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Lovro Pandzic
- */
+/// @author Lovro Pandzic
 class ObjectArrays_assertContainsExactlyInAnyOrder_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnlyNulls_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnlyNulls_Test.java
@@ -27,9 +27,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Billy Yuan
- */
+/// @author Billy Yuan
 class ObjectArrays_assertContainsOnlyNulls_Test extends ObjectArraysBaseTest {
   private Object[] actual = array();
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnlyOnce_Test.java
@@ -31,9 +31,7 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Delanoue
- */
+/// @author William Delanoue
 class ObjectArrays_assertContainsOnlyOnce_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsOnly_Test.java
@@ -28,10 +28,8 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertContainsOnly_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsSequence_Test.java
@@ -29,10 +29,8 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.AssertionInfo;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertContainsSequence_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContainsSubsequence_Test.java
@@ -27,16 +27,12 @@ import static org.assertj.tests.core.testkit.ObjectArrays.emptyArray;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
-import org.assertj.core.internal.ObjectArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ObjectArrays#assertContainsSubsequence(AssertionInfo, Object[], Object[])}</code>.
- *
- * @author Marcin Mikosik
- */
+/// Tests for [ObjectArrays#assertContainsSubsequence(AssertionInfo, Object[].
+///
+/// @author Marcin Mikosik
 class ObjectArrays_assertContainsSubsequence_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContains_Test.java
@@ -23,10 +23,8 @@ import org.assertj.core.internal.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertContains_Test extends ObjectArraysBaseTest {
 
   private Arrays internalArrays;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertContains_at_Index_Test.java
@@ -31,10 +31,8 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.data.Index;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertContains_at_Index_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoNotHave_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoNotHave_Test.java
@@ -24,10 +24,8 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
 class ObjectArrays_assertDoNotHave_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainNull_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainNull_Test.java
@@ -22,16 +22,12 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ObjectArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ObjectArrays#assertDoesNotContainNull(AssertionInfo, Object[])}</code>.
- *
- * @author Joel Costigliola
- * @author Mikhail Mazursky
- */
+/// Tests for [ObjectArrays#assertDoesNotContainNull(AssertionInfo, Object[].
+///
+/// @author Joel Costigliola
+/// @author Mikhail Mazursky
 class ObjectArrays_assertDoesNotContainNull_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSequence_Test.java
@@ -28,9 +28,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Chris Arnott
- */
+/// @author Chris Arnott
 class ObjectArrays_assertDoesNotContainSequence_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContainSubsequence_Test.java
@@ -29,9 +29,7 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.internal.ObjectArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Marcin Mikosik
- */
+/// @author Marcin Mikosik
 class ObjectArrays_assertDoesNotContainSubsequence_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_Test.java
@@ -30,10 +30,8 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertDoesNotContain_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotContain_at_Index_Test.java
@@ -29,10 +29,8 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.data.Index;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertDoesNotContain_at_Index_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertDoesNotHaveDuplicates_Test.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class ObjectArrays_assertDoesNotHaveDuplicates_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertEmpty_Test.java
@@ -23,10 +23,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertEmpty_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertEndsWith_Test.java
@@ -27,11 +27,9 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- * @author Florent Biville
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
+/// @author Florent Biville
 class ObjectArrays_assertEndsWith_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -23,10 +23,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Joel Costigliola
 class ObjectArrays_assertHasSameSizeAs_with_Array_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -28,10 +28,8 @@ import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Joel Costigliola
 class ObjectArrays_assertHasSameSizeAs_with_Iterable_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHasSize_Test.java
@@ -22,10 +22,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertHasSize_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveAtLeast_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveAtLeast_Test.java
@@ -23,10 +23,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
 class ObjectArrays_assertHaveAtLeast_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveAtMost_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveAtMost_Test.java
@@ -23,11 +23,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertHaveAtMost_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveExactly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveExactly_Test.java
@@ -23,11 +23,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertHaveExactly_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveNot_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHaveNot_Test.java
@@ -24,11 +24,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertHaveNot_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHave_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertHave_Test.java
@@ -24,11 +24,9 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Nicolas François
- * @author Mikhail Mazursky
- * @author Joel Costigliola
- */
+/// @author Nicolas François
+/// @author Mikhail Mazursky
+/// @author Joel Costigliola
 class ObjectArrays_assertHave_Test extends ObjectArraysWithConditionBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertIsSortedAccordingToComparator_Test.java
@@ -27,10 +27,8 @@ import java.util.Comparator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- * @author Mikhail Mazursky
- */
+/// @author Joel Costigliola
+/// @author Mikhail Mazursky
 class ObjectArrays_assertIsSortedAccordingToComparator_Test extends ObjectArraysBaseTest {
 
   private Comparator<String> byDescendingOrderComparator;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
@@ -26,10 +26,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- * @author Mikhail Mazursky
- */
+/// @author Joel Costigliola
+/// @author Mikhail Mazursky
 class ObjectArrays_assertIsSorted_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertNotEmpty_Test.java
@@ -24,10 +24,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertNotEmpty_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertNullOrEmpty_Test.java
@@ -22,10 +22,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertNullOrEmpty_Test extends ObjectArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/objectarrays/ObjectArrays_assertStartsWith_Test.java
@@ -28,10 +28,8 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ObjectArrays_assertStartsWith_Test extends ObjectArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/PathsSimpleBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/PathsSimpleBaseTest.java
@@ -30,9 +30,7 @@ import org.assertj.core.internal.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
-/**
- * @author David Haccoun
- */
+/// @author David Haccoun
 public abstract class PathsSimpleBaseTest {
 
   protected static final AssertionInfo INFO = someInfo();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test.java
@@ -41,9 +41,7 @@ import org.assertj.core.internal.DigestDiff;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertHasDigest_with_MessageDigest_and_Byte_array_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_MessageDigest_and_String_Test.java
@@ -41,9 +41,7 @@ import org.assertj.core.internal.DigestDiff;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertHasDigest_with_MessageDigest_and_String_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_String_and_Byte_array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_String_and_Byte_array_Test.java
@@ -41,9 +41,7 @@ import org.assertj.core.internal.DigestDiff;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertHasDigest_with_String_and_Byte_array_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_String_and_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasDigest_with_String_and_String_Test.java
@@ -41,9 +41,7 @@ import org.assertj.core.internal.DigestDiff;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertHasDigest_with_String_and_String_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasFileSystem_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasFileSystem_Test.java
@@ -31,9 +31,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
-/**
- * @author Ashley Scopes
- */
+/// @author Ashley Scopes
 class Paths_assertHasFileSystem_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasSameFileSystemAsPath_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasSameFileSystemAsPath_Test.java
@@ -31,9 +31,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
-/**
- * @author Ashley Scopes
- */
+/// @author Ashley Scopes
 class Paths_assertHasSameFileSystemAsPath_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasTextualContent_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasTextualContent_Test.java
@@ -38,10 +38,8 @@ import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/**
- * @author Olivier Michallat
- * @author Joel Costigliola
- */
+/// @author Olivier Michallat
+/// @author Joel Costigliola
 class Paths_assertHasTextualContent_Test extends PathsBaseTest {
 
   private static final Charset CHARSET = defaultCharset();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryContaining_with_Predicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryContaining_with_Predicate_Test.java
@@ -37,9 +37,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsDirectoryContaining_with_Predicate_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
@@ -37,9 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_Predicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_Predicate_Test.java
@@ -36,9 +36,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsDirectoryNotContaining_with_Predicate_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
@@ -36,9 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_Predicate_Test.java
@@ -36,9 +36,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author David Haccoun
- */
+/// @author David Haccoun
 class Paths_assertIsDirectoryRecursivelyContaining_Predicate_Test extends PathsSimpleBaseTest {
 
   private static final String THE_GIVEN_FILTER_DESCRIPTION = "the given filter";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author David Haccoun
- */
+/// @author David Haccoun
 class Paths_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test extends PathsSimpleBaseTest {
 
   private static final String TXT_EXTENSION_PATTERN = "regex:.+\\.txt";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsEmptyDirectory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsEmptyDirectory_Test.java
@@ -34,9 +34,7 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsEmptyDirectory_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsNotEmptyDirectory_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertIsNotEmptyDirectory_Test.java
@@ -33,9 +33,7 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Valeriy Vyrva
- */
+/// @author Valeriy Vyrva
 class Paths_assertIsNotEmptyDirectory_Test extends PathsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArraysBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArraysBaseTest.java
@@ -26,9 +26,7 @@ import org.assertj.core.internal.Short2DArrays;
 import org.assertj.tests.core.testkit.TestData;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArraysBaseTest {
 
   protected short[][] actual;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertContains_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertContains_at_Index_Test.java
@@ -20,9 +20,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertContains_at_Index_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertDoesNotContain_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertDoesNotContain_at_Index_Test.java
@@ -20,9 +20,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertDoesNotContain_at_Index_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertEmpty_Test.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertEmpty_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertHasDimensions_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertHasDimensions_Test.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertHasDimensions_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertHasSameDimensionsAs_with_Array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertHasSameDimensionsAs_with_Array_Test.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertHasSameDimensionsAs_with_Array_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertNotEmpty_Test.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertNotEmpty_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/short2darrays/Short2DArrays_assertNullOrEmpty_Test.java
@@ -19,9 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Wajcht
- */
+/// @author Maciej Wajcht
 class Short2DArrays_assertNullOrEmpty_Test extends Short2DArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArraysBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArraysBaseTest.java
@@ -28,17 +28,13 @@ import org.assertj.core.internal.ShortArrays;
 import org.assertj.tests.core.testkit.AbsValueComparator;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * Base class for testing <code>{@link ShortArrays}</code>, set up an instance with {@link StandardComparisonStrategy} and another
- * with {@link ComparatorBasedComparisonStrategy}. *
- *
- * @author Joel Costigliola
- */
+/// Base class for testing [ShortArrays], set up an instance with [StandardComparisonStrategy] and another
+/// with [ComparatorBasedComparisonStrategy]. *
+///
+/// @author Joel Costigliola
 class ShortArraysBaseTest {
 
-  /**
-   * is initialized with {@link #initActualArray()} with default value = {6, 8, 10}
-   */
+  /// is initialized with [#initActualArray()] with default value = {6, 8, 10}
   protected short[] actual;
   protected Failures failures;
   protected ShortArrays arrays;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsExactlyInAnyOrder_Test.java
@@ -31,12 +31,9 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContainsExactlyInAnyOrder(AssertionInfo, short[], short[])}</code>.
- */
+/// Tests for [ShortArrays#assertContainsExactlyInAnyOrder(AssertionInfo, short[].
 class ShortArrays_assertContainsExactlyInAnyOrder_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsExactly_Test.java
@@ -31,12 +31,9 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContainsExactly(AssertionInfo, short[], short[])}</code>.
- */
+/// Tests for [ShortArrays#assertContainsExactly(AssertionInfo, short[].
 class ShortArrays_assertContainsExactly_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsOnlyOnce_Test.java
@@ -29,14 +29,11 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContainsOnlyOnce(AssertionInfo, short[], short[])}</code>.
- * 
- * @author William Delanoue
- */
+/// Tests for [ShortArrays#assertContainsOnlyOnce(AssertionInfo, short[].
+///
+/// @author William Delanoue
 class ShortArrays_assertContainsOnlyOnce_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsOnly_Test.java
@@ -29,15 +29,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContainsOnly(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertContainsOnly(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertContainsOnly_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContainsSequence_Test.java
@@ -28,15 +28,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContainsSequence(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertContainsSequence(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertContainsSequence_Test extends ShortArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContains_Test.java
@@ -21,18 +21,14 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Arrays;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContains(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertContains(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertContains_Test extends ShortArraysBaseTest {
 
   private Arrays internalArrays;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertContains_at_Index_Test.java
@@ -30,15 +30,12 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertContains(AssertionInfo, short[], short, Index)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertContains(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertContains_at_Index_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotContain_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotContain_Test.java
@@ -31,15 +31,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertDoesNotContain(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertDoesNotContain(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertDoesNotContain_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotContain_at_Index_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotContain_at_Index_Test.java
@@ -29,15 +29,12 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.Index;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertDoesNotContain(AssertionInfo, short[], short, Index)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertDoesNotContain(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertDoesNotContain_at_Index_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotHaveDuplicates_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertDoesNotHaveDuplicates_Test.java
@@ -27,15 +27,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertDoesNotHaveDuplicates(AssertionInfo, short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertDoesNotHaveDuplicates(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertDoesNotHaveDuplicates_Test extends ShortArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertEmpty_Test.java
@@ -25,14 +25,11 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertEmpty(AssertionInfo, short[])}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [ShortArrays#assertEmpty(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
 class ShortArrays_assertEmpty_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertEndsWith_Test.java
@@ -28,15 +28,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertEndsWith(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Florent Biville
- */
+/// Tests for [ShortArrays#assertEndsWith(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Florent Biville
 class ShortArrays_assertEndsWith_Test extends ShortArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -25,14 +25,11 @@ import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertHasSameSizeAs(AssertionInfo, short[], Iterable)}</code>.
- *
- * @author Nicolas François
- */
+/// Tests for [ShortArrays#assertHasSameSizeAs(AssertionInfo, short[].
+///
+/// @author Nicolas François
 class ShortArrays_assertHasSameSizeAs_with_Iterable_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertHasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertHasSize_Test.java
@@ -20,16 +20,12 @@ import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertHasSize(AssertionInfo, short[], int)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertHasSize(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertHasSize_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertIsSortedAccordingToComparator_Test.java
@@ -28,15 +28,12 @@ import static org.mockito.Mockito.verify;
 import java.util.Comparator;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertIsSortedAccordingToComparator(AssertionInfo, short[], Comparator)}</code>
- * 
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertIsSortedAccordingToComparator(AssertionInfo, short[]
+///
+/// @author Joel Costigliola
 class ShortArrays_assertIsSortedAccordingToComparator_Test extends ShortArraysBaseTest {
 
   private Comparator<Short> shortDescendingOrderComparator;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertIsSorted_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertIsSorted_Test.java
@@ -27,14 +27,11 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertIsSorted(AssertionInfo, short[])}</code>.
- * 
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertIsSorted(AssertionInfo, short[].
+///
+/// @author Joel Costigliola
 class ShortArrays_assertIsSorted_Test extends ShortArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertNotEmpty_Test.java
@@ -26,15 +26,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertNotEmpty(AssertionInfo, short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertNotEmpty(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertNotEmpty_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertNullOrEmpty_Test.java
@@ -23,15 +23,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertNullOrEmpty(AssertionInfo, short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertNullOrEmpty(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertNullOrEmpty_Test extends ShortArraysBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shortarrays/ShortArrays_assertStartsWith_Test.java
@@ -28,15 +28,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.ShortArrays;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShortArrays#assertStartsWith(AssertionInfo, short[], short[])}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [ShortArrays#assertStartsWith(AssertionInfo, short[].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class ShortArrays_assertStartsWith_Test extends ShortArraysBaseTest {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertEqual_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertEqual_Test.java
@@ -23,16 +23,13 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertEqual(AssertionInfo, Object, Object)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Shorts#assertEqual(AssertionInfo, Object, Object)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Shorts_assertEqual_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsBetween_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsBetween_Test.java
@@ -24,14 +24,11 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsBetween(AssertionInfo, Short, Short, Short)}</code>.
- *
- * @author William Delanoue
- */
+/// Tests for [Shorts#assertIsBetween(AssertionInfo, Short, Short, Short)].
+///
+/// @author William Delanoue
 class Shorts_assertIsBetween_Test extends ShortsBaseTest {
 
   private static final Short ZERO = 0;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsEven_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsEven_Test.java
@@ -20,16 +20,12 @@ import static org.assertj.core.error.ShouldBeEven.shouldBeEven;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * Tests for <code>{@link Shorts#assertIsEven(AssertionInfo, Number)}</code>.
- *
- * @author Cal027
- */
+/// Tests for [Shorts#assertIsEven(AssertionInfo, Number)].
+///
+/// @author Cal027
 class Shorts_assertIsEven_Test extends ShortsBaseTest {
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsNegative_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsNegative_Test.java
@@ -20,16 +20,12 @@ import static org.assertj.core.error.ShouldBeLess.shouldBeLess;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsNegative(AssertionInfo, Short)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Shorts#assertIsNegative(AssertionInfo, Short)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Shorts_assertIsNegative_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsNotNegative_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsNotNegative_Test.java
@@ -18,15 +18,11 @@ package org.assertj.tests.core.internal.shorts;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsNotPositive(AssertionInfo, Short)}</code>.
- *
- * @author Nicolas François
- */
+/// Tests for [Shorts#assertIsNotPositive(AssertionInfo, Short)].
+///
+/// @author Nicolas François
 class Shorts_assertIsNotNegative_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsOdd_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsOdd_Test.java
@@ -20,17 +20,13 @@ import static org.assertj.core.error.ShouldBeOdd.shouldBeOdd;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * Tests for <code>{@link Shorts#assertIsOdd(AssertionInfo, Number)}</code>.
- *
- * @author Cal027
- */
+/// Tests for [Shorts#assertIsOdd(AssertionInfo, Number)].
+///
+/// @author Cal027
 @DisplayName("Shorts assertIsOdd")
 class Shorts_assertIsOdd_Test extends ShortsBaseTest {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsOne_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsOne_Test.java
@@ -19,15 +19,11 @@ import static org.assertj.tests.core.testkit.ErrorMessagesForTest.shouldBeEqualM
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsOne(AssertionInfo, Short)}</code>.
- *
- * @author Drummond Dawson
- */
+/// Tests for [Shorts#assertIsOne(AssertionInfo, Short)].
+///
+/// @author Drummond Dawson
 class Shorts_assertIsOne_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsPositive_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsPositive_Test.java
@@ -18,16 +18,12 @@ package org.assertj.tests.core.internal.shorts;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsPositive(AssertionInfo, Short)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Shorts#assertIsPositive(AssertionInfo, Short)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Shorts_assertIsPositive_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsStrictlyBetween_Test.java
@@ -25,14 +25,11 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsStrictlyBetween(AssertionInfo, Short, Short, Short)}</code>.
- *
- * @author William Delanoue
- */
+/// Tests for [Shorts#assertIsStrictlyBetween(AssertionInfo, Short, Short, Short)].
+///
+/// @author William Delanoue
 class Shorts_assertIsStrictlyBetween_Test extends ShortsBaseTest {
 
   private static final Short ZERO = 0;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsZero_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/shorts/Shorts_assertIsZero_Test.java
@@ -19,16 +19,12 @@ import static org.assertj.tests.core.testkit.ErrorMessagesForTest.shouldBeEqualM
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Shorts;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Shorts#assertIsNegative(AssertionInfo, Short)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Shorts#assertIsNegative(AssertionInfo, Short)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Shorts_assertIsZero_Test extends ShortsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/spliterator/Spliterators_assertHasCharacteristics_Test.java
@@ -28,9 +28,7 @@ import org.assertj.tests.core.internal.SpliteratorsBaseTest;
 import org.assertj.tests.core.testkit.StringSpliterator;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Bakker
- */
+/// @author William Bakker
 class Spliterators_assertHasCharacteristics_Test extends SpliteratorsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/spliterator/Spliterators_assertHasOnlyCharacteristics_Test.java
@@ -29,9 +29,7 @@ import org.assertj.tests.core.internal.SpliteratorsBaseTest;
 import org.assertj.tests.core.testkit.StringSpliterator;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author William Bakker
- */
+/// @author William Bakker
 class Spliterators_assertHasOnlyCharacteristics_Test extends SpliteratorsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsIgnoringCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsIgnoringCase_Test.java
@@ -27,10 +27,8 @@ import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.util.DefaultLocale;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertContainsIgnoringCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsOnlyDigits_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsOnlyDigits_Test.java
@@ -20,13 +20,10 @@ import static org.assertj.core.error.ShouldContainOnlyDigits.shouldContainOnlyDi
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertContainsOnlyDigits(AssertionInfo info, CharSequence actual)}</code>.
- */
+/// Tests for [org.assertj.core.internal.Strings#assertContainsOnlyDigits(AssertionInfo, CharSequence)].
 class Strings_assertContainsOnlyDigits_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsOnlyOnce_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsOnlyOnce_Test.java
@@ -22,14 +22,10 @@ import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNul
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertContainsOnlyOnce(AssertionInfo, CharSequence, CharSequence)}</code>.
- */
+/// Tests for [Strings#assertContainsOnlyOnce(AssertionInfo, CharSequence, CharSequence)].
 class Strings_assertContainsOnlyOnce_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsPattern_CharSequence_Test.java
@@ -25,16 +25,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.PatternSyntaxException;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertContainsPattern(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
- * @author Pierre Templier
- */
+/// Tests for [Strings#assertContainsPattern(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Pierre Templier
 class Strings_assertContainsPattern_CharSequence_Test extends StringsBaseTest {
 
   private static final String CONTAINED_PATTERN = "dark";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsPattern_Pattern_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsPattern_Pattern_Test.java
@@ -25,16 +25,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertContainsPattern(AssertionInfo, CharSequence, Pattern)}</code>.
- * 
- * @author Pierre Templier
- */
+/// Tests for [Strings#assertContainsPattern(AssertionInfo, CharSequence, Pattern)].
+///
+/// @author Pierre Templier
 class Strings_assertContainsPattern_Pattern_Test extends StringsBaseTest {
 
   private static final String CONTAINED_PATTERN = "dark";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContainsSequence_Test.java
@@ -27,16 +27,12 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertContainsSequence(AssertionInfo, CharSequence, CharSequence[])}</code>.
- *
- * @author Billy Yuan
- */
+/// Tests for [Strings#assertContainsSequence(AssertionInfo, CharSequence, CharSequence[].
+///
+/// @author Billy Yuan
 class Strings_assertContainsSequence_Test extends StringsBaseTest {
   String actual = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertContains_Test.java
@@ -27,10 +27,8 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertContains_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainIgnoringCase_Test.java
@@ -31,9 +31,7 @@ import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.util.DefaultLocale;
 
-/**
- * @author Brummolix
- */
+/// @author Brummolix
 class Strings_assertDoesNotContainIgnoringCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainPattern_CharSequence_Test.java
@@ -25,14 +25,10 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.PatternSyntaxException;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, CharSequence)}</code>.
- */
+/// Tests for [Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, CharSequence)].
 class Strings_assertDoesNotContainPattern_CharSequence_Test extends StringsBaseTest {
 
   private static final String CONTAINED_PATTERN = "y.*u?";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainPattern_Pattern_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainPattern_Pattern_Test.java
@@ -25,14 +25,10 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, Pattern)}</code>.
- */
+/// Tests for [Strings#assertDoesNotContainPattern(AssertionInfo, CharSequence, Pattern)].
 class Strings_assertDoesNotContainPattern_Pattern_Test extends StringsBaseTest {
 
   private static final String CONTAINED_PATTERN = "y.*u?";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSequence_Test.java
@@ -24,14 +24,10 @@ import static org.assertj.core.internal.ErrorMessages.arrayOfValuesToLookForIsNu
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link Strings#assertDoesNotContainSequence(AssertionInfo, CharSequence, CharSequence[])}.
- */
+/// Tests for [Strings#assertDoesNotContainSequence(AssertionInfo, CharSequence, CharSequence[])].
 class Strings_assertDoesNotContainSequence_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSubsequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContainSubsequence_Test.java
@@ -25,14 +25,10 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for {@link Strings#assertDoesNotContainSubsequence(AssertionInfo, CharSequence, CharSequence[])}.
- */
+/// Tests for [Strings#assertDoesNotContainSubsequence(AssertionInfo, CharSequence, CharSequence[])].
 class Strings_assertDoesNotContainSubsequence_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContain_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotContain_Test.java
@@ -28,9 +28,7 @@ import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 class Strings_assertDoesNotContain_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotEndWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotEndWith_Test.java
@@ -21,16 +21,12 @@ import static org.assertj.core.error.ShouldNotEndWith.shouldNotEndWith;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotEndWith(AssertionInfo, CharSequence, CharSequence)}</code>.
- *
- * @author Michal Kordas
- */
+/// Tests for [Strings#assertDoesNotEndWith(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Michal Kordas
 class Strings_assertDoesNotEndWith_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotMatch_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotMatch_CharSequence_Test.java
@@ -25,16 +25,12 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.PatternSyntaxException;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotMatch(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- */
+/// Tests for [Strings#assertDoesNotMatch(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Alex Ruiz
 class Strings_assertDoesNotMatch_CharSequence_Test extends StringsBaseTest {
 
   private String actual = "Yoda";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotMatch_Pattern_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotMatch_Pattern_Test.java
@@ -24,17 +24,13 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotMatch(AssertionInfo, CharSequence, Pattern)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertDoesNotMatch(AssertionInfo, CharSequence, Pattern)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertDoesNotMatch_Pattern_Test extends StringsBaseTest {
 
   private String actual = "Yoda";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotStartWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertDoesNotStartWith_Test.java
@@ -21,16 +21,12 @@ import static org.assertj.core.error.ShouldNotStartWith.shouldNotStartWith;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertDoesNotStartWith(AssertionInfo, CharSequence, CharSequence)}</code>.
- *
- * @author Michal Kordas
- */
+/// Tests for [Strings#assertDoesNotStartWith(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Michal Kordas
 class Strings_assertDoesNotStartWith_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEmpty_Test.java
@@ -20,17 +20,13 @@ import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertEmpty(AssertionInfo, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertEmpty(AssertionInfo, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertEmpty_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEndsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEndsWith_Test.java
@@ -21,17 +21,13 @@ import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertEndsWith(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertEndsWith(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertEndsWith_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsIgnoringCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsIgnoringCase_Test.java
@@ -24,10 +24,8 @@ import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.util.DefaultLocale;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertEqualsIgnoringCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsIgnoringWhitespace_Test.java
@@ -33,14 +33,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertEqualsIgnoringWhitespace(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- * @author Alexander Bischof
- * @author Dan Corder
- */
+/// Tests for [org.assertj.core.internal.Strings#assertEqualsIgnoringWhitespace(org.assertj.core.api.AssertionInfo, CharSequence,
+/// CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
+/// @author Alexander Bischof
+/// @author Dan Corder
 class Strings_assertEqualsIgnoringWhitespace_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test.java
@@ -29,11 +29,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#normalizePunctuationAndWhitespace(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
- *
- * @author Harisha Talanki
- */
+/// Tests for [org.assertj.core.internal.Strings#normalizePunctuationAndWhitespace(org.assertj.core.api.AssertionInfo,
+/// CharSequence, CharSequence)].
+///
+/// @author Harisha Talanki
 class Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingUnicode_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingUnicode_Test.java
@@ -31,11 +31,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertEqualsToNormalizingUnicode(AssertionInfo, CharSequence, CharSequence)} (org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
- *
- * @author Julieta Navarro
- */
+/// Tests for [org.assertj.core.internal.Strings#assertEqualsToNormalizingUnicode(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Julieta Navarro
 class Strings_assertEqualsNormalizingUnicode_Test extends StringsBaseTest {
   @Test
   void should_fail_if_actual_is_not_null_and_expected_is_null() {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingWhitespace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertEqualsNormalizingWhitespace_Test.java
@@ -32,12 +32,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author Alex Ruiz
- * @author Joel Costigliola
- * @author Alexander Bischof
- * @author Dan Corder
- */
+/// @author Alex Ruiz
+/// @author Joel Costigliola
+/// @author Alexander Bischof
+/// @author Dan Corder
 class Strings_assertEqualsNormalizingWhitespace_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasLinesCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasLinesCount_Test.java
@@ -25,11 +25,9 @@ import org.assertj.core.api.AssertionInfo;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertHasLineCount(org.assertj.core.api.AssertionInfo, CharSequence, int)}</code>.
- *
- * @author Mariusz Smykula
- */
+/// Tests for [org.assertj.core.internal.Strings#assertHasLineCount(org.assertj.core.api.AssertionInfo, CharSequence, int)].
+///
+/// @author Mariusz Smykula
 class Strings_assertHasLinesCount_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_Array_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_Array_Test.java
@@ -23,15 +23,12 @@ import static org.assertj.tests.core.util.AssertionsUtil.assertThatAssertionErro
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSameSizeAs(AssertionInfo, CharSequence, Object[])}</code>.
- *
- * @author Nicolas François
- */
+/// Tests for [Strings#assertHasSameSizeAs(AssertionInfo, CharSequence, Object[].
+///
+/// @author Nicolas François
 class Strings_assertHasSameSizeAs_with_Array_Test extends StringsBaseTest {
 
   private String actual = "Han";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_CharSequence_Test.java
@@ -25,11 +25,10 @@ import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertHasSameSizeAs(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)}</code>.
- *
- * @author Joel Costigliola
- */
+/// Tests for [org.assertj.core.internal.Strings#assertHasSameSizeAs(org.assertj.core.api.AssertionInfo, CharSequence,
+/// CharSequence)].
+///
+/// @author Joel Costigliola
 class Strings_assertHasSameSizeAs_with_CharSequence_Test extends StringsBaseTest {
 
   private String actual = "Luke";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSameSizeAs_with_Iterable_Test.java
@@ -25,15 +25,12 @@ import java.util.List;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSameSizeAs(AssertionInfo, CharSequence, Iterable)}</code>.
- *
- * @author Nicolas François
- */
+/// Tests for [Strings#assertHasSameSizeAs(AssertionInfo, CharSequence, Iterable)].
+///
+/// @author Nicolas François
 class Strings_assertHasSameSizeAs_with_Iterable_Test extends StringsBaseTest {
 
   private String actual = "Han";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeBetween_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeBetween_Test.java
@@ -21,16 +21,12 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSizeGreaterThan(AssertionInfo, CharSequence, int)}</code>.
- *
- * @author Geoffrey Arthaud
- */
+/// Tests for [Strings#assertHasSizeGreaterThan(AssertionInfo, CharSequence, int)].
+///
+/// @author Geoffrey Arthaud
 class Strings_assertHasSizeBetween_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeGreaterThanOrEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeGreaterThanOrEqualTo_Test.java
@@ -21,16 +21,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSizeGreaterThanOrEqualTo(AssertionInfo, CharSequence, int)} </code>.
- *
- * @author Sandra Parsick
- * @author Georg Berky
- */
+/// Tests for [Strings#assertHasSizeGreaterThanOrEqualTo(AssertionInfo, CharSequence, int)].
+///
+/// @author Sandra Parsick
+/// @author Georg Berky
 class Strings_assertHasSizeGreaterThanOrEqualTo_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeGreaterThan_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeGreaterThan_Test.java
@@ -21,16 +21,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSizeGreaterThan(AssertionInfo, CharSequence, int)}</code>.
- *
- * @author Sandra Parsick
- * @author Georg Berky
- */
+/// Tests for [Strings#assertHasSizeGreaterThan(AssertionInfo, CharSequence, int)].
+///
+/// @author Sandra Parsick
+/// @author Georg Berky
 class Strings_assertHasSizeGreaterThan_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeLessThanOrEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeLessThanOrEqualTo_Test.java
@@ -21,16 +21,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSizeLessThanOrEqualTo(AssertionInfo, CharSequence, int)} </code>.
- *
- * @author Sandra Parsick
- * @author Georg Berky
- */
+/// Tests for [Strings#assertHasSizeLessThanOrEqualTo(AssertionInfo, CharSequence, int)].
+///
+/// @author Sandra Parsick
+/// @author Georg Berky
 class Strings_assertHasSizeLessThanOrEqualTo_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeLessThan_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSizeLessThan_Test.java
@@ -21,16 +21,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSizeLessThan(AssertionInfo, CharSequence, int)}</code>.
- *
- * @author Sandra Parsick
- * @author Georg Berky
- */
+/// Tests for [Strings#assertHasSizeLessThan(AssertionInfo, CharSequence, int)].
+///
+/// @author Sandra Parsick
+/// @author Georg Berky
 class Strings_assertHasSizeLessThan_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertHasSize_Test.java
@@ -21,16 +21,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.tests.core.testkit.TestData.someInfo;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertHasSize(AssertionInfo, CharSequence, int)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertHasSize(AssertionInfo, CharSequence, int)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertHasSize_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsEqualToIgnoringNewlines_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsEqualToIgnoringNewlines_Test.java
@@ -23,9 +23,7 @@ import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Daniel Weber
- */
+/// @author Daniel Weber
 class Strings_assertIsEqualToIgnoringNewlines_Test extends StringsBaseTest {
 
   private static final String ACTUAL_WITHOUT_NEW_LINES = "Some textWith new lines";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -28,13 +28,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Strings#assertIsEqualToNormalizingNewlines(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)}</code>
- * .
- *
- * @author Mauricio Aniche
- */
+/// Tests for [org.assertj.core.internal.Strings#assertIsEqualToNormalizingNewlines(org.assertj.core.api.AssertionInfo,
+/// CharSequence, CharSequence)].
+///
+/// @author Mauricio Aniche
 class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsLowerCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsLowerCase_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Marcel Overdijk
- */
+/// @author Marcel Overdijk
 class Strings_assertIsLowerCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsMixedCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsMixedCase_Test.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * @author Andrey Kuzmin
- */
+/// @author Andrey Kuzmin
 class Strings_assertIsMixedCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsUpperCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertIsUpperCase_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Marcel Overdijk
- */
+/// @author Marcel Overdijk
 class Strings_assertIsUpperCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertMatches_CharSequence_Test.java
@@ -29,16 +29,13 @@ import static org.mockito.Mockito.verify;
 import java.util.regex.PatternSyntaxException;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertMatches(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertMatches(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertMatches_CharSequence_Test extends StringsBaseTest {
 
   private String actual = "Yoda";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertMatches_Pattern_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertMatches_Pattern_Test.java
@@ -29,16 +29,13 @@ import static org.mockito.Mockito.verify;
 import java.util.regex.Pattern;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertMatches(AssertionInfo, CharSequence, Pattern)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertMatches(AssertionInfo, CharSequence, Pattern)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertMatches_Pattern_Test extends StringsBaseTest {
 
   private String actual = "Yoda";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEmpty_Test.java
@@ -24,16 +24,13 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertNotEmpty(AssertionInfo, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertNotEmpty(AssertionInfo, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertNotEmpty_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsIgnoringCase_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsIgnoringCase_Test.java
@@ -30,9 +30,7 @@ import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.util.DefaultLocale;
 
-/**
- * @author Alexander Bischof
- */
+/// @author Alexander Bischof
 class Strings_assertNotEqualsIgnoringCase_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsIgnoringWhitespace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsIgnoringWhitespace_Test.java
@@ -33,11 +33,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertNotEqualsIgnoringWhitespace(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
- *
- * @author Dan Corder
- */
+/// Tests for [org.assertj.core.internal.Strings#assertNotEqualsIgnoringWhitespace(org.assertj.core.api.AssertionInfo,
+/// CharSequence, CharSequence)].
+///
+/// @author Dan Corder
 class Strings_assertNotEqualsIgnoringWhitespace_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsNormalizingWhitespace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNotEqualsNormalizingWhitespace_Test.java
@@ -30,11 +30,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * Tests for <code>{@link org.assertj.core.internal.Strings#assertNotEqualsNormalizingWhitespace(org.assertj.core.api.AssertionInfo, CharSequence, CharSequence)} </code>.
- *
- * @author Dan Corder
- */
+/// Tests for [org.assertj.core.internal.Strings#assertNotEqualsNormalizingWhitespace(org.assertj.core.api.AssertionInfo,
+/// CharSequence, CharSequence)].
+///
+/// @author Dan Corder
 class Strings_assertNotEqualsNormalizingWhitespace_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertNullOrEmpty_Test.java
@@ -22,16 +22,13 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertNullOrEmpty(AssertionInfo, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertNullOrEmpty(AssertionInfo, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertNullOrEmpty_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertStartsWith_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/strings/Strings_assertStartsWith_Test.java
@@ -25,16 +25,13 @@ import static org.assertj.tests.core.testkit.TestData.someInfo;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Strings;
 import org.assertj.tests.core.internal.StringsBaseTest;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link Strings#assertStartsWith(AssertionInfo, CharSequence, CharSequence)}</code>.
- * 
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
+/// Tests for [Strings#assertStartsWith(AssertionInfo, CharSequence, CharSequence)].
+///
+/// @author Alex Ruiz
+/// @author Joel Costigliola
 class Strings_assertStartsWith_Test extends StringsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasCauseExactlyInstanceOf_Test.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jean-Christophe Gay
- */
+/// @author Jean-Christophe Gay
 class Throwables_assertHasCauseExactlyInstanceOf_Test extends ThrowablesBaseTest {
 
   private final Throwable throwableWithCause = new Throwable(new IllegalArgumentException());

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasCauseInstanceOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasCauseInstanceOf_Test.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jean-Christophe Gay
- */
+/// @author Jean-Christophe Gay
 class Throwables_assertHasCauseInstanceOf_Test extends ThrowablesBaseTest {
 
   private final Throwable throwableWithCause = new Throwable(new IllegalArgumentException());

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageContainingAll_Test.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Phillip Webb
- */
+/// @author Phillip Webb
 class Throwables_assertHasMessageContainingAll_Test extends ThrowablesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageContaining_Test.java
@@ -23,10 +23,8 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- * @author Phillip Webb
- */
+/// @author Joel Costigliola
+/// @author Phillip Webb
 class Throwables_assertHasMessageContaining_Test extends ThrowablesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageFindingMatch_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageFindingMatch_Test.java
@@ -24,9 +24,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author David Haccoun
- */
+/// @author David Haccoun
 class Throwables_assertHasMessageFindingMatch_Test extends ThrowablesBaseTest {
 
   private static final String REGEX = "waiting for Foo";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageMatching_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageMatching_Test.java
@@ -26,9 +26,7 @@ import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Libor Ondrusek
- */
+/// @author Libor Ondrusek
 class Throwables_assertHasMessageMatching_Test extends ThrowablesBaseTest {
 
   public static final String REGEX = "Given id='\\d{2,4}' not exists";

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageNotContainingAny_Test.java
@@ -24,9 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Phillip Webb
- */
+/// @author Phillip Webb
 class Throwables_assertHasMessageNotContainingAny_Test extends ThrowablesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageNotContaining_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasMessageNotContaining_Test.java
@@ -23,10 +23,8 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Sandra Parsick
- * @author Georg Berky
- */
+/// @author Sandra Parsick
+/// @author Georg Berky
 class Throwables_assertHasMessageNotContaining_Test extends ThrowablesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasRootCauseExactlyInstanceOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasRootCauseExactlyInstanceOf_Test.java
@@ -26,9 +26,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jean-Christophe Gay
- */
+/// @author Jean-Christophe Gay
 class Throwables_assertHasRootCauseExactlyInstanceOf_Test extends ThrowablesBaseTest {
 
   private static final Throwable throwableWithCause = new Throwable(new Exception(new IllegalArgumentException()));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasRootCauseInstanceOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasRootCauseInstanceOf_Test.java
@@ -26,9 +26,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jean-Christophe Gay
- */
+/// @author Jean-Christophe Gay
 class Throwables_assertHasRootCauseInstanceOf_Test extends ThrowablesBaseTest {
 
   private static final Throwable throwableWithCause = new Throwable(new Exception(new IllegalArgumentException()));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/throwables/Throwables_assertHasStackTraceContaining_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Daniel Zlotin
- */
+/// @author Daniel Zlotin
 class Throwables_assertHasStackTraceContaining_Test extends ThrowablesBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/UrisBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/UrisBaseTest.java
@@ -24,11 +24,9 @@ import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Uris;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * Base test class for {@link java.net.URI} tests.
- *
- * @author Alexander Bischof
- */
+/// Base test class for [java.net.URI] tests.
+///
+/// @author Alexander Bischof
 public abstract class UrisBaseTest {
 
   protected Failures failures;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/Uris_assertHasFragment_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/Uris_assertHasFragment_Test.java
@@ -26,13 +26,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Uris#assertHasFragment(org.assertj.core.api.AssertionInfo, java.net.URI, String)}  </code>
- * .
- *
- * @author Alexander Bischof
- */
+/// Tests for [org.assertj.core.internal.Uris#assertHasFragment(org.assertj.core.api.AssertionInfo, java.net.URI, String)].
+///
+/// @author Alexander Bischof
 class Uris_assertHasFragment_Test extends UrisBaseTest {
 
   @ParameterizedTest

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/Uris_assertHasQuery_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/uris/Uris_assertHasQuery_Test.java
@@ -24,13 +24,9 @@ import java.net.URI;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Uris#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URI, String)}  </code>
- * .
- *
- * @author Alexander Bischof
- */
+/// Tests for [org.assertj.core.internal.Uris#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URI, String)].
+///
+/// @author Alexander Bischof
 class Uris_assertHasQuery_Test extends UrisBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/urls/Urls_assertHasQuery_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/urls/Urls_assertHasQuery_Test.java
@@ -25,13 +25,9 @@ import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Urls#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URL, String)}  </code>
- * .
- *
- * @author Alexander Bischof
- */
+/// Tests for [org.assertj.core.internal.Urls#assertHasQuery(org.assertj.core.api.AssertionInfo, java.net.URL, String)].
+///
+/// @author Alexander Bischof
 class Urls_assertHasQuery_Test extends UrlsBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/urls/Urls_assertIsEqualToWithSortedQueryParameters_Test.java
@@ -21,18 +21,13 @@ import static org.mockito.Mockito.verify;
 
 import java.net.URL;
 
-import org.assertj.core.api.AssertionInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-/**
- * Tests for
- * <code>{@link org.assertj.core.internal.Urls#assertIsEqualToWithSortedQueryParameters(AssertionInfo, URL, URL)} (org.assertj.core.api.AssertionInfo, java.net.URL, java.net.URL)}  </code>
- * .
- *
- * @author SUN Ting
- */
+/// Tests for [org.assertj.core.internal.Urls#assertIsEqualToWithSortedQueryParameters(AssertionInfo, URL, URL)].
+///
+/// @author SUN Ting
 @DisplayName("assertIsEqualToWithSortedQueryParameters")
 class Urls_assertIsEqualToWithSortedQueryParameters_Test extends UrlsBaseTest {
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/matcher/AssertionMatcher_matches_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/matcher/AssertionMatcher_matches_Test.java
@@ -44,11 +44,9 @@ class AssertionMatcher_matches_Test {
 
   private boolean removeAssertJRelatedElementsFromStackTrace;
 
-  /**
-   * Stacktrace filtering must be disabled in order to check frames in
-   * {@link this#matcher_should_fill_description_when_assertion_fails()}.
-   * I use setUp and tearDown methods to ensure that it is set to original value after a test.
-   */
+  /// Stacktrace filtering must be disabled in order to check frames in
+  /// [#matcher_should_fill_description_when_assertion_fails()].
+  /// I use setUp and tearDown methods to ensure that it is set to original value after a test.
   @BeforeEach
   public void setUp() {
     removeAssertJRelatedElementsFromStackTrace = Failures.instance().isRemoveAssertJRelatedElementsFromStackTrace();
@@ -80,10 +78,8 @@ class AssertionMatcher_matches_Test {
     assertThat(isZeroMatcher.matches(ONE)).isFalse();
   }
 
-  /**
-   * {@link Failures#removeAssertJRelatedElementsFromStackTrace} must be set to true
-   * in order for this test to pass. It is in {@link this#setUp()}.
-   */
+  /// [Failures#removeAssertJRelatedElementsFromStackTrace] must be set to true
+  /// in order for this test to pass. It is in [#setUp()].
   @Test
   void matcher_should_fill_description_when_assertion_fails() {
     // WHEN

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/navigation/ClassBasedNavigableList_withDefault_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/navigation/ClassBasedNavigableList_withDefault_Test.java
@@ -23,9 +23,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests navigating a generated Assert class with a List property
- */
+/// Tests navigating a generated Assert class with a List property
 class ClassBasedNavigableList_withDefault_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/AbstractBaseRepresentationTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/AbstractBaseRepresentationTest.java
@@ -19,9 +19,7 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-/**
- * @author Filip Hrisafov
- */
+/// @author Filip Hrisafov
 abstract class AbstractBaseRepresentationTest {
 
   @BeforeEach

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/BooleanArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/BooleanArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class BooleanArrays {
   private static final boolean[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ByteArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ByteArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class ByteArrays {
   private static final byte[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/CaseInsensitiveCharSequenceComparator.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/CaseInsensitiveCharSequenceComparator.java
@@ -17,9 +17,7 @@ package org.assertj.tests.core.testkit;
 
 import java.util.Comparator;
 
-/**
- * @author Mikhail Mazursky
- */
+/// @author Mikhail Mazursky
 public class CaseInsensitiveCharSequenceComparator implements Comparator<CharSequence> {
 
   public static final CaseInsensitiveCharSequenceComparator INSTANCE = new CaseInsensitiveCharSequenceComparator();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/CharArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/CharArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class CharArrays {
   private static final char[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/DoubleArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/DoubleArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class DoubleArrays {
   private static final double[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Employee.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Employee.java
@@ -18,10 +18,8 @@ package org.assertj.tests.core.testkit;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Yvonne Wang
- * @author Joel Costigliola
- */
+/// @author Yvonne Wang
+/// @author Joel Costigliola
 public class Employee {
 
   // intentionally public to test retrieval of a public field that is not a property

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/EqualsHashCodeContractAssert.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/EqualsHashCodeContractAssert.java
@@ -17,63 +17,53 @@ package org.assertj.tests.core.testkit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Assertion methods that verify that an object's {@code equals} and {@code hashCode} are implemented correctly.
- *
- * @author Alex Ruiz
- */
+/// Assertion methods that verify that an object's `equals` and `hashCode` are implemented correctly.
+///
+/// @author Alex Ruiz
 public final class EqualsHashCodeContractAssert {
 
-  /**
-   * Verifies that the {@code equals} implementation of the given object is reflexive: the object must be equal to
-   * itself, which it would be at any given instance; unless you intentionally override the equals method to behave
-   * otherwise.
-   * @param obj the object to verify.
-   * @throws AssertionError if the {@code equals} implementation of the given object is reflexive.
-   */
+  /// Verifies that the `equals` implementation of the given object is reflexive: the object must be equal to
+  /// itself, which it would be at any given instance; unless you intentionally override the equals method to behave
+  /// otherwise.
+  /// @param obj the object to verify.
+  /// @throws AssertionError if the `equals` implementation of the given object is reflexive.
   public static void assertEqualsIsReflexive(Object obj) {
     assertThat(obj).isEqualTo(obj);
   }
 
-  /**
-   * Verifies that the {@code equals} implementation of the given objects is symmetric: if object of one class is equal
-   * to another class object, the other class object must be equal to this class object. In other words, one object can
-   * not unilaterally decide whether it is equal to another object; two objects, and consequently the classes to which
-   * they belong, must bilaterally decide if they are equal or not. They BOTH must agree.
-   * @param obj1 the object to verify.
-   * @param obj2 the object to compare to.
-   * @throws AssertionError if the {@code equals} implementation of the given object is not symmetric.
-   */
+  /// Verifies that the `equals` implementation of the given objects is symmetric: if object of one class is equal
+  /// to another class object, the other class object must be equal to this class object. In other words, one object can
+  /// not unilaterally decide whether it is equal to another object; two objects, and consequently the classes to which
+  /// they belong, must bilaterally decide if they are equal or not. They BOTH must agree.
+  /// @param obj1 the object to verify.
+  /// @param obj2 the object to compare to.
+  /// @throws AssertionError if the `equals` implementation of the given object is not symmetric.
   public static void assertEqualsIsSymmetric(Object obj1, Object obj2) {
     assertThat(obj1).isEqualTo(obj2);
     assertThat(obj2).isEqualTo(obj1);
   }
 
-  /**
-   * Verifies that the {@code equals} implementation of the given objects is transitive: if the first object is equal to
-   * the second object and the second object is equal to the third object; then the first object is equal to the third
-   * object. In other words, if two objects agree that they are equal, and follow the symmetry principle, one of them
-   * can not decide to have a similar contract with another object of different class. All three must agree and follow
-   * symmetry principle for various permutations of these three classes.
-   * @param obj1 the object to verify.
-   * @param obj2 an object to compare to.
-   * @param obj3 an object to compare to.
-   * @throws AssertionError if the {@code equals} implementation of the given objects is not transitive.
-   */
+  /// Verifies that the `equals` implementation of the given objects is transitive: if the first object is equal to
+  /// the second object and the second object is equal to the third object; then the first object is equal to the third
+  /// object. In other words, if two objects agree that they are equal, and follow the symmetry principle, one of them
+  /// can not decide to have a similar contract with another object of different class. All three must agree and follow
+  /// symmetry principle for various permutations of these three classes.
+  /// @param obj1 the object to verify.
+  /// @param obj2 an object to compare to.
+  /// @param obj3 an object to compare to.
+  /// @throws AssertionError if the `equals` implementation of the given objects is not transitive.
   public static void assertEqualsIsTransitive(Object obj1, Object obj2, Object obj3) {
     assertThat(obj1).isEqualTo(obj2);
     assertThat(obj2).isEqualTo(obj3);
     assertThat(obj1).isEqualTo(obj3);
   }
 
-  /**
-   * Verifies that the {@code equals}/{@code hashCode} contract of the given objects is implemented correctly: if two
-   * objects are equal, then they must have the same hash code, however the opposite is NOT true.
-   * @param obj1 the object to verify.
-   * @param obj2 the object to compare to.
-   * @throws AssertionError if the {@code equals}/{@code hashCode} contract of the given objects is not implemented
-   * correctly.
-   */
+  /// Verifies that the `equals`/`hashCode` contract of the given objects is implemented correctly: if two
+  /// objects are equal, then they must have the same hash code, however the opposite is NOT true.
+  /// @param obj1 the object to verify.
+  /// @param obj2 the object to compare to.
+  /// @throws AssertionError if the `equals`/`hashCode` contract of the given objects is not implemented
+  /// correctly.
   public static void assertMaintainsEqualsAndHashCodeContract(Object obj1, Object obj2) {
     assertThat(obj1).isEqualTo(obj2);
     assertThat(obj1.hashCode()).isEqualTo(obj2.hashCode());

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/EqualsHashCodeContractTestCase.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/EqualsHashCodeContractTestCase.java
@@ -15,51 +15,37 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * Test case that provides the contract for verification that an object's {@code equals} and {@code hashCode} are
- * implemented correctly.
- *
- * @author Alex Ruiz
- */
+/// Test case that provides the contract for verification that an object's `equals` and `hashCode` are
+/// implemented correctly.
+///
+/// @author Alex Ruiz
 public interface EqualsHashCodeContractTestCase {
 
   void should_not_be_equal_to_Object_of_different_type();
 
-  /**
-   * If two objects are equal, they must remain equal as long as they are not modified.
-   */
+  /// If two objects are equal, they must remain equal as long as they are not modified.
   void equals_should_be_consistent();
 
-  /**
-   * The object must be equal to itself, which it would be at any given instance; unless you intentionally override the
-   * equals method to behave otherwise.
-   */
+  /// The object must be equal to itself, which it would be at any given instance; unless you intentionally override the
+  /// equals method to behave otherwise.
   void equals_should_be_reflexive();
 
-  /**
-   * If object of one class is equal to another class object, the other class object must be equal to this class object.
-   * In other words, one object can not unilaterally decide whether it is equal to another object; two objects, and
-   * consequently the classes to which they belong, must bilaterally decide if they are equal or not. They BOTH must
-   * agree.
-   */
+  /// If object of one class is equal to another class object, the other class object must be equal to this class object.
+  /// In other words, one object can not unilaterally decide whether it is equal to another object; two objects, and
+  /// consequently the classes to which they belong, must bilaterally decide if they are equal or not. They BOTH must
+  /// agree.
   void equals_should_be_symmetric();
 
-  /**
-   * If the first object is equal to the second object and the second object is equal to the third object; then the
-   * first object is equal to the third object. In other words, if two objects agree that they are equal, and follow the
-   * symmetry principle, one of them can not decide to have a similar contract with another object of different class.
-   * All three must agree and follow symmetry principle for various permutations of these three classes.
-   */
+  /// If the first object is equal to the second object and the second object is equal to the third object; then the
+  /// first object is equal to the third object. In other words, if two objects agree that they are equal, and follow the
+  /// symmetry principle, one of them can not decide to have a similar contract with another object of different class.
+  /// All three must agree and follow symmetry principle for various permutations of these three classes.
   void equals_should_be_transitive();
 
-  /**
-   * If two objects are equal, then they must have the same hash code, however the opposite is NOT true.
-   */
+  /// If two objects are equal, then they must have the same hash code, however the opposite is NOT true.
   void should_maintain_equals_and_hashCode_contract();
 
-  /**
-   * Verifies that the implementation of the method {@code equals} returns {@code false} if a {@code null} is passed as
-   * argument.
-   */
+  /// Verifies that the implementation of the method `equals` returns `false` if a `null` is passed as
+  /// argument.
   void should_not_be_equal_to_null();
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/FloatArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/FloatArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class FloatArrays {
   private static final float[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/FluentJedi.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/FluentJedi.java
@@ -15,14 +15,9 @@
  */
 package org.assertj.tests.core.testkit;
 
-import org.assertj.core.api.AbstractIterableAssert;
-
-/**
- * Helper class for testing <code>{@link AbstractIterableAssert#extractingResultOf(String)}</code>.
- * 
- * @author Michał Piotrkowski
- *
- */
+/// Helper class for testing [AbstractIterableAssert#extractingResultOf(String)].
+///
+/// @author Michał Piotrkowski
 public class FluentJedi {
 
   private final Name name;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/IllegalVehicleAssert.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/IllegalVehicleAssert.java
@@ -17,9 +17,7 @@ package org.assertj.tests.core.testkit;
 
 import org.assertj.core.api.AbstractAssert;
 
-/**
- * The constructor is wrong, it must be public for reflection.
- */
+/// The constructor is wrong, it must be public for reflection.
 public class IllegalVehicleAssert extends AbstractAssert<IllegalVehicleAssert, Vehicle> {
 
   protected IllegalVehicleAssert(Vehicle actual) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/IntArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/IntArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class IntArrays {
   private static final int[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Jedi.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Jedi.java
@@ -17,12 +17,10 @@ package org.assertj.tests.core.testkit;
 
 import java.util.Random;
 
-/**
- * Object for test.
- *
- * @author Nicolas François
- * @author Joel Costigliola
- */
+/// Object for test.
+///
+/// @author Nicolas François
+/// @author Joel Costigliola
 public class Jedi extends Person {
 
   @SuppressWarnings("unused")

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/JediCondition.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/JediCondition.java
@@ -21,11 +21,9 @@ import java.util.Set;
 
 import org.assertj.core.api.Condition;
 
-/**
- * A {@code Condition} checking is a Jedi
- *
- * @author Nicolas François
- */
+/// A `Condition` checking is a Jedi
+///
+/// @author Nicolas François
 public class JediCondition extends Condition<String> {
 
   private final Set<String> jedis = newLinkedHashSet("Luke", "Yoda", "Obiwan");

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/JediPowerCondition.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/JediPowerCondition.java
@@ -15,11 +15,9 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * same as {@link JediCondition}, only the description is different, it works better on error message
- *
- * @author Nicolas François
- */
+/// same as [JediCondition], only the description is different, it works better on error message
+///
+/// @author Nicolas François
 public class JediPowerCondition extends JediCondition {
 
   public JediPowerCondition() {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/LongArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/LongArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class LongArrays {
   private static final long[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Maps.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Maps.java
@@ -22,9 +22,7 @@ import java.util.function.Supplier;
 
 import org.assertj.core.data.MapEntry;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class Maps {
 
   @SafeVarargs

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/MutatesGlobalConfiguration.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/MutatesGlobalConfiguration.java
@@ -26,14 +26,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Isolated;
 
-/**
- * An annotation for any test class that mutates the global configuration.
- *
- * <p>By using this annotation, any tests that mutate this configuration will have the configuration
- * reset to the default values after each test case runs.
- *
- * @author Ashley Scopes
- */
+/// An annotation for any test class that mutates the global configuration.
+///
+/// By using this annotation, any tests that mutate this configuration will have the configuration
+/// reset to the default values after each test case runs.
+///
+/// @author Ashley Scopes
 @ExtendWith(MutatesGlobalConfiguration.AssumptionMutatingExtension.class)
 @Isolated("Mutates global state")
 @Target(ElementType.TYPE)

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Name.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Name.java
@@ -20,10 +20,8 @@ import static java.util.Comparator.comparing;
 import java.util.Comparator;
 import java.util.Objects;
 
-/**
- * @author Yvonne Wang
- * @author Joel Costigliola
- */
+/// @author Yvonne Wang
+/// @author Joel Costigliola
 public class Name implements Comparable<Name> {
 
   public static final Comparator<Name> lastNameComparator = comparing(Name::getLast);

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/NavigationMethodBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/NavigationMethodBaseTest.java
@@ -26,11 +26,9 @@ import org.assertj.core.api.AbstractAssertWithComparator;
 import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 import org.junit.jupiter.api.Test;
 
-/**
- * Base tests for navigation methods which create a new assertion.
- *
- * @author Stefano Cordio
- */
+/// Base tests for navigation methods which create a new assertion.
+///
+/// @author Stefano Cordio
 public interface NavigationMethodBaseTest<ASSERT extends AbstractAssertWithComparator<ASSERT, ?>> {
 
   ASSERT getAssertion();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ObjectArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ObjectArrays.java
@@ -17,9 +17,7 @@ package org.assertj.tests.core.testkit;
 
 import java.util.List;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class ObjectArrays {
   private static final Object[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Person.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Person.java
@@ -17,11 +17,9 @@ package org.assertj.tests.core.testkit;
 
 import java.util.Objects;
 
-/**
- * A person.
- *
- * @author Alex Ruiz
- */
+/// A person.
+///
+/// @author Alex Ruiz
 public class Person implements Comparable<Person> {
 
   private final String name;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/PersonCaseInsensitiveNameComparator.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/PersonCaseInsensitiveNameComparator.java
@@ -17,11 +17,9 @@ package org.assertj.tests.core.testkit;
 
 import java.util.Comparator;
 
-/**
- * A {@link Person} comparator comparing name case insensitively.
- * 
- * @author Joel Costigliola
- */
+/// A [Person] comparator comparing name case insensitively.
+///
+/// @author Joel Costigliola
 public class PersonCaseInsensitiveNameComparator implements Comparator<Person> {
 
   @Override

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Player.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Player.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Joel Costigliola
- */
+/// @author Joel Costigliola
 public class Player {
 
   private Name name;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/PotentialMvpCondition.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/PotentialMvpCondition.java
@@ -17,12 +17,9 @@ package org.assertj.tests.core.testkit;
 
 import org.assertj.core.api.Condition;
 
-/**
- * 
- * A {@code Condition} checking if a {@link Player} is a potential MVP.
- * 
- * @author Joel Costigliola
- */
+/// A `Condition` checking if a [Player] is a potential MVP.
+///
+/// @author Joel Costigliola
 public class PotentialMvpCondition extends Condition<Player> {
 
   public PotentialMvpCondition() {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ShortArrays.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/ShortArrays.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Alex Ruiz
- */
+/// @author Alex Ruiz
 public final class ShortArrays {
   private static final short[] EMPTY = {};
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/StackTraceUtils.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/StackTraceUtils.java
@@ -22,12 +22,10 @@ import java.util.Arrays;
 
 public class StackTraceUtils {
 
-  /**
-   * Returns true if given {@link Throwable} stack trace contains AssertJ related elements, false otherwise.
-   *
-   * @param throwable the {@link Throwable} we want to check stack trace for AssertJ related elements.
-   * @return true if given {@link Throwable} stack trace contains AssertJ related elements, false otherwise.
-   */
+  /// Returns true if given [Throwable] stack trace contains AssertJ related elements, false otherwise.
+  ///
+  /// @param throwable the [Throwable] we want to check stack trace for AssertJ related elements.
+  /// @return true if given [Throwable] stack trace contains AssertJ related elements, false otherwise.
   public static boolean hasAssertJStackTraceElement(Throwable throwable) {
     return Arrays.stream(throwable.getStackTrace())
                  .anyMatch(stackTraceElement -> stackTraceElement.getClassName().contains("org.assertj.core"));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/StringSpliterator.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/StringSpliterator.java
@@ -18,11 +18,9 @@ package org.assertj.tests.core.testkit;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 
-/**
- * Dummy spliterator for testing purpose
- *
- * @author William Bakker
- */
+/// Dummy spliterator for testing purpose
+///
+/// @author William Bakker
 public class StringSpliterator implements Spliterator<String> {
   private final int characteristics;
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestClassWithRandomId.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestClassWithRandomId.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * Object for test with a private inaccessible field set a unique value.
- */
+/// Object for test with a private inaccessible field set a unique value.
 public class TestClassWithRandomId {
 
   private final long id;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestCondition.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestCondition.java
@@ -17,14 +17,12 @@ package org.assertj.tests.core.testkit;
 
 import org.assertj.core.api.Condition;
 
-/**
- * A <code>{@link Condition}</code> for testing.
- *
- * @param <T> the type of object this condition accepts.
- * @author Yvonne Wang
- * @author Alex Ruiz
- * @author Mikhail Mazursky
- */
+/// A [Condition] for testing.
+///
+/// @param T the type of object this condition accepts.
+/// @author Yvonne Wang
+/// @author Alex Ruiz
+/// @author Mikhail Mazursky
 public class TestCondition<T> extends Condition<T> {
 
   private boolean matches;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestData.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestData.java
@@ -25,10 +25,8 @@ import org.assertj.core.data.Index;
 import org.assertj.core.description.Description;
 import org.assertj.core.description.TextDescription;
 
-/**
- * @author Alex Ruiz
- * @author Yvonne Wang
- */
+/// @author Alex Ruiz
+/// @author Yvonne Wang
 public final class TestData {
 
   private static final WritableAssertionInfo ASSERTION_INFO = new WritableAssertionInfo();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestDescription.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TestDescription.java
@@ -17,11 +17,9 @@ package org.assertj.tests.core.testkit;
 
 import org.assertj.core.description.Description;
 
-/**
- * A description to be used for testing.
- * 
- * @author Alex Ruiz
- */
+/// A description to be used for testing.
+///
+/// @author Alex Ruiz
 public class TestDescription extends Description {
 
   private final String value;

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TypeCanonizer.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TypeCanonizer.java
@@ -30,23 +30,18 @@ import java.util.Set;
 
 import com.google.common.reflect.TypeResolver;
 
-/**
- * A Type canonizar that helps with the resolving of a {@link Type} so it can be compared to a similar one
- * considering generics.
- *
- * @author Filip Hrisafov
- * @author Clement Mathieu
- */
+/// A Type canonizar that helps with the resolving of a [Type] so it can be compared to a similar one
+/// considering generics.
+///
+/// @author Filip Hrisafov
+/// @author Clement Mathieu
 public class TypeCanonizer {
 
-  /**
-   * Returns a canonical form of {@code initialType} by replacing all {@link TypeVariable} by {@link Class}
-   * instances.
-   * <p>
-   * Such a canonical form allows to compare {@link ParameterizedType}s, {@link WildcardType}(s),
-   * {@link GenericArrayType}(s), {@link TypeVariable}(s).
-   * </p>
-   */
+  /// Returns a canonical form of `initialType` by replacing all [TypeVariable] by [Class]
+  /// instances.
+  ///
+  /// Such a canonical form allows to compare [ParameterizedType]s, [WildcardType](s),
+  /// [GenericArrayType](s), [TypeVariable](s).
   public static Type canonize(Type initialType) {
     if (doesNotNeedCanonization(initialType)) {
       return initialType;
@@ -71,22 +66,18 @@ public class TypeCanonizer {
              || type instanceof TypeVariable);
   }
 
-  /**
-   * @param type the type for which all type variables need to be extracted
-   * @return all {@code type}'s {@link TypeVariable}
-   */
+  /// @param type the type for which all type variables need to be extracted
+  /// @return all `type`'s [TypeVariable]
   private static Set<TypeVariable<?>> findAllTypeVariables(Type type) {
     Set<TypeVariable<?>> typeVariables = new LinkedHashSet<>();
     populateAllTypeVariables(typeVariables, type);
     return typeVariables;
   }
 
-  /**
-   * Adds all {@code type}'s {@link TypeVariable} to {@code typeVariables}
-   *
-   * @param typeVariables that need to be populated
-   * @param types         the types for which the {@link TypeVariable}(s) need to be extracted
-   */
+  /// Adds all `type`'s [TypeVariable] to `typeVariables`
+  ///
+  /// @param typeVariables that need to be populated
+  /// @param types the types for which the [TypeVariable](s) need to be extracted
   private static void populateAllTypeVariables(Set<TypeVariable<?>> typeVariables, Type... types) {
     for (Type type : types) {
       if (type instanceof ParameterizedType parameterizedType) {
@@ -102,15 +93,11 @@ public class TypeCanonizer {
     }
   }
 
-  /**
-   * Class that is used to supply replacement types for the canonization. The classes that are actually used have no
-   * meaning. Any random classes can be used to do the canonization. Only the order of the classes is important.
-   */
+  /// Class that is used to supply replacement types for the canonization. The classes that are actually used have no
+  /// meaning. Any random classes can be used to do the canonization. Only the order of the classes is important.
   private static class ReplacementClassSupplier {
 
-    /**
-     * Classes used as replacement types. The classes picked here are random classes, any class can be used.
-     */
+    /// Classes used as replacement types. The classes picked here are random classes, any class can be used.
     static List<Class<?>> REPLACEMENT_TYPES = List.of(String.class, Integer.class, Exception.class, InputStream.class,
                                                       System.class);
 
@@ -124,10 +111,8 @@ public class TypeCanonizer {
       this.classPool = new ArrayDeque<>(classPool);
     }
 
-    /**
-     * @return a class which has not yet been returned
-     * @throws IllegalStateException If the replacement class poll is exhausted
-     */
+    /// @return a class which has not yet been returned
+    /// @throws IllegalStateException If the replacement class poll is exhausted
     Class<?> get() {
       Class<?> clazz = classPool.poll();
       if (clazz == null) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TypeCanonizerTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/TypeCanonizerTest.java
@@ -29,10 +29,8 @@ import org.assertj.core.api.MapAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Filip Hrisafov
- * @author Clement Mathieu
- */
+/// @author Filip Hrisafov
+/// @author Clement Mathieu
 @SuppressWarnings("unused")
 class TypeCanonizerTest {
   private interface Asssert<T> {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Vehicle.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/Vehicle.java
@@ -15,9 +15,7 @@
  */
 package org.assertj.tests.core.testkit;
 
-/**
- * @author Marcus Klimstra (CGI)
- */
+/// @author Marcus Klimstra (CGI)
 public interface Vehicle {
   String getName();
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/VehicleFactory.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/VehicleFactory.java
@@ -18,11 +18,9 @@ package org.assertj.tests.core.testkit;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Used for testing property access of inner classes.
- * 
- * @author Marcus Klimstra (CGI)
- */
+/// Used for testing property access of inner classes.
+///
+/// @author Marcus Klimstra (CGI)
 public class VehicleFactory {
 
   public List<Vehicle> getVehicles() {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/junit/jupiter/params/converter/Hex.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/testkit/junit/jupiter/params/converter/Hex.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.converter.TypedArgumentConverter;
 
-/**
-* Annotation that allows converting string parameters of hexadecimal values into byte arrays.
-*/
+/// Annotation that allows converting string parameters of hexadecimal values into byte arrays.
 @Target(PARAMETER)
 @Retention(RUNTIME)
 @ConvertWith(Hex.HexArgumentConverter.class)

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/example/test/StandardRepresentation_MultipleAssertionsError_format_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/example/test/StandardRepresentation_MultipleAssertionsError_format_Test.java
@@ -30,10 +30,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * this is not in a org.assertj package to avoid assertj packages in the stack trace that is handled specifically and
- * does not reflect real users code.
- */
+/// this is not in a org.assertj package to avoid assertj packages in the stack trace that is handled specifically and
+/// does not reflect real users code.
 class StandardRepresentation_MultipleAssertionsError_format_Test {
 
   private static final StandardRepresentation REPRESENTATION = new StandardRepresentation();

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/example/test/Throwables_removeAssertJElementFromStackTrace_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/example/test/Throwables_removeAssertJElementFromStackTrace_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.tests.core.testkit.StackTraceUtils.hasAssertJStackTrac
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- */
+/// @author Joel Costigliola
 class Throwables_removeAssertJElementFromStackTrace_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_assertThat_with_Multimap_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_assertThat_with_Multimap_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-/**
- * @author Joel Costigliola
- */
+/// @author Joel Costigliola
 class Assertions_assertThat_with_Multimap_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_assertThat_with_Optional_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_assertThat_with_Optional_Test.java
@@ -23,9 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Optional;
 
-/**
- * @author Joel Costigliola
- */
+/// @author Joel Costigliola
 @SuppressWarnings("Guava")
 class Assertions_assertThat_with_Optional_Test {
 

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -44,10 +44,8 @@ import org.assertj.guava.api.RangeMapAssert;
 import org.assertj.guava.api.RangeSetAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Stefano Cordio
- * @since 3.3.0
- */
+/// @author Stefano Cordio
+/// @since 3.3.0
 class Assertions_sync_with_InstanceOfAssertFactories_Test {
 
   private static final Class<?>[] FIELD_FACTORIES_IGNORED_TYPES = {

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_hasSameContentAs_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_hasSameContentAs_Test.java
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.io.ByteSource;
 
-/**
- * @author Andrew Gaul
- */
+/// @author Andrew Gaul
 class ByteSourceAssert_hasSameContentAs_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_hasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_hasSize_Test.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.io.ByteSource;
 
-/**
- * Tests for <code>{@link org.assertj.guava.api.ByteSourceAssert#hasSize(long)}</code>.
- *
- * @author Andrew Gaul
- */
+/// Tests for [org.assertj.guava.api.ByteSourceAssert#hasSize(long)].
+///
+/// @author Andrew Gaul
 public class ByteSourceAssert_hasSize_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/ByteSourceAssert_isEmpty_Test.java
@@ -26,11 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.io.ByteSource;
 
-/**
- * Tests for <code>{@link ByteSource#isEmpty()}</code>.
- *
- * @author Andrew Gaul
- */
+/// Tests for [ByteSource#isEmpty()].
+///
+/// @author Andrew Gaul
 public class ByteSourceAssert_isEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/InstanceOfAssertFactoriesTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/InstanceOfAssertFactoriesTest.java
@@ -52,10 +52,8 @@ import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Range;
 import com.google.common.io.ByteSource;
 
-/**
- * @author Stefano Cordio
- * @since 3.3.0
- */
+/// @author Stefano Cordio
+/// @since 3.3.0
 class InstanceOfAssertFactoriesTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/MultimapAssert_hasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/MultimapAssert_hasSize_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Joel Costigliola
- */
+/// @author Joel Costigliola
 class MultimapAssert_hasSize_Test extends MultimapAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/MultisetAssert_containsAtLeast_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/MultisetAssert_containsAtLeast_Test.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 
-/**
- * @author Max Daniline
- */
+/// @author Max Daniline
 public class MultisetAssert_containsAtLeast_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_contains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_contains_Test.java
@@ -25,10 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Optional;
 
-/**
- * @author Kornel
- * @author Joel Costigliola
- */
+/// @author Kornel
+/// @author Joel Costigliola
 public class OptionalAssert_contains_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_isAbsent_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_isAbsent_Test.java
@@ -24,10 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Optional;
 
-/**
- * @author Kornel
- * @author Joel Costigliola
- */
+/// @author Kornel
+/// @author Joel Costigliola
 public class OptionalAssert_isAbsent_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_isPresent_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/OptionalAssert_isPresent_Test.java
@@ -24,10 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Optional;
 
-/**
- * @author Kornel
- * @author Joel Costigliola
- */
+/// @author Kornel
+/// @author Joel Costigliola
 public class OptionalAssert_isPresent_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_contains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_contains_Test.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 class RangeAssert_contains_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_doesNotContain_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_doesNotContain_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_doesNotContain_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasClosedLowerBound_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasClosedLowerBound_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_hasClosedLowerBound_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasClosedUpperBound_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasClosedUpperBound_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_hasClosedUpperBound_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasLowerEndpointEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasLowerEndpointEqualTo_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_hasLowerEndpointEqualTo_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasOpenedLowerBound_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasOpenedLowerBound_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_hasOpenedLowerBound_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasOpenedUpperBound_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_hasOpenedUpperBound_Test.java
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_hasOpenedUpperBound_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_isEmpty_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_isEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeAssert_isNotEmpty_Test.java
@@ -24,9 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Range;
 
-/**
- * @author Marcin Kwaczyński
- */
+/// @author Marcin Kwaczyński
 public class RangeAssert_isNotEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAll_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAll_Test.java
@@ -31,9 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_containsAll_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAnyOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAnyOf_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_containsAnyOf_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAnyRangesOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_containsAnyRangesOf_Test.java
@@ -33,9 +33,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_containsAnyRangesOf_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_contains_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_contains_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_contains_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_doesNotContainAll_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_doesNotContainAll_Test.java
@@ -34,9 +34,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_doesNotContainAll_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_doesNotContain_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_doesNotContain_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_doesNotContain_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAll_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAll_with_Iterable_Test.java
@@ -34,9 +34,7 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_intersectsAll_with_Iterable_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAll_with_RangeSet_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAll_with_RangeSet_Test.java
@@ -32,9 +32,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_intersectsAll_with_RangeSet_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAnyRangesOf_with_Iterable_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAnyRangesOf_with_Iterable_Test.java
@@ -34,9 +34,7 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_intersectsAnyRangesOf_with_Iterable_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAnyRangesOf_with_RangeSet_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersectsAnyRangesOf_with_RangeSet_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_intersectsAnyRangesOf_with_RangeSet_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersects_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_intersects_Test.java
@@ -33,9 +33,7 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_intersects_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isEmpty_Test.java
@@ -27,9 +27,7 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_isEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isNotEmpty_Test.java
@@ -27,9 +27,7 @@ import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 class RangeSetAssert_isNotEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isNullOrEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/RangeSetAssert_isNullOrEmpty_Test.java
@@ -26,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.RangeSet;
 
-/**
-  * @author Ilya Koshaleu
-  */
+/// @author Ilya Koshaleu
 class RangeSetAssert_isNullOrEmpty_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssertBaseTest.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssertBaseTest.java
@@ -20,9 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import com.google.common.collect.Table;
 import com.google.common.collect.TreeBasedTable;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssertBaseTest {
 
   protected Table<Integer, Integer, String> actual;

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_columnCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_columnCount_Test.java
@@ -25,9 +25,7 @@ import org.assertj.guava.api.TableAssert;
 import org.assertj.guava.api.TableIntegerAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Kucharczyk
- */
+/// @author Maciej Kucharczyk
 class TableAssert_columnCount_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsCells_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsCells_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert_containsCells_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsColumns_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsColumns_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert_containsColumns_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsRows_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsRows_Test.java
@@ -24,9 +24,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert_containsRows_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsValues_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_containsValues_Test.java
@@ -24,9 +24,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert_containsValues_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasColumnCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasColumnCount_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.error.TableShouldHaveColumnCount.tableShouldHave
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableAssert_hasColumnCount_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasRowCount_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.error.TableShouldHaveRowCount.tableShouldHaveRow
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableAssert_hasRowCount_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasSize_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_hasSize_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableAssert_hasSize_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isEmpty_Test.java
@@ -22,9 +22,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert_isEmpty_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_isNotEmpty_Test.java
@@ -23,9 +23,7 @@ import static org.assertj.guava.api.Assertions.assertThat;
 import org.assertj.guava.api.TableAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Kucharczyk
- */
+/// @author Maciej Kucharczyk
 class TableAssert_isNotEmpty_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_rowCount_Test.java
@@ -25,9 +25,7 @@ import org.assertj.guava.api.TableAssert;
 import org.assertj.guava.api.TableIntegerAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Kucharczyk
- */
+/// @author Maciej Kucharczyk
 class TableAssert_rowCount_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_size_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/api/TableAssert_size_Test.java
@@ -25,9 +25,7 @@ import org.assertj.guava.api.TableAssert;
 import org.assertj.guava.api.TableIntegerAssert;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Maciej Kucharczyk
- */
+/// @author Maciej Kucharczyk
 class TableAssert_size_Test extends TableAssertBaseTest {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldEncloseAnyOf_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldEncloseAnyOf_create_Test.java
@@ -26,15 +26,12 @@ import static org.assertj.guava.error.RangeSetShouldEncloseAnyOf.shouldEncloseAn
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldEncloseAnyOf;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldEncloseAnyOf#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- *
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldEncloseAnyOf#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldEncloseAnyOf_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldEnclose_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldEnclose_create_Test.java
@@ -27,15 +27,12 @@ import static org.assertj.guava.error.RangeSetShouldEnclose.shouldEnclose;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldEnclose;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldEnclose#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- * 
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldEnclose#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldEnclose_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldIntersectAnyOf_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldIntersectAnyOf_create_Test.java
@@ -26,15 +26,12 @@ import static org.assertj.guava.error.RangeSetShouldIntersectAnyOf.shouldInterse
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldIntersectAnyOf;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldIntersectAnyOf#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- *
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldIntersectAnyOf#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldIntersectAnyOf_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldIntersect_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldIntersect_create_Test.java
@@ -27,15 +27,12 @@ import static org.assertj.guava.error.RangeSetShouldIntersect.shouldIntersect;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldIntersect;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldIntersect#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- *
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldIntersect#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldIntersect_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldNotEnclose_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldNotEnclose_create_Test.java
@@ -27,15 +27,12 @@ import static org.assertj.guava.error.RangeSetShouldNotEnclose.shouldNotEnclose;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldNotEnclose;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldNotEnclose#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- *
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldNotEnclose#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldNotEnclose_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldNotIntersect_create_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-guava-tests/src/test/java/org/assertj/tests/guava/error/RangeSetShouldNotIntersect_create_Test.java
@@ -27,15 +27,12 @@ import static org.assertj.guava.error.RangeSetShouldNotIntersect.shouldNotInters
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.presentation.StandardRepresentation;
-import org.assertj.guava.error.RangeSetShouldNotIntersect;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for
- * <code>{@link RangeSetShouldNotIntersect#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>
- *
- * @author Ilya_Koshaleu
- */
+/// Tests for [RangeSetShouldNotIntersect#create(org.assertj.core.description.Description,
+/// org.assertj.core.presentation.Representation)]
+///
+/// @author Ilya_Koshaleu
 public class RangeSetShouldNotIntersect_create_Test {
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/Convert_JUnit5_Assertions_To_AssertJ_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/Convert_JUnit5_Assertions_To_AssertJ_Test.java
@@ -31,9 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author XiaoMingZHM, Eveneko
- */
+/// @author XiaoMingZHM, Eveneko
 class Convert_JUnit5_Assertions_To_AssertJ_Test {
 
   @TempDir

--- a/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/Convert_JUnit_Assertions_To_AssertJ_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/Convert_JUnit_Assertions_To_AssertJ_Test.java
@@ -30,9 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-/**
- * @author XiaoMingZHM, Eveneko
- */
+/// @author XiaoMingZHM, Eveneko
 class Convert_JUnit_Assertions_To_AssertJ_Test {
 
   @TempDir

--- a/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/ShellScriptExecutor.java
+++ b/assertj-tests/assertj-integration-tests/assertj-scripts/src/test/java/org/assertj/scripts/ShellScriptExecutor.java
@@ -20,9 +20,7 @@ import static org.assertj.core.util.Arrays.array;
 
 import java.nio.file.Path;
 
-/**
- * @author XiaoMingZHM, Eveneko
- */
+/// @author XiaoMingZHM, Eveneko
 class ShellScriptExecutor {
 
   static void execute(Path script, Path inputFile) throws Exception {

--- a/assertj-tests/assertj-performance-tests/src/test/java/org/assertj/tests/core/perf/ContainsOnlyPerfTest.java
+++ b/assertj-tests/assertj-performance-tests/src/test/java/org/assertj/tests/core/perf/ContainsOnlyPerfTest.java
@@ -25,21 +25,19 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-/**
- * These tests ensure assertThat(list_of_1m_elements).containsOnly(...) is an O(N) rather than O(N^2)
- * operation. Given that the list has 1 million elements, O(N^2) is O(1000 billion), which should
- * take from several dozens to several thousands seconds, given that the constant in the actual
- * complexity is low (which indeed is, in case of ArrayList, where the main contributor to the time
- * consumed by the operation is System.arraycopy()). O(N) is O(1 million), which should take perhaps
- * from one to a hundred milliseconds, depending on the frequency of the test machine, the JVM
- * version used, etc.
- * <p>
- * Therefore, 5 seconds (the limit used in the tests below) seems to be a good threshold that would
- * clearly distinguish .containsOnly(...) being O(N) or O(N^2) on any test agent, thus preventing
- * a regression of .containsOnly(...) back to O(N^2) complexity.
- *
- * @see <a href="https://github.com/assertj/assertj/issues/1718">assertj/assertj#1718</a>
- */
+/// These tests ensure assertThat(list_of_1m_elements).containsOnly(...) is an O(N) rather than O(N^2)
+/// operation. Given that the list has 1 million elements, O(N^2) is O(1000 billion), which should
+/// take from several dozens to several thousands seconds, given that the constant in the actual
+/// complexity is low (which indeed is, in case of ArrayList, where the main contributor to the time
+/// consumed by the operation is System.arraycopy()). O(N) is O(1 million), which should take perhaps
+/// from one to a hundred milliseconds, depending on the frequency of the test machine, the JVM
+/// version used, etc.
+///
+/// Therefore, 5 seconds (the limit used in the tests below) seems to be a good threshold that would
+/// clearly distinguish .containsOnly(...) being O(N) or O(N^2) on any test agent, thus preventing
+/// a regression of .containsOnly(...) back to O(N^2) complexity.
+///
+/// @see <a href="https://github.com/assertj/assertj/issues/1718">assertj/assertj#1718</a>
 class ContainsOnlyPerfTest {
 
   @Test

--- a/assertj-tests/assertj-performance-tests/src/test/java/org/assertj/tests/core/perf/SoftAssertionsPerfTest.java
+++ b/assertj-tests/assertj-performance-tests/src/test/java/org/assertj/tests/core/perf/SoftAssertionsPerfTest.java
@@ -54,14 +54,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-/**
- * results in 3.9.0  : ~3000ms
- * results in 3.9.1+ : ~9300ms
- * results in 3.10.0 : ~6000ms
- * results in 3.10.0 with Raphael changes < 1.8.10: ~5500ms
- * results in 3.10.0 with 1.8.10: ~5100ms
- * results in 3.10.0 with 1.8.11: ~5000ms
- */
+/// results in 3.9.0 : ~3000ms
+/// results in 3.9.1+ : ~9300ms
+/// results in 3.10.0 : ~6000ms
+/// results in 3.10.0 with Raphael changes < 1.8.10: ~5500ms
+/// results in 3.10.0 with 1.8.10: ~5100ms
+/// results in 3.10.0 with 1.8.11: ~5000ms
 @Disabled
 class SoftAssertionsPerfTest {
 


### PR DESCRIPTION
This is work on https://github.com/assertj/assertj/issues/3977 on modules supporting Java 23+.

Most of the changes were done with Openrewrite with several bugs fixed on the way.

Initial review was done by Claude followed by several fixes and a final manual review.

---

Blocked by:
* https://github.com/assertj/assertj/pull/4298