### PR TITLE
Migrate to Markdown Javadoc for `assertj-guava`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Project Context & Agent Guidelines
+
+This file defines the technical stack, development conventions, and documentation standards for this repository. All AI agents, code generators, and automated review tools must strictly adhere to these rules. If a more specific `AGENTS.md` exists deeper in the tree, follow that file for the narrower scope.
+
+## Technical Stack
+* **Build Toolchain**: Use JDK 25 or newer to build the project and generate documentation.
+* **Production Code Compatibility**: Target the language version declared in the `java.version` property of the root POM.
+  * Do *not* use preview features or APIs introduced in later Java versions.
+* **Dependency Management**: Maven 3.9.x (always use the wrapper via `./mvnw`).
+* **Testing Ecosystem**: JUnit, Mockito, and AssertJ.
+
+## Code & Testing Conventions
+
+### Visibility & Structure
+* Prefer `package-private` (no modifier) visibility for test classes and methods.
+* Write exactly one JUnit test class for each assertion method.
+* **Naming Convention**: Use `<AssertClass>_<assertion>_Test` for the class name.
+* **Method Names**: Use underscore-based (snake_case) naming rather than camelCase for unit test methods.
+
+### Test Architecture (GIVEN/WHEN/THEN)
+* Use explicit `GIVEN`, `WHEN`, and `THEN` comments in every test.
+* **Assertions**: Prefer `BDDAssertions.then` over `Assertions.assertThat` for assertions in the `THEN` step.
+* **Exception Testing**: Use `AssertionUtil.expectAssertionError` for tests expecting an `AssertionError`.
+* **Imports**: Use static imports when it improves code readability.
+
+### Reference Unit Test Example
+```java
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class OptionalAssert_containsInstanceOf_Test {
+
+  @Test
+  void should_fail_if_actual_is_empty() {
+    // GIVEN
+    Optional<Object> actual = Optional.empty();
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actual).containsInstanceOf(Object.class));
+    // THEN
+    then(assertionError).hasMessage(shouldBePresent(actual).create());
+  }
+
+  @Test
+  void should_pass_if_actual_contains_required_type() {
+    // GIVEN
+    Optional<String> actual = Optional.of("something");
+    // WHEN/THEN
+    assertThat(actual).containsInstanceOf(String.class);
+  }
+
+}
+```
+
+## Javadoc Rules (JDK 25 Markdown)
+
+Newly introduced or updated documentation comments must use Markdown and be accepted by the JDK 25 `javadoc` tool.
+
+### Syntax & Formatting
+
+* **Prefix**: Always use the `///` (three forward slashes) prefix for documentation comments instead of the traditional `/ ... */` block.
+* **Styling**: Use standard Markdown syntax (e.g., `bold`, `*italic*`, `[link](url)`). **Never use HTML tags** (such as `<p>`, `<ul>`, `<code>`).
+* **Line Breaks**: Use plain newlines to separate consecutive sentences or paragraphs in documentation comments. Do not use `<br>`; if you need a new paragraph, insert a blank line instead.
+* **Code Blocks**: Enclose code examples in fenced `java` code blocks. Do not use `<pre><code>` or inline `{@code ...}` for multi-line snippets.
+* **Lists**: Create lists using standard Markdown lists (`-` or `1.`).
+* **Block Tags**: Place standard Javadoc block tags (`@param`, `@return`, `@throws`) at the end of the comment block, formatting their accompanying descriptions in Markdown.
+
+### Referencing Program Elements (Links)
+
+Use the extended Markdown reference link syntax instead of traditional `{@link ...}` or `{@linkplain ...}` inline tags:
+
+* **Within the Same Class**: Reference local methods or fields directly in square brackets: `[#localMethod()]` or `[#localField]`.
+* **Other Classes and Packages**: Use simple names if imported `[String]`, fully qualified names if not `[java.util.List]`, or reference entire packages via `[java.util]`. If an import exists solely for Javadoc references, delete the import and use the fully qualified name instead.
+* **Members of Other Classes**: Join class and member using the `#` symbol: `[String#chars()]` or `[String#CASE_INSENSITIVE_ORDER]`.
+* **Methods with Varargs**: Use standard ellipsis notation inside the signature: `[String#format(String, Object...)]`.
+* **Custom Link Text**: Use the `[alternative text][Element]` syntax.
+* **Escaping Brackets**: Escape array parameter brackets with backslashes: `[String#copyValueOf(char\[\])]`.
+
+## Build & Run Commands
+
+Use the Maven wrapper for the following verification and formatting commands:
+
+* **License Headers**: `./mvnw license:format` to add or update license headers.
+* **Code Formatting**: `./mvnw spotless:apply` to format code and optimize imports.
+* **Verification**: `./mvnw clean verify` to ensure all tests pass.
+* **Documentation**: `./mvnw clean  javadoc:javadoc` to generate Javadoc documentation.
+
+## Strict Restrictions (Do Not)
+
+* **No Kotlin**: Do not suggest Kotlin alternatives or mix Kotlin into the codebase, except for test code in the `assertj-tests/assertj-integration-tests/assertj-core-kotlin` module.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Use the Maven wrapper for the following verification and formatting commands:
 * **License Headers**: `./mvnw license:format` to add or update license headers.
 * **Code Formatting**: `./mvnw spotless:apply` to format code and optimize imports.
 * **Verification**: `./mvnw clean verify` to ensure all tests pass.
-* **Documentation**: `./mvnw clean  javadoc:javadoc` to generate Javadoc documentation.
+* **Documentation**: `./mvnw clean javadoc:javadoc` to generate Javadoc documentation.
 
 ## Strict Restrictions (Do Not)
 

--- a/assertj-guava/src/main/java/org/assertj/guava/api/Assertions.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/Assertions.java
@@ -26,18 +26,16 @@ import com.google.common.collect.RangeSet;
 import com.google.common.collect.Table;
 import com.google.common.io.ByteSource;
 
-/**
- * The entry point for all Guava assertions.
- *
- * @author marcelfalliere
- * @author miralak
- * @author Kornel
- * @author Jan Gorman
- * @author Joel Costigliola
- * @author Marcin Kwaczyński
- * @author Max Daniline
- * @author Ilya Koshaleu
- */
+/// The entry point for all Guava assertions.
+///
+/// @author marcelfalliere
+/// @author miralak
+/// @author Kornel
+/// @author Jan Gorman
+/// @author Joel Costigliola
+/// @author Marcin Kwaczyński
+/// @author Max Daniline
+/// @author Ilya Koshaleu
 public class Assertions implements InstanceOfAssertFactories {
 
   public static ByteSourceAssert assertThat(final ByteSource actual) {
@@ -76,32 +74,30 @@ public class Assertions implements InstanceOfAssertFactories {
   // Data utility methods : not assertions but here to have a single entry point to all AssertJ Guava features.
   // ------------------------------------------------------------------------------------------------------
 
-  /**
-   * Only delegate to {@link MapEntry#entry(Object, Object)} so that Assertions offers a fully featured entry point to all
-   * AssertJ Guava features (but you can use {@link MapEntry} if you prefer).
-   * <p>
-   * Typical usage is to call <code>entry</code> in MultimapAssert <code>contains</code> assertion as shown below :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   * actual.putAll(&quot;Lakers&quot;, newArrayList(&quot;Kobe Bryant&quot;, &quot;Magic Johnson&quot;, &quot;Kareem Abdul Jabbar&quot;));
-   * actual.putAll(&quot;Spurs&quot;, newArrayList(&quot;Tony Parker&quot;, &quot;Tim Duncan&quot;, &quot;Manu Ginobili&quot;));
-   *
-   * assertThat(actual).contains(entry(&quot;Lakers&quot;, &quot;Kobe Bryant&quot;), entry(&quot;Spurs&quot;, &quot;Tim Duncan&quot;)); </code></pre>
-   *
-   * @param <K> the type of the key of this entry.
-   * @param <V> the type of the value of this entry.
-   * @param key the key of the entry to create.
-   * @param value the value of the entry to create.
-   *
-   * @return the built entry
-   */
+  /// Only delegate to [MapEntry#entry(Object, Object)] so that Assertions offers a fully featured entry point to all
+  /// AssertJ Guava features (but you can use [MapEntry] if you prefer).
+  ///
+  /// Typical usage is to call `entry` in MultimapAssert `contains` assertion as shown below :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  /// actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  ///
+  /// assertThat(actual).contains(entry("Lakers", "Kobe Bryant"), entry("Spurs", "Tim Duncan"));
+  /// ```
+  ///
+  /// @param <K> the type of the key of this entry.
+  /// @param <V> the type of the value of this entry.
+  /// @param key the key of the entry to create.
+  /// @param value the value of the entry to create.
+  ///
+  /// @return the built entry
   public static <K, V> MapEntry<K, V> entry(K key, V value) {
     return MapEntry.entry(key, value);
   }
 
-  /**
-   * protected to avoid direct instantiation but allowing subclassing.
-   */
+  /// protected to avoid direct instantiation but allowing subclassing.
   protected Assertions() {
     // empty
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/api/ByteSourceAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/ByteSourceAssert.java
@@ -25,70 +25,68 @@ import org.assertj.core.api.AbstractAssert;
 
 import com.google.common.io.ByteSource;
 
-/**
- * Assertions for Guava {@link ByteSource}.
- *
- * @author Andrew Gaul
- */
+/// Assertions for Guava [ByteSource].
+///
+/// @author Andrew Gaul
 public class ByteSourceAssert extends AbstractAssert<ByteSourceAssert, ByteSource> {
 
   protected ByteSourceAssert(ByteSource actual) {
     super(actual, ByteSourceAssert.class);
   }
 
-  /**
-   * Verifies that the actual {@link ByteSource} has the same content as the provided one.<br>
-   * <p>
-   * Example :
-   * <pre><code class='java'> ByteSource actual = ByteSource.wrap(new byte[1]);
-   * ByteSource other = ByteSource.wrap(new byte[1]);
-   *
-   * assertThat(actual).hasSameContentAs(other);</code></pre>
-   *
-   * @param other ByteSource to compare against.
-   * @return this {@link ByteSourceAssert} for assertions chaining.
-   * @throws IOException    if {@link ByteSource#contentEquals} throws one.
-   * @throws AssertionError if the actual {@link ByteSource} is {@code null}.
-   * @throws AssertionError if the actual {@link ByteSource} does not contain the same content.
-   */
+  /// Verifies that the actual [ByteSource] has the same content as the provided one.
+  ///
+  /// Example :
+  /// ```java
+  /// ByteSource actual = ByteSource.wrap(new byte[1]);
+  /// ByteSource other = ByteSource.wrap(new byte[1]);
+  ///
+  /// assertThat(actual).hasSameContentAs(other);
+  /// ```
+  ///
+  /// @param other ByteSource to compare against.
+  /// @return this [ByteSourceAssert] for assertions chaining.
+  /// @throws IOException    if [ByteSource#contentEquals] throws one.
+  /// @throws AssertionError if the actual [ByteSource] is `null`.
+  /// @throws AssertionError if the actual [ByteSource] does not contain the same content.
   public ByteSourceAssert hasSameContentAs(ByteSource other) throws IOException {
     isNotNull();
     if (!actual.contentEquals(other)) throw assertionError(shouldHaveSameContent(actual, other));
     return this;
   }
 
-  /**
-   * Verifies that the actual {@link ByteSource} is empty.
-   * <p>
-   * Example :
-   * <pre><code class='java'> ByteSource actual = ByteSource.wrap(new byte[0]);
-   *
-   * assertThat(actual).isEmpty();</code></pre>
-   *
-   * @throws IOException    if {@link ByteSource#isEmpty} throws one.
-   * @throws AssertionError if the actual {@link ByteSource} is {@code null}.
-   * @throws AssertionError if the actual {@link ByteSource} is not empty.
-   */
+  /// Verifies that the actual [ByteSource] is empty.
+  ///
+  /// Example :
+  /// ```java
+  /// ByteSource actual = ByteSource.wrap(new byte[0]);
+  ///
+  /// assertThat(actual).isEmpty();
+  /// ```
+  ///
+  /// @throws IOException    if [ByteSource#isEmpty] throws one.
+  /// @throws AssertionError if the actual [ByteSource] is `null`.
+  /// @throws AssertionError if the actual [ByteSource] is not empty.
   public void isEmpty() throws IOException {
     isNotNull();
     if (!actual.isEmpty()) throw assertionError(shouldBeEmpty(actual));
   }
 
-  /**
-   * Verifies that the size of the actual {@link ByteSource} is equal to the given one.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> ByteSource actual = ByteSource.wrap(new byte[9]);
-   *
-   * assertThat(actual).hasSize(9);</code></pre>
-   *
-   * @param expectedSize the expected size of actual {@link ByteSource}.
-   * @return this {@link ByteSourceAssert} for assertions chaining.
-   * @throws IOException    if {@link com.google.common.io.ByteSource#size()} throws one.
-   * @throws AssertionError if the actual {@link ByteSource} is {@code null}.
-   * @throws AssertionError if the number of values of the actual {@link ByteSource} is not equal to the given one.
-   */
+  /// Verifies that the size of the actual [ByteSource] is equal to the given one.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// ByteSource actual = ByteSource.wrap(new byte[9]);
+  ///
+  /// assertThat(actual).hasSize(9);
+  /// ```
+  ///
+  /// @param expectedSize the expected size of actual [ByteSource].
+  /// @return this [ByteSourceAssert] for assertions chaining.
+  /// @throws IOException    if [com.google.common.io.ByteSource#size()] throws one.
+  /// @throws AssertionError if the actual [ByteSource] is `null`.
+  /// @throws AssertionError if the number of values of the actual [ByteSource] is not equal to the given one.
   public ByteSourceAssert hasSize(long expectedSize) throws IOException {
     isNotNull();
     long sizeOfActual = actual.size();

--- a/assertj-guava/src/main/java/org/assertj/guava/api/InstanceOfAssertFactories.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/InstanceOfAssertFactories.java
@@ -26,151 +26,125 @@ import com.google.common.collect.RangeSet;
 import com.google.common.collect.Table;
 import com.google.common.io.ByteSource;
 
-/**
- * {@link InstanceOfAssertFactory} instances for Guava types.
- *
- * @author Stefano Cordio
- * @since 3.3.0
- * @see org.assertj.core.api.InstanceOfAssertFactories
- */
+/// [InstanceOfAssertFactory] instances for Guava types.
+///
+/// @author Stefano Cordio
+/// @since 3.3.0
+/// @see org.assertj.core.api.InstanceOfAssertFactories
 public interface InstanceOfAssertFactories {
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link ByteSource}.
-   */
+  /// [InstanceOfAssertFactory] for a [ByteSource].
   InstanceOfAssertFactory<ByteSource, ByteSourceAssert> BYTE_SOURCE = new InstanceOfAssertFactory<>(ByteSource.class,
                                                                                                     Assertions::assertThat);
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Multimap}, assuming {@code Object} as key and value types.
-   *
-   * @see #multimap(Class, Class)
-   */
+  /// [InstanceOfAssertFactory] for a [Multimap], assuming `Object` as key and value types.
+  ///
+  /// @see #multimap(Class, Class)
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
   InstanceOfAssertFactory<Multimap, MultimapAssert<Object, Object>> MULTIMAP = multimap(Object.class, Object.class);
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Multimap}.
-   *
-   * @param <K>       the {@code Multimap} key type.
-   * @param <V>       the {@code Multimap} value type.
-   * @param keyType   the key type instance.
-   * @param valueType the value type instance.
-   * @return the factory instance.
-   *
-   * @see #MULTIMAP
-   */
+  /// [InstanceOfAssertFactory] for a [Multimap].
+  ///
+  /// @param <K>       the `Multimap` key type.
+  /// @param <V>       the `Multimap` value type.
+  /// @param keyType   the key type instance.
+  /// @param valueType the value type instance.
+  /// @return the factory instance.
+  ///
+  /// @see #MULTIMAP
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <K, V> InstanceOfAssertFactory<Multimap, MultimapAssert<K, V>> multimap(Class<K> keyType, Class<V> valueType) {
     return new InstanceOfAssertFactory<>(Multimap.class, Assertions::<K, V> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for an {@link Optional}, assuming {@code Object} as value type.
-   *
-   * @see #optional(Class)
-   */
+  /// [InstanceOfAssertFactory] for an [Optional], assuming `Object` as value type.
+  ///
+  /// @see #optional(Class)
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
   InstanceOfAssertFactory<Optional, OptionalAssert<Object>> OPTIONAL = optional(Object.class);
 
-  /**
-   * {@link InstanceOfAssertFactory} for an {@link Optional}.
-   *
-   * @param <VALUE>    the {@code Optional} value type.
-   * @param resultType the value type instance.
-   * @return the factory instance.
-   *
-   * @see #OPTIONAL
-   */
+  /// [InstanceOfAssertFactory] for an [Optional].
+  ///
+  /// @param <VALUE>    the `Optional` value type.
+  /// @param resultType the value type instance.
+  /// @return the factory instance.
+  ///
+  /// @see #OPTIONAL
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <VALUE> InstanceOfAssertFactory<Optional, OptionalAssert<VALUE>> optional(Class<VALUE> resultType) {
     return new InstanceOfAssertFactory<>(Optional.class, Assertions::<VALUE> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Range}.
-   *
-   * @param <C>            the {@code Comparable} type.
-   * @param comparableType the comparable type instance.
-   * @return the factory instance.
-   */
+  /// [InstanceOfAssertFactory] for a [Range].
+  ///
+  /// @param <C>            the `Comparable` type.
+  /// @param comparableType the comparable type instance.
+  /// @return the factory instance.
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <C extends Comparable<C>> InstanceOfAssertFactory<Range, RangeAssert<C>> range(Class<C> comparableType) {
     return new InstanceOfAssertFactory<>(Range.class, Assertions::<C> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link RangeMap}.
-   *
-   * @param <K>       the {@code RangeMap} key type.
-   * @param <V>       the {@code RangeMap} value type.
-   * @param keyType   the key type instance.
-   * @param valueType the value type instance.
-   * @return the factory instance.
-   */
+  /// [InstanceOfAssertFactory] for a [RangeMap].
+  ///
+  /// @param <K>       the `RangeMap` key type.
+  /// @param <V>       the `RangeMap` value type.
+  /// @param keyType   the key type instance.
+  /// @param valueType the value type instance.
+  /// @return the factory instance.
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <K extends Comparable<K>, V> InstanceOfAssertFactory<RangeMap, RangeMapAssert<K, V>> rangeMap(Class<K> keyType,
                                                                                                        Class<V> valueType) {
     return new InstanceOfAssertFactory<>(RangeMap.class, Assertions::<K, V> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link RangeSet}.
-   *
-   * @param comparableType the comparable type instance.
-   * @param <T> the {@code Comparable} type.
-   * @return the factory instance
-   */
+  /// [InstanceOfAssertFactory] for a [RangeSet].
+  ///
+  /// @param comparableType the comparable type instance.
+  /// @param <T> the `Comparable` type.
+  /// @return the factory instance
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <T extends Comparable<T>> InstanceOfAssertFactory<RangeSet, RangeSetAssert<T>> rangeSet(Class<T> comparableType) {
     return new InstanceOfAssertFactory<>(RangeSet.class, Assertions::<T> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Table}, assuming {@code Object} as row key type, column key type and
-   * value type.
-   *
-   * @see #table(Class, Class, Class)
-   */
+  /// [InstanceOfAssertFactory] for a [Table], assuming `Object` as row key type, column key type and
+  /// value type.
+  ///
+  /// @see #table(Class, Class, Class)
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
   InstanceOfAssertFactory<Table, TableAssert<Object, Object, Object>> TABLE = table(Object.class, Object.class, Object.class);
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Table}.
-   *
-   * @param <R>           the {@code Table} row key type.
-   * @param <C>           the {@code Table} column key type.
-   * @param <V>           the {@code Table} value type.
-   * @param rowKeyType    the row key type instance.
-   * @param columnKeyType the column key type instance.
-   * @param valueType     the value type instance.
-   * @return the factory instance.
-   *
-   * @see #TABLE
-   */
+  /// [InstanceOfAssertFactory] for a [Table].
+  ///
+  /// @param <R>           the `Table` row key type.
+  /// @param <C>           the `Table` column key type.
+  /// @param <V>           the `Table` value type.
+  /// @param rowKeyType    the row key type instance.
+  /// @param columnKeyType the column key type instance.
+  /// @param valueType     the value type instance.
+  /// @return the factory instance.
+  ///
+  /// @see #TABLE
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <R, C, V> InstanceOfAssertFactory<Table, TableAssert<R, C, V>> table(Class<R> rowKeyType, Class<C> columnKeyType,
                                                                               Class<V> valueType) {
     return new InstanceOfAssertFactory<>(Table.class, Assertions::<R, C, V> assertThat);
   }
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Multiset}, assuming {@code Object} as element type.
-   *
-   * @see #multiset(Class)
-   */
+  /// [InstanceOfAssertFactory] for a [Multiset], assuming `Object` as element type.
+  ///
+  /// @see #multiset(Class)
   @SuppressWarnings("rawtypes") // rawtypes: using Class instance
   InstanceOfAssertFactory<Multiset, MultisetAssert<Object>> MULTISET = multiset(Object.class);
 
-  /**
-   * {@link InstanceOfAssertFactory} for a {@link Multiset}.
-   *
-   * @param <ELEMENT>   the {@code Multiset} element type.
-   * @param elementType the element type instance.
-   * @return the factory instance.
-   *
-   * @see #MULTISET
-   */
+  /// [InstanceOfAssertFactory] for a [Multiset].
+  ///
+  /// @param <ELEMENT>   the `Multiset` element type.
+  /// @param elementType the element type instance.
+  /// @return the factory instance.
+  ///
+  /// @see #MULTISET
   @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
   static <ELEMENT> InstanceOfAssertFactory<Multiset, MultisetAssert<ELEMENT>> multiset(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(Multiset.class, Assertions::<ELEMENT> assertThat);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -40,13 +40,11 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 
-/**
- * Assertions for guava {@link Multimap}.
- *
- * @author marcelfalliere
- * @author miralak
- * @author Joel Costigliola
- */
+/// Assertions for guava [Multimap].
+///
+/// @author marcelfalliere
+/// @author miralak
+/// @author Joel Costigliola
 public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, Multimap<K, V>> {
 
   protected MultimapAssert(Multimap<K, V> actual) {
@@ -58,28 +56,27 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     return actual;
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} contains the given keys.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   *
-   * actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
-   * actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * assertThat(actual).containsKeys(&quot;Lakers&quot;, &quot;Bulls&quot;);</code></pre>
-   * <p>
-   * If the <code>keys</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param keys the keys to look for in actual {@link Multimap}.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param keys have been set.
-   * @throws AssertionError           if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError           if the actual {@link Multimap} does not contain the given keys.
-   */
+  /// Verifies that the actual [Multimap] contains the given keys.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  ///
+  /// actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// assertThat(actual).containsKeys("Lakers", "Bulls");
+  /// ```
+  ///
+  /// If the `keys` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param keys the keys to look for in actual [Multimap].
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param keys have been set.
+  /// @throws AssertionError           if the actual [Multimap] is `null`.
+  /// @throws AssertionError           if the actual [Multimap] does not contain the given keys.
   public MultimapAssert<K, V> containsKeys(@SuppressWarnings("unchecked") K... keys) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(keys == null, "The keys to look for should not be null");
@@ -97,29 +94,28 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} contains the given entries.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   *
-   * actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
-   * actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * // entry can be statically imported from org.assertj.guava.api.Assertions or org.assertj.guava.data.MapEntry
-   * assertThat(actual).contains(entry("Lakers", "Kobe Bryant"), entry("Spurs", "Tim Duncan"));</code></pre>
-   * <p>
-   * If the <code>entries</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param entries the entries to look for in actual {@link Multimap}.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param entries have been set.
-   * @throws AssertionError           if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError           if the actual {@link Multimap} does not contain the given entries.
-   */
+  /// Verifies that the actual [Multimap] contains the given entries.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  ///
+  /// actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// // entry can be statically imported from org.assertj.guava.api.Assertions or org.assertj.guava.data.MapEntry
+  /// assertThat(actual).contains(entry("Lakers", "Kobe Bryant"), entry("Spurs", "Tim Duncan"));
+  /// ```
+  ///
+  /// If the `entries` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param entries the entries to look for in actual [Multimap].
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param entries have been set.
+  /// @throws AssertionError           if the actual [Multimap] is `null`.
+  /// @throws AssertionError           if the actual [Multimap] does not contain the given entries.
   @SafeVarargs
   public final MultimapAssert<K, V> contains(MapEntry<K, V>... entries) {
     isNotNull();
@@ -138,29 +134,28 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} contains the given values for any key.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   *
-   * actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
-   * actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * // note that given values are not linked to same key
-   * assertThat(actual).containsValues(&quot;Kobe Bryant&quot;, &quot;Michael Jordan&quot;);</code></pre>
-   * <p>
-   * If the <code>values</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param values the values to look for in actual {@link Multimap}.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param values have been set.
-   * @throws AssertionError           if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError           if the actual {@link Multimap} does not contain the given values.
-   */
+  /// Verifies that the actual [Multimap] contains the given values for any key.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  ///
+  /// actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// // note that given values are not linked to same key
+  /// assertThat(actual).containsValues("Kobe Bryant", "Michael Jordan");
+  /// ```
+  ///
+  /// If the `values` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param values the values to look for in actual [Multimap].
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param values have been set.
+  /// @throws AssertionError           if the actual [Multimap] is `null`.
+  /// @throws AssertionError           if the actual [Multimap] does not contain the given values.
   public MultimapAssert<K, V> containsValues(@SuppressWarnings("unchecked") V... values) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(values == null, "The values to look for should not be null");
@@ -178,19 +173,18 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} is empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   *
-   * assertThat(actual).isEmpty();</code></pre>
-   *
-   * @throws AssertionError if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError if the actual {@link Multimap} is not empty.
-   */
+  /// Verifies that the actual [Multimap] is empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  ///
+  /// assertThat(actual).isEmpty();
+  /// ```
+  ///
+  /// @throws AssertionError if the actual [Multimap] is `null`.
+  /// @throws AssertionError if the actual [Multimap] is not empty.
   public void isEmpty() {
     isNotNull();
     if (!actual.isEmpty()) {
@@ -198,21 +192,20 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     }
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} is not empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   * nba.put("Bulls", "Derrick Rose");
-   * nba.put("Bulls", "Joachim Noah");
-   *
-   * assertThat(nba).isNotEmpty();</code></pre>
-   *
-   * @throws AssertionError if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError if the actual {@link Multimap} is empty.
-   */
+  /// Verifies that the actual [Multimap] is not empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  /// nba.put("Bulls", "Derrick Rose");
+  /// nba.put("Bulls", "Joachim Noah");
+  ///
+  /// assertThat(nba).isNotEmpty();
+  /// ```
+  ///
+  /// @throws AssertionError if the actual [Multimap] is `null`.
+  /// @throws AssertionError if the actual [Multimap] is empty.
   public void isNotEmpty() {
     isNotNull();
     if (actual.isEmpty()) {
@@ -220,25 +213,24 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     }
   }
 
-  /**
-   * Verifies that the number of values in the actual {@link Multimap} is equal to the given one.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   *
-   * actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
-   * actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * assertThat(actual).hasSize(9);</code></pre>
-   *
-   * @param expectedSize the expected size of actual {@link Multimap}.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link Multimap} is {@code null}.
-   * @throws AssertionError if the number of values of the actual {@link Multimap} is not equal to the given one.
-   */
+  /// Verifies that the number of values in the actual [Multimap] is equal to the given one.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  ///
+  /// actual.putAll("Lakers", newArrayList("Kobe Bryant", "Magic Johnson", "Kareem Abdul Jabbar"));
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// assertThat(actual).hasSize(9);
+  /// ```
+  ///
+  /// @param expectedSize the expected size of actual [Multimap].
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [Multimap] is `null`.
+  /// @throws AssertionError if the number of values of the actual [Multimap] is not equal to the given one.
   public MultimapAssert<K, V> hasSize(int expectedSize) {
     isNotNull();
     int sizeOfActual = actual.size();
@@ -248,33 +240,33 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     throw assertionError(shouldHaveSize(actual, sizeOfActual, expectedSize));
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} has the same entries as the given one.<br>
-   * It allows to compare two multimaps having the same content but who are not equal because being of different types
-   * like {@link SetMultimap} and {@link ListMultimap}.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   * listMultimap.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * listMultimap.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * Multimap&lt;String, String&gt; setMultimap = TreeMultimap.create();
-   * setMultimap.putAll("Spurs", newHashSet("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * setMultimap.putAll("Bulls", newHashSet("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * // assertion will pass as listMultimap and setMultimap have the same content
-   * assertThat(listMultimap).hasSameEntriesAs(setMultimap);
-   *
-   * // this assertion FAILS even though both multimaps have the same content
-   * assertThat(listMultimap).isEqualTo(setMultimap);</code></pre>
-   *
-   * @param other {@link Multimap} to compare actual's entries with.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws AssertionError           if the actual {@link Multimap} is {@code null}.
-   * @throws IllegalArgumentException if the other {@link Multimap} is {@code null}.
-   * @throws AssertionError           if actual {@link Multimap} does not have the same entries as the other {@link Multimap}.
-   */
+  /// Verifies that the actual [Multimap] has the same entries as the given one.
+  /// It allows to compare two multimaps having the same content but who are not equal because being of different types
+  /// like [SetMultimap] and [ListMultimap].
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  /// listMultimap.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// listMultimap.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// Multimap<String, String> setMultimap = TreeMultimap.create();
+  /// setMultimap.putAll("Spurs", newHashSet("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// setMultimap.putAll("Bulls", newHashSet("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// // assertion will pass as listMultimap and setMultimap have the same content
+  /// assertThat(listMultimap).hasSameEntriesAs(setMultimap);
+  ///
+  /// // this assertion FAILS even though both multimaps have the same content
+  /// assertThat(listMultimap).isEqualTo(setMultimap);
+  /// ```
+  ///
+  /// @param other [Multimap] to compare actual's entries with.
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws AssertionError           if the actual [Multimap] is `null`.
+  /// @throws IllegalArgumentException if the other [Multimap] is `null`.
+  /// @throws AssertionError           if actual [Multimap] does not have the same entries as the other [Multimap].
   public final MultimapAssert<K, V> hasSameEntriesAs(Multimap<? extends K, ? extends V> other) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(other == null, "The multimap to compare actual with should not be null");
@@ -285,31 +277,31 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     throw assertionError(shouldContainOnly(actual, other, entriesNotFoundInActual, entriesNotExpectedInActual));
   }
 
-  /**
-   * Verifies that the actual {@link Multimap} contains all entries of the given one (it might contain more entries).
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multimap&lt;String, String&gt; actual = ArrayListMultimap.create();
-   * actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
-   * actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
-   *
-   * Multimap&lt;String, String&gt; other = TreeMultimap.create();
-   * other.putAll("Spurs", newHashSet("Tony Parker", "Tim Duncan"));
-   * other.putAll("Bulls", newHashSet("Michael Jordan", "Scottie Pippen"));
-   *
-   * // assertion will pass as other is a subset of actual.
-   * assertThat(actual).containsAllEntriesOf(other);
-   *
-   * // this assertion FAILS as other does not contain "Spurs -&gt; "Manu Ginobili" and "Bulls" -&gt; "Derrick Rose"
-   * assertThat(other).containsAllEntriesOf(actual);</code></pre>
-   *
-   * @param other {@link Multimap} to compare actual's entries with.
-   * @return this {@link MultimapAssert} for assertions chaining.
-   * @throws AssertionError           if the actual {@link Multimap} is {@code null}.
-   * @throws IllegalArgumentException if the other {@link Multimap} is {@code null}.
-   * @throws AssertionError           if actual {@link Multimap} does not have contain all the given {@link Multimap} entries.
-   */
+  /// Verifies that the actual [Multimap] contains all entries of the given one (it might contain more entries).
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  /// actual.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
+  /// actual.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
+  ///
+  /// Multimap<String, String> other = TreeMultimap.create();
+  /// other.putAll("Spurs", newHashSet("Tony Parker", "Tim Duncan"));
+  /// other.putAll("Bulls", newHashSet("Michael Jordan", "Scottie Pippen"));
+  ///
+  /// // assertion will pass as other is a subset of actual.
+  /// assertThat(actual).containsAllEntriesOf(other);
+  ///
+  /// // this assertion FAILS as other does not contain "Spurs -> "Manu Ginobili" and "Bulls" -> "Derrick Rose"
+  /// assertThat(other).containsAllEntriesOf(actual);
+  /// ```
+  ///
+  /// @param other [Multimap] to compare actual's entries with.
+  /// @return this [MultimapAssert] for assertions chaining.
+  /// @throws AssertionError           if the actual [Multimap] is `null`.
+  /// @throws IllegalArgumentException if the other [Multimap] is `null`.
+  /// @throws AssertionError           if actual [Multimap] does not have contain all the given [Multimap] entries.
   public final MultimapAssert<K, V> containsAllEntriesOf(Multimap<? extends K, ? extends V> other) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(other == null, "The multimap to compare actual with should not be null");
@@ -319,54 +311,54 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
     throw assertionError(shouldContain(actual, other, entriesNotFoundInActual));
   }
 
-  /**
-   * Verifies that the actual multimap does not contain the given key.
-   * <p>
-   * Examples:
-   * <pre><code class='java'> Multimap&lt;Ring, TolkienCharacter&gt; elvesRingBearers = HashMultimap.create();
-   * elvesRingBearers.put(nenya, galadriel);
-   * elvesRingBearers.put(narya, gandalf);
-   * elvesRingBearers.put(vilya, elrond);
-   *
-   * // assertion will pass
-   * assertThat(elvesRingBearers).doesNotContainKey(oneRing);
-   *
-   * // assertion will fail
-   * assertThat(elvesRingBearers).doesNotContainKey(vilya);</code></pre>
-   *
-   * @param key the given key
-   * @return {@code this} assertions object
-   * @throws AssertionError if the actual map is {@code null}.
-   * @throws AssertionError if the actual map contains the given key.
-   * @since 3.26.0
-   */
+  /// Verifies that the actual multimap does not contain the given key.
+  ///
+  /// Examples:
+  /// ```java
+  /// Multimap<Ring, TolkienCharacter> elvesRingBearers = HashMultimap.create();
+  /// elvesRingBearers.put(nenya, galadriel);
+  /// elvesRingBearers.put(narya, gandalf);
+  /// elvesRingBearers.put(vilya, elrond);
+  ///
+  /// // assertion will pass
+  /// assertThat(elvesRingBearers).doesNotContainKey(oneRing);
+  ///
+  /// // assertion will fail
+  /// assertThat(elvesRingBearers).doesNotContainKey(vilya);
+  /// ```
+  ///
+  /// @param key the given key
+  /// @return `this` assertions object
+  /// @throws AssertionError if the actual map is `null`.
+  /// @throws AssertionError if the actual map contains the given key.
+  /// @since 3.26.0
   public MultimapAssert<K, V> doesNotContainKey(K key) {
     return doesNotContainKeys(key);
   }
 
-  /**
-   * Verifies that the actual multimap does not contain any of the given keys.
-   * <p>
-   * Examples:
-   * <pre><code class='java'> Multimap&lt;Ring, TolkienCharacter&gt; elvesRingBearers = HashMultimap.create();
-   * elvesRingBearers.put(nenya, galadriel);
-   * elvesRingBearers.put(narya, gandalf);
-   * elvesRingBearers.put(vilya, elrond);
-   *
-   * // assertion will pass
-   * assertThat(elvesRingBearers).doesNotContainKeys(oneRing, someManRing);
-   *
-   * // assertions will fail
-   * assertThat(elvesRingBearers).doesNotContainKeys(vilya, nenya);
-   * assertThat(elvesRingBearers).doesNotContainKeys(vilya, oneRing);</code></pre>
-   *
-   * @param keys the given keys
-   * @return {@code this} assertions object
-   * @throws AssertionError if the actual map is {@code null}.
-   * @throws AssertionError if the actual map contains the given key.
-   * @throws NullPointerException if the varargs of keys is null
-   * @since 3.26.0
-   */
+  /// Verifies that the actual multimap does not contain any of the given keys.
+  ///
+  /// Examples:
+  /// ```java
+  /// Multimap<Ring, TolkienCharacter> elvesRingBearers = HashMultimap.create();
+  /// elvesRingBearers.put(nenya, galadriel);
+  /// elvesRingBearers.put(narya, gandalf);
+  /// elvesRingBearers.put(vilya, elrond);
+  ///
+  /// // assertion will pass
+  /// assertThat(elvesRingBearers).doesNotContainKeys(oneRing, someManRing);
+  ///
+  /// // assertions will fail
+  /// assertThat(elvesRingBearers).doesNotContainKeys(vilya, nenya);
+  /// assertThat(elvesRingBearers).doesNotContainKeys(vilya, oneRing);
+  /// ```
+  ///
+  /// @param keys the given keys
+  /// @return `this` assertions object
+  /// @throws AssertionError if the actual map is `null`.
+  /// @throws AssertionError if the actual map contains the given key.
+  /// @throws NullPointerException if the varargs of keys is null
+  /// @since 3.26.0
   public MultimapAssert<K, V> doesNotContainKeys(K... keys) {
     isNotNull();
     assertDoesNotContainKeys(keys);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -36,9 +36,7 @@ import java.util.Set;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.data.MapEntry;
 
-import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.SetMultimap;
 
 /// Assertions for guava [Multimap].
 ///
@@ -242,7 +240,7 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
 
   /// Verifies that the actual [Multimap] has the same entries as the given one.
   /// It allows to compare two multimaps having the same content but who are not equal because being of different types
-  /// like [SetMultimap] and [ListMultimap].
+  /// like [com.google.common.collect.SetMultimap] and [com.google.common.collect.ListMultimap].
   ///
   /// Example :
   ///

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultimapAssert.java
@@ -196,10 +196,10 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
   ///
   /// ```java
   /// Multimap<String, String> actual = ArrayListMultimap.create();
-  /// nba.put("Bulls", "Derrick Rose");
-  /// nba.put("Bulls", "Joachim Noah");
+  /// actual.put("Bulls", "Derrick Rose");
+  /// actual.put("Bulls", "Joachim Noah");
   ///
-  /// assertThat(nba).isNotEmpty();
+  /// assertThat(actual).isNotEmpty();
   /// ```
   ///
   /// @throws AssertionError if the actual [Multimap] is `null`.
@@ -239,13 +239,13 @@ public class MultimapAssert<K, V> extends AbstractAssert<MultimapAssert<K, V>, M
   }
 
   /// Verifies that the actual [Multimap] has the same entries as the given one.
-  /// It allows to compare two multimaps having the same content but who are not equal because being of different types
-  /// like [com.google.common.collect.SetMultimap] and [com.google.common.collect.ListMultimap].
+  /// It allows to compare two multimaps having the same content but which are not equal because they are of different
+  /// types like [com.google.common.collect.SetMultimap] and [com.google.common.collect.ListMultimap].
   ///
   /// Example :
   ///
   /// ```java
-  /// Multimap<String, String> actual = ArrayListMultimap.create();
+  /// Multimap<String, String> listMultimap = ArrayListMultimap.create();
   /// listMultimap.putAll("Spurs", newArrayList("Tony Parker", "Tim Duncan", "Manu Ginobili"));
   /// listMultimap.putAll("Bulls", newArrayList("Michael Jordan", "Scottie Pippen", "Derrick Rose"));
   ///

--- a/assertj-guava/src/main/java/org/assertj/guava/api/MultisetAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/MultisetAssert.java
@@ -26,46 +26,42 @@ import org.assertj.core.api.ObjectAssert;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 
-/**
- *
- * Assertions for guava {@link Multiset}.
- * <p>
- * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Multiset)}</code>
- * <p>
- *
- * @param <T> the type of elements contained in the tested Multiset value
- *
- * @author Max Daniline
- */
+/// Assertions for guava [Multiset].
+///
+/// To create an instance of this class, invoke `[Assertions#assertThat(Multiset)]`
+///
+/// @param <T> the type of elements contained in the tested Multiset value
+///
+/// @author Max Daniline
 public class MultisetAssert<T> extends AbstractIterableAssert<MultisetAssert<T>, Multiset<? extends T>, T, ObjectAssert<T>> {
 
   protected MultisetAssert(Multiset<? extends T> actual) {
     super(actual, MultisetAssert.class);
   }
 
-  /**
-   * Verifies the actual {@link Multiset} contains the given value <b>exactly</b> the given number of times.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multiset&lt;String&gt; actual = HashMultiset.create();
-   * actual.add("shoes", 2);
-   *
-   * // assertion succeeds
-   * assertThat(actual).contains(2, "shoes");
-   *
-   * // assertions fail
-   * assertThat(actual).contains(1, "shoes");
-   * assertThat(actual).contains(3, "shoes");</code></pre>
-   *
-   * @param expectedCount the exact number of times the given value should appear in the set
-   * @param expected the value which to expect
-   *
-   * @return this {@link MultisetAssert} for fluent chaining
-   *
-   * @throws AssertionError if the actual {@link Multiset} is null
-   * @throws AssertionError if the actual {@link Multiset} contains the given value a number of times different to the given count
-   */
+  /// Verifies the actual [Multiset] contains the given value **exactly** the given number of times.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multiset<String> actual = HashMultiset.create();
+  /// actual.add("shoes", 2);
+  ///
+  /// // assertion succeeds
+  /// assertThat(actual).contains(2, "shoes");
+  ///
+  /// // assertions fail
+  /// assertThat(actual).contains(1, "shoes");
+  /// assertThat(actual).contains(3, "shoes");
+  /// ```
+  ///
+  /// @param expectedCount the exact number of times the given value should appear in the set
+  /// @param expected the value which to expect
+  ///
+  /// @return this [MultisetAssert] for fluent chaining
+  ///
+  /// @throws AssertionError if the actual [Multiset] is null
+  /// @throws AssertionError if the actual [Multiset] contains the given value a number of times different to the given count
   public MultisetAssert<T> contains(int expectedCount, T expected) {
     isNotNull();
     checkArgument(expectedCount >= 0, "The expected count should not be negative.");
@@ -76,29 +72,29 @@ public class MultisetAssert<T> extends AbstractIterableAssert<MultisetAssert<T>,
     return myself;
   }
 
-  /**
-   * Verifies the actual {@link Multiset} contains the given value <b>at least</b> the given number of times.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multiset&lt;String&gt; actual = HashMultiset.create();
-   * actual.add("shoes", 2);
-   *
-   * // assertions succeed
-   * assertThat(actual).containsAtLeast(1, "shoes");
-   * assertThat(actual).containsAtLeast(2, "shoes");
-   *
-   * // assertion fails
-   * assertThat(actual).containsAtLeast(3, "shoes");</code></pre>
-   *
-   * @param minimumCount the minimum number of times the given value should appear in the set
-   * @param expected the value which to expect
-   *
-   * @return this {@link MultisetAssert} for fluent chaining
-   *
-   * @throws AssertionError if the actual {@link Multiset} is null
-   * @throws AssertionError if the actual {@link Multiset} contains the given value fewer times than the given count
-   */
+  /// Verifies the actual [Multiset] contains the given value **at least** the given number of times.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multiset<String> actual = HashMultiset.create();
+  /// actual.add("shoes", 2);
+  ///
+  /// // assertions succeed
+  /// assertThat(actual).containsAtLeast(1, "shoes");
+  /// assertThat(actual).containsAtLeast(2, "shoes");
+  ///
+  /// // assertion fails
+  /// assertThat(actual).containsAtLeast(3, "shoes");
+  /// ```
+  ///
+  /// @param minimumCount the minimum number of times the given value should appear in the set
+  /// @param expected the value which to expect
+  ///
+  /// @return this [MultisetAssert] for fluent chaining
+  ///
+  /// @throws AssertionError if the actual [Multiset] is null
+  /// @throws AssertionError if the actual [Multiset] contains the given value fewer times than the given count
   public MultisetAssert<T> containsAtLeast(int minimumCount, T expected) {
     isNotNull();
     checkArgument(minimumCount >= 0, "The minimum count should not be negative.");
@@ -109,30 +105,29 @@ public class MultisetAssert<T> extends AbstractIterableAssert<MultisetAssert<T>,
     return myself;
   }
 
-  /**
-   * Verifies the actual {@link Multiset} contains the given value <b>at most</b> the given number of times.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Multiset&lt;String&gt; actual = HashMultiset.create();
-   * actual.add("shoes", 2);
-   *
-   * // assertions succeed
-   * assertThat(actual).containsAtMost(3, "shoes");
-   * assertThat(actual).containsAtMost(2, "shoes");
-   *
-   * // assertion fails
-   * assertThat(actual).containsAtMost(1, "shoes");</code></pre>
-   *
-   *
-   * @param maximumCount the maximum number of times the given value should appear in the set
-   *
-   * @param expected the value which to expect
-   * @return this {@link MultisetAssert} for fluent chaining
-   *
-   * @throws AssertionError if the actual {@link Multiset} is null
-   * @throws AssertionError if the actual {@link Multiset} contains the given value more times than the given count
-   */
+  /// Verifies the actual [Multiset] contains the given value **at most** the given number of times.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Multiset<String> actual = HashMultiset.create();
+  /// actual.add("shoes", 2);
+  ///
+  /// // assertions succeed
+  /// assertThat(actual).containsAtMost(3, "shoes");
+  /// assertThat(actual).containsAtMost(2, "shoes");
+  ///
+  /// // assertion fails
+  /// assertThat(actual).containsAtMost(1, "shoes");
+  /// ```
+  ///
+  /// @param maximumCount the maximum number of times the given value should appear in the set
+  ///
+  /// @param expected the value which to expect
+  /// @return this [MultisetAssert] for fluent chaining
+  ///
+  /// @throws AssertionError if the actual [Multiset] is null
+  /// @throws AssertionError if the actual [Multiset] contains the given value more times than the given count
   public MultisetAssert<T> containsAtMost(int maximumCount, T expected) {
     isNotNull();
     checkArgument(maximumCount >= 0, "The maximum count should not be negative.");

--- a/assertj-guava/src/main/java/org/assertj/guava/api/OptionalAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/OptionalAssert.java
@@ -26,17 +26,13 @@ import org.assertj.core.api.AbstractObjectAssert;
 
 import com.google.common.base.Optional;
 
-/**
- *
- * Assertions for guava {@link Optional}.
- * <p>
- * To create an instance of this class, invoke <code>{@link Assertions#assertThat(Optional)}</code>
- * <p>
- *
- * @param <T> the type of elements of the tested Optional value
- *
- * @author Kornel Kiełczewski
- */
+/// Assertions for guava [Optional].
+///
+/// To create an instance of this class, invoke `[Assertions#assertThat(Optional)]`
+///
+/// @param <T> the type of elements of the tested Optional value
+///
+/// @author Kornel Kiełczewski
 public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optional<T>> {
 
   protected OptionalAssert(final Optional<T> actual) {
@@ -48,21 +44,21 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
     return actual;
   }
 
-  /**
-   * Verifies that the actual {@link Optional} contains the given value.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Optional&lt;String&gt; optional = Optional.of(&quot;Test&quot;);
-   *
-   * assertThat(optional).contains(&quot;Test&quot;);</code></pre>
-   *
-   * @param value the value to look for in actual {@link Optional}.
-   * @return this {@link OptionalAssert} for assertions chaining.
-   *
-   * @throws AssertionError if the actual {@link Optional} is {@code null}.
-   * @throws AssertionError if the actual {@link Optional} contains nothing or does not have the given value.
-   */
+  /// Verifies that the actual [Optional] contains the given value.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Optional<String> optional = Optional.of("Test");
+  ///
+  /// assertThat(optional).contains("Test");
+  /// ```
+  ///
+  /// @param value the value to look for in actual [Optional].
+  /// @return this [OptionalAssert] for assertions chaining.
+  ///
+  /// @throws AssertionError if the actual [Optional] is `null`.
+  /// @throws AssertionError if the actual [Optional] contains nothing or does not have the given value.
   @SuppressWarnings("deprecation")
   public OptionalAssert<T> contains(final Object value) {
     isNotNull();
@@ -75,20 +71,20 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
     return this;
   }
 
-  /**
-   * Verifies that the actual {@link Optional} contained instance is absent/null (ie. not {@link Optional#isPresent()}).<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Optional&lt;String&gt; optional = Optional.absent();
-   *
-   * assertThat(optional).isAbsent();</code></pre>
-   *
-   * @return this {@link OptionalAssert} for assertions chaining.
-   *
-   * @throws AssertionError if the actual {@link Optional} is {@code null}.
-   * @throws AssertionError if the actual {@link Optional} contains a (non-null) instance.
-   */
+  /// Verifies that the actual [Optional] contained instance is absent/null (ie. not [Optional#isPresent()]).
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Optional<String> optional = Optional.absent();
+  ///
+  /// assertThat(optional).isAbsent();
+  /// ```
+  ///
+  /// @return this [OptionalAssert] for assertions chaining.
+  ///
+  /// @throws AssertionError if the actual [Optional] is `null`.
+  /// @throws AssertionError if the actual [Optional] contains a (non-null) instance.
   public OptionalAssert<T> isAbsent() {
     isNotNull();
     if (actual.isPresent()) {
@@ -97,20 +93,20 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
     return this;
   }
 
-  /**
-   * Verifies that the actual {@link Optional} contains a (non-null) instance.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Optional&lt;String&gt; optional = Optional.of(&quot;value&quot;);
-   *
-   * assertThat(optional).isPresent();</code></pre>
-   *
-   * @return this {@link OptionalAssert} for assertions chaining.
-   *
-   * @throws AssertionError if the actual {@link Optional} is {@code null}.
-   * @throws AssertionError if the actual {@link Optional} contains a null instance.
-   */
+  /// Verifies that the actual [Optional] contains a (non-null) instance.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Optional<String> optional = Optional.of("value");
+  ///
+  /// assertThat(optional).isPresent();
+  /// ```
+  ///
+  /// @return this [OptionalAssert] for assertions chaining.
+  ///
+  /// @throws AssertionError if the actual [Optional] is `null`.
+  /// @throws AssertionError if the actual [Optional] contains a null instance.
   public OptionalAssert<T> isPresent() {
     isNotNull();
     if (!actual.isPresent()) {
@@ -119,38 +115,38 @@ public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optiona
     return this;
   }
 
-  /**
-   * Chain assertion on the content of the {@link Optional}.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Optional&lt;Number&gt; optional = Optional.of(12L);
-   *
-   * assertThat(optional).extractingValue().isInstanceOf(Long.class);</code></pre>
-   *
-   * @return a new {@link AbstractObjectAssert} for assertions chaining on the content of the Optional.
-   * @throws AssertionError if the actual {@link Optional} is {@code null}.
-   * @throws AssertionError if the actual {@link Optional} contains a null instance.
-   */
+  /// Chain assertion on the content of the [Optional].
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Optional<Number> optional = Optional.of(12L);
+  ///
+  /// assertThat(optional).extractingValue().isInstanceOf(Long.class);
+  /// ```
+  ///
+  /// @return a new [AbstractObjectAssert] for assertions chaining on the content of the Optional.
+  /// @throws AssertionError if the actual [Optional] is `null`.
+  /// @throws AssertionError if the actual [Optional] contains a null instance.
   public AbstractObjectAssert<?, T> extractingValue() {
     isPresent();
     T assertion = actual.get();
     return assertThat(assertion);
   }
 
-  /**
-   * Chain assertion on the content of the {@link Optional}.
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Optional&lt;String&gt; optional = Optional.of("Bill");
-   *
-   * assertThat(optional).extractingCharSequence().startsWith("Bi");</code></pre>
-   *
-   * @return a new {@link AbstractCharSequenceAssert} for assertions chaining on the content of the Optional.
-   * @throws AssertionError if the actual {@link Optional} is {@code null}.
-   * @throws AssertionError if the actual {@link Optional} contains a null instance.
-   */
+  /// Chain assertion on the content of the [Optional].
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Optional<String> optional = Optional.of("Bill");
+  ///
+  /// assertThat(optional).extractingCharSequence().startsWith("Bi");
+  /// ```
+  ///
+  /// @return a new [AbstractCharSequenceAssert] for assertions chaining on the content of the Optional.
+  /// @throws AssertionError if the actual [Optional] is `null`.
+  /// @throws AssertionError if the actual [Optional] contains a null instance.
   public AbstractCharSequenceAssert<?, ? extends CharSequence> extractingCharSequence() {
     isPresent();
     assertThat(actual.get()).isInstanceOf(CharSequence.class);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeAssert.java
@@ -35,36 +35,32 @@ import org.assertj.core.api.AbstractAssert;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 
-/**
- * Assertions for guava {@link com.google.common.collect.Range}.
- * <p>
- * To create an instance of this class, invoke <code>{@link
- * org.assertj.guava.api.Assertions#assertThat(com.google.common.collect.Range)}</code>
- * <p>
- *
- * @param <T> the type of elements of the tested Range value
- * @author Marcin Kwaczyński
- */
+/// Assertions for guava [com.google.common.collect.Range].
+///
+/// To create an instance of this class, invoke `[org.assertj.guava.api.Assertions#assertThat(com.google.common.collect.Range)]`
+///
+/// @param <T> the type of elements of the tested Range value
+/// @author Marcin Kwaczyński
 public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAssert<T>, Range<T>> {
 
   protected RangeAssert(final Range<T> actual) {
     super(actual, RangeAssert.class);
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} contains the given values.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(10, 12);
-   *
-   * assertThat(range).contains(10, 11, 12);</code></pre>
-   *
-   * @param values the values to look for in actual {@link com.google.common.collect.Range}.
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} does not contain the given values.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] contains the given values.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(10, 12);
+  ///
+  /// assertThat(range).contains(10, 11, 12);
+  /// ```
+  ///
+  /// @param values the values to look for in actual [com.google.common.collect.Range].
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] does not contain the given values.
   public RangeAssert<T> contains(@SuppressWarnings("unchecked") final T... values) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(values == null, "The values to look for should not be null");
@@ -86,20 +82,20 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} does not contain the given values.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(10, 12);
-   *
-   * assertThat(range).doesNotContain(13);</code></pre>
-   *
-   * @param values the values that should not be present in actual {@link com.google.common.collect.Range}.
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} contains the given values.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] does not contain the given values.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(10, 12);
+  ///
+  /// assertThat(range).doesNotContain(13);
+  /// ```
+  ///
+  /// @param values the values that should not be present in actual [com.google.common.collect.Range].
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] contains the given values.
   public RangeAssert<T> doesNotContain(@SuppressWarnings("unchecked") final T... values) {
     isNotNull();
 
@@ -116,19 +112,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} lower bound is closed.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(10, 12);
-   *
-   * assertThat(range).hasClosedLowerBound();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} lower bound is opened.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] lower bound is closed.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(10, 12);
+  ///
+  /// assertThat(range).hasClosedLowerBound();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] lower bound is opened.
   public RangeAssert<T> hasClosedLowerBound() throws AssertionError {
     isNotNull();
 
@@ -139,19 +135,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} upper bound is closed.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(10, 12);
-   *
-   * assertThat(range).hasClosedUpperBound();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} upper bound is opened.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] upper bound is closed.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(10, 12);
+  ///
+  /// assertThat(range).hasClosedUpperBound();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] upper bound is opened.
   public RangeAssert<T> hasClosedUpperBound() throws AssertionError {
     isNotNull();
 
@@ -162,21 +158,21 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} lower endpoint is equal to the given value.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(10, 12);
-   *
-   * assertThat(range).hasLowerEndpointEqualTo(10);</code></pre>
-   *
-   * @param value {@link com.google.common.collect.Range} expected lower bound value.
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} does not have lower endpoint equal to
-   *           the given values.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] lower endpoint is equal to the given value.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(10, 12);
+  ///
+  /// assertThat(range).hasLowerEndpointEqualTo(10);
+  /// ```
+  ///
+  /// @param value [com.google.common.collect.Range] expected lower bound value.
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] does not have lower endpoint equal to
+  ///           the given values.
   public RangeAssert<T> hasLowerEndpointEqualTo(final T value) throws AssertionError {
     isNotNull();
 
@@ -187,19 +183,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} lower bound is opened.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.open(1, 2);
-   *
-   * assertThat(range).hasOpenedLowerBound();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} lower bound is closed.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] lower bound is opened.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.open(1, 2);
+  ///
+  /// assertThat(range).hasOpenedLowerBound();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] lower bound is closed.
   public RangeAssert<T> hasOpenedLowerBound() throws AssertionError {
     isNotNull();
 
@@ -210,19 +206,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} upper bound is opened.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.open(10, 12);
-   *
-   * assertThat(range).hasOpenedUpperBound();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} upper bound is closed.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] upper bound is opened.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.open(10, 12);
+  ///
+  /// assertThat(range).hasOpenedUpperBound();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] upper bound is closed.
   public RangeAssert<T> hasOpenedUpperBound() throws AssertionError {
     isNotNull();
 
@@ -233,21 +229,21 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} upper endpoint is equal to the given value.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.open(10, 12);
-   *
-   * assertThat(range).hasUpperEndpointEqualTo(12);</code></pre>
-   *
-   * @param value {@link com.google.common.collect.Range} expected upper bound value.
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} does not have upper endpoint equal to
-   *           the given values.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] upper endpoint is equal to the given value.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.open(10, 12);
+  ///
+  /// assertThat(range).hasUpperEndpointEqualTo(12);
+  /// ```
+  ///
+  /// @param value [com.google.common.collect.Range] expected upper bound value.
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] does not have upper endpoint equal to
+  ///           the given values.
   public RangeAssert<T> hasUpperEndpointEqualTo(final T value) throws AssertionError {
     isNotNull();
 
@@ -258,19 +254,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} is empty.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closedOpen(0, 0);
-   *
-   * assertThat(range).isEmpty();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is not empty.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] is empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closedOpen(0, 0);
+  ///
+  /// assertThat(range).isEmpty();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is not empty.
   public RangeAssert<T> isEmpty() throws AssertionError {
     isNotNull();
 
@@ -281,19 +277,19 @@ public class RangeAssert<T extends Comparable<T>> extends AbstractAssert<RangeAs
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.Range} is not empty.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Range&lt;Integer&gt; range = Range.closed(0, 0);
-   *
-   * assertThat(range).isNotEmpty();</code></pre>
-   *
-   * @return this {@link RangeAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.Range} is empty.
-   */
+  /// Verifies that the actual [com.google.common.collect.Range] is not empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Range<Integer> range = Range.closed(0, 0);
+  ///
+  /// assertThat(range).isNotEmpty();
+  /// ```
+  ///
+  /// @return this [RangeAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.Range] is empty.
   public RangeAssert<T> isNotEmpty() throws AssertionError {
     isNotNull();
 

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeMapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeMapAssert.java
@@ -76,7 +76,8 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
   /// @throws IllegalArgumentException if no param keys have been set.
   /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
   /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] does not contain the given keys.
-  public RangeMapAssert<K, V> containsKeys(@SuppressWarnings("unchecked") K... keys) {
+  @SafeVarargs
+  public final RangeMapAssert<K, V> containsKeys(@SuppressWarnings("unchecked") K... keys) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(keys == null, "The keys to look for should not be null");
     throwIllegalArgumentExceptionIfTrue(keys.length == 0, "The keys to look for should not be empty");
@@ -94,7 +95,8 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /// @deprecated use [#contains(MapEntry...)] instead (same method but using [org.assertj.core.data.MapEntry][MapEntry] in place of [org.assertj.guava.data.MapEntry].
+  /// @deprecated use [#contains(MapEntry...)] instead (similar method but accepting [org.assertj.core.data.MapEntry]
+  /// instead of [org.assertj.guava.data.MapEntry]).
   ///
   /// Verifies that the actual [com.google.common.collect.RangeMap] contains the given entries.
   ///

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeMapAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeMapAssert.java
@@ -34,17 +34,13 @@ import org.assertj.core.data.MapEntry;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 
-/**
- * Assertions for guava {@link com.google.common.collect.RangeMap}.
- * <p>
- * To create an instance of this class, invoke <code>{@link
- * org.assertj.guava.api.Assertions#assertThat(com.google.common.collect.RangeMap)}</code>
- * <p>
- *
- * @param <K> the type of keys of the tested RangeMap value
- * @param <V> the type of values of the tested RangeMap value
- * @author Marcin Kwaczyński
- */
+/// Assertions for guava [com.google.common.collect.RangeMap].
+///
+/// To create an instance of this class, invoke `[org.assertj.guava.api.Assertions#assertThat(com.google.common.collect.RangeMap)]`
+///
+/// @param <K> the type of keys of the tested RangeMap value
+/// @param <V> the type of values of the tested RangeMap value
+/// @author Marcin Kwaczyński
 public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<RangeMapAssert<K, V>, RangeMap<K, V>> {
 
   protected RangeMapAssert(final RangeMap<K, V> actual) {
@@ -56,31 +52,30 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return actual;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} contains the given keys.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   *
-   * spectralColors.put(Range.closedOpen(380, 450), "violet");
-   * spectralColors.put(Range.closedOpen(450, 495), "blue");
-   * spectralColors.put(Range.closedOpen(495, 570), "green");
-   * spectralColors.put(Range.closedOpen(570, 590), "yellow");
-   * spectralColors.put(Range.closedOpen(590, 620), "orange");
-   * spectralColors.put(Range.closedOpen(620, 750), "red");
-   *
-   * assertThat(spectralColors).containsKeys(380, 600, 700);</code></pre>
-   *
-   * If the <code>keys</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param keys the keys to look for in actual {@link com.google.common.collect.RangeMap}.
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param keys have been set.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} does not contain the given keys.
-   */
+  /// Verifies that the actual [com.google.common.collect.RangeMap] contains the given keys.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  ///
+  /// spectralColors.put(Range.closedOpen(380, 450), "violet");
+  /// spectralColors.put(Range.closedOpen(450, 495), "blue");
+  /// spectralColors.put(Range.closedOpen(495, 570), "green");
+  /// spectralColors.put(Range.closedOpen(570, 590), "yellow");
+  /// spectralColors.put(Range.closedOpen(590, 620), "orange");
+  /// spectralColors.put(Range.closedOpen(620, 750), "red");
+  ///
+  /// assertThat(spectralColors).containsKeys(380, 600, 700);
+  /// ```
+  ///
+  /// If the `keys` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param keys the keys to look for in actual [com.google.common.collect.RangeMap].
+  /// @return this [RangeMapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param keys have been set.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] does not contain the given keys.
   public RangeMapAssert<K, V> containsKeys(@SuppressWarnings("unchecked") K... keys) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(keys == null, "The keys to look for should not be null");
@@ -99,34 +94,33 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /**
-   * @deprecated use {@link #contains(MapEntry...)} instead (same method but using {@link MapEntry org.assertj.core.data.MapEntry} in place of {@link org.assertj.guava.data.MapEntry}.
-   * <p>
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} contains the given entries.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   *
-   * spectralColors.put(Range.closedOpen(380, 450), "violet");
-   * spectralColors.put(Range.closedOpen(450, 495), "blue");
-   * spectralColors.put(Range.closedOpen(495, 570), "green");
-   * spectralColors.put(Range.closedOpen(570, 590), "yellow");
-   * spectralColors.put(Range.closedOpen(590, 620), "orange");
-   * spectralColors.put(Range.closedOpen(620, 750), "red");
-   *
-   * // entry can be statically imported from {@link org.assertj.guava.data.MapEntry}
-   * assertThat(spectralColors).contains(entry("400", "violet"), entry("650", "red"));</code></pre>
-   *
-   * If the <code>entries</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param entries the entries to look for in actual {@link com.google.common.collect.RangeMap}.
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param entries have been set.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} does not contain the given entries.
-   */
+  /// @deprecated use [#contains(MapEntry...)] instead (same method but using [org.assertj.core.data.MapEntry][MapEntry] in place of [org.assertj.guava.data.MapEntry].
+  ///
+  /// Verifies that the actual [com.google.common.collect.RangeMap] contains the given entries.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  ///
+  /// spectralColors.put(Range.closedOpen(380, 450), "violet");
+  /// spectralColors.put(Range.closedOpen(450, 495), "blue");
+  /// spectralColors.put(Range.closedOpen(495, 570), "green");
+  /// spectralColors.put(Range.closedOpen(570, 590), "yellow");
+  /// spectralColors.put(Range.closedOpen(590, 620), "orange");
+  /// spectralColors.put(Range.closedOpen(620, 750), "red");
+  ///
+  /// // entry can be statically imported from [org.assertj.guava.data.MapEntry]
+  /// assertThat(spectralColors).contains(entry("400", "violet"), entry("650", "red"));
+  /// ```
+  ///
+  /// If the `entries` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param entries the entries to look for in actual [com.google.common.collect.RangeMap].
+  /// @return this [RangeMapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param entries have been set.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] does not contain the given entries.
   @SafeVarargs
   @Deprecated
   public final RangeMapAssert<K, V> contains(org.assertj.guava.data.MapEntry<K, V>... entries) {
@@ -147,32 +141,31 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} contains the given entries.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   *
-   * spectralColors.put(Range.closedOpen(380, 450), "violet");
-   * spectralColors.put(Range.closedOpen(450, 495), "blue");
-   * spectralColors.put(Range.closedOpen(495, 570), "green");
-   * spectralColors.put(Range.closedOpen(570, 590), "yellow");
-   * spectralColors.put(Range.closedOpen(590, 620), "orange");
-   * spectralColors.put(Range.closedOpen(620, 750), "red");
-   *
-   * // entry can be statically imported from {@link org.assertj.core.data.MapEntry}
-   * assertThat(spectralColors).contains(entry("400", "violet"), entry("650", "red"));</code></pre>
-   *
-   * If the <code>entries</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param entries the entries to look for in actual {@link com.google.common.collect.RangeMap}.
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param entries have been set.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} does not contain the given entries.
-   */
+  /// Verifies that the actual [com.google.common.collect.RangeMap] contains the given entries.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  ///
+  /// spectralColors.put(Range.closedOpen(380, 450), "violet");
+  /// spectralColors.put(Range.closedOpen(450, 495), "blue");
+  /// spectralColors.put(Range.closedOpen(495, 570), "green");
+  /// spectralColors.put(Range.closedOpen(570, 590), "yellow");
+  /// spectralColors.put(Range.closedOpen(590, 620), "orange");
+  /// spectralColors.put(Range.closedOpen(620, 750), "red");
+  ///
+  /// // entry can be statically imported from [org.assertj.core.data.MapEntry]
+  /// assertThat(spectralColors).contains(entry("400", "violet"), entry("650", "red"));
+  /// ```
+  ///
+  /// If the `entries` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param entries the entries to look for in actual [com.google.common.collect.RangeMap].
+  /// @return this [RangeMapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param entries have been set.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] does not contain the given entries.
   @SafeVarargs
   public final RangeMapAssert<K, V> contains(MapEntry<K, V>... entries) {
     isNotNull();
@@ -192,31 +185,30 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} contains the given values.<br>
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   *
-   * spectralColors.put(Range.closedOpen(380, 450), "violet");
-   * spectralColors.put(Range.closedOpen(450, 495), "blue");
-   * spectralColors.put(Range.closedOpen(495, 570), "green");
-   * spectralColors.put(Range.closedOpen(570, 590), "yellow");
-   * spectralColors.put(Range.closedOpen(590, 620), "orange");
-   * spectralColors.put(Range.closedOpen(620, 750), "red");
-   *
-   * assertThat(actual).containsValues(&quot;violet&quot;, &quot;orange&quot;);</code></pre>
-   *
-   * If the <code>values</code> argument is null or empty, an {@link IllegalArgumentException} is thrown.
-   * <p>
-   *
-   * @param values the values to look for in actual {@link com.google.common.collect.RangeMap}.
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   * @throws IllegalArgumentException if no param values have been set.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} does not contain the given values.
-   */
+  /// Verifies that the actual [com.google.common.collect.RangeMap] contains the given values.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  ///
+  /// spectralColors.put(Range.closedOpen(380, 450), "violet");
+  /// spectralColors.put(Range.closedOpen(450, 495), "blue");
+  /// spectralColors.put(Range.closedOpen(495, 570), "green");
+  /// spectralColors.put(Range.closedOpen(570, 590), "yellow");
+  /// spectralColors.put(Range.closedOpen(590, 620), "orange");
+  /// spectralColors.put(Range.closedOpen(620, 750), "red");
+  ///
+  /// assertThat(actual).containsValues("violet", "orange");
+  /// ```
+  ///
+  /// If the `values` argument is null or empty, an [IllegalArgumentException] is thrown.
+  ///
+  /// @param values the values to look for in actual [com.google.common.collect.RangeMap].
+  /// @return this [RangeMapAssert] for assertions chaining.
+  /// @throws IllegalArgumentException if no param values have been set.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] does not contain the given values.
   public RangeMapAssert<K, V> containsValues(@SuppressWarnings("unchecked") V... values) {
     isNotNull();
     throwIllegalArgumentExceptionIfTrue(values == null, "The values to look for should not be null");
@@ -235,20 +227,19 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} is empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   *
-   * assertThat(actual).isEmpty();</code></pre>
-   *
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is not empty.
-   */
+  /// Verifies that the actual [com.google.common.collect.RangeMap] is empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  ///
+  /// assertThat(actual).isEmpty();
+  /// ```
+  ///
+  /// @return this [RangeMapAssert] for assertions chaining.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is not empty.
   public RangeMapAssert<K, V> isEmpty() {
     isNotNull();
     if (!actual.asMapOfRanges().isEmpty()) {
@@ -257,27 +248,26 @@ public class RangeMapAssert<K extends Comparable<K>, V> extends AbstractAssert<R
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link com.google.common.collect.RangeMap} is not empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> RangeMap&lt;Integer, String&gt; spectralColors = TreeRangeMap.create();
-   * spectralColors.put(Range.closedOpen(380, 450), "violet");
-   * spectralColors.put(Range.closedOpen(450, 495), "blue");
-   * spectralColors.put(Range.closedOpen(495, 570), "green");
-   * spectralColors.put(Range.closedOpen(570, 590), "yellow");
-   * spectralColors.put(Range.closedOpen(590, 620), "orange");
-   * spectralColors.put(Range.closedOpen(620, 750), "red");
-   *
-   * assertThat(spectralColors).isNotEmpty();</code></pre>
-   *
-   * @return this {@link RangeMapAssert} for assertions chaining.
-   *
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is {@code null}.
-   * @throws AssertionError if the actual {@link com.google.common.collect.RangeMap} is empty.
-   */
+  /// Verifies that the actual [com.google.common.collect.RangeMap] is not empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// RangeMap<Integer, String> spectralColors = TreeRangeMap.create();
+  /// spectralColors.put(Range.closedOpen(380, 450), "violet");
+  /// spectralColors.put(Range.closedOpen(450, 495), "blue");
+  /// spectralColors.put(Range.closedOpen(495, 570), "green");
+  /// spectralColors.put(Range.closedOpen(570, 590), "yellow");
+  /// spectralColors.put(Range.closedOpen(590, 620), "orange");
+  /// spectralColors.put(Range.closedOpen(620, 750), "red");
+  ///
+  /// assertThat(spectralColors).isNotEmpty();
+  /// ```
+  ///
+  /// @return this [RangeMapAssert] for assertions chaining.
+  ///
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is `null`.
+  /// @throws AssertionError if the actual [com.google.common.collect.RangeMap] is empty.
   public RangeMapAssert<K, V> isNotEmpty() {
     isNotNull();
     if (actual.asMapOfRanges().isEmpty()) {

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
@@ -41,39 +41,36 @@ import org.assertj.core.api.AbstractAssert;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * Assertion for guava {@link RangeSet}.
- * <p>
- * To create an instance of this class, invoke <code>{@link Assertions#assertThat(RangeSet)}</code>.
- * <p>
- *
- * @param <T> the type of the tested RangeSet elements
- * @author Ilya Koshaleu
- */
+/// Assertion for guava [RangeSet].
+///
+/// To create an instance of this class, invoke `[Assertions#assertThat(RangeSet)]`.
+///
+/// @param <T> the type of the tested RangeSet elements
+/// @author Ilya Koshaleu
 public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<RangeSetAssert<T>, RangeSet<T>> {
 
   protected RangeSetAssert(RangeSet<T> actual) {
     super(actual, RangeSetAssert.class);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} has specific {@code size} of disconnected {@code Range} elements.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).hasSize(3);</code></pre>
-   *
-   * @param size expected amount of disconnected {@code Range} elements.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual size of {@code RangeSet} is different from the expected {@code size}.
-   */
+  /// Verifies that the given `RangeSet` has specific `size` of disconnected `Range` elements.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).hasSize(3);
+  /// ```
+  ///
+  /// @param size expected amount of disconnected `Range` elements.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual size of `RangeSet` is different from the expected `size`.
   public RangeSetAssert<T> hasSize(int size) {
     isNotNull();
     assertHasSize(size);
@@ -85,26 +82,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (actualSize != expectedSize) throwAssertionError(shouldHaveSize(actual, actualSize, expectedSize));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} contains the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).contains(50, 270, 550);</code></pre>
-   *
-   * @param values the values to look for in actual {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not contain the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` contains the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).contains(50, 270, 550);
+  /// ```
+  ///
+  /// @param values the values to look for in actual `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not contain the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> contains(T... values) {
     isNotNull();
@@ -119,26 +116,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetContainsGivenValues(actual, values);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} contains all the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).containsAll(Arrays.asList(50, 270, 550));</code></pre>
-   *
-   * @param values the values to look for in actual {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not contain all the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` contains all the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).containsAll(Arrays.asList(50, 270, 550));
+  /// ```
+  ///
+  /// @param values the values to look for in actual `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not contain all the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty while actual is not empty.
   public RangeSetAssert<T> containsAll(Iterable<T> values) {
     isNotNull();
     assertContainsAll(values);
@@ -158,26 +155,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!elementsNotFound.isEmpty()) throwAssertionError(shouldContain(actual, values, elementsNotFound));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} contains at least one of the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).containsAnyOf(150, 250, 700);</code></pre>
-   *
-   * @param values the values to look for in actual {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not contain at least one of the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` contains at least one of the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).containsAnyOf(150, 250, 700);
+  /// ```
+  ///
+  /// @param values the values to look for in actual `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not contain at least one of the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> containsAnyOf(T... values) {
     isNotNull();
@@ -193,26 +190,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetContainsAnyGivenValues(actual, values);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} contains at least one of the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).containsAnyRangesOf(Arrays.asList(150, 250, 700));</code></pre>
-   *
-   * @param values the values to look for in actual {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not contain at least one of the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` contains at least one of the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).containsAnyRangesOf(Arrays.asList(150, 250, 700));
+  /// ```
+  ///
+  /// @param values the values to look for in actual `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not contain at least one of the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty while actual is not empty.
   public RangeSetAssert<T> containsAnyRangesOf(Iterable<T> values) {
     isNotNull();
     assertContainsAnyRangesOf(values);
@@ -232,26 +229,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!match) throwAssertionError(shouldContainAnyOf(actual, values));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not contain any of the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotContain(150, 320, 650);</code></pre>
-   *
-   * @param values the values that should not be present in actual {@code RangeSet}
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} contains any of the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty.
-   */
+  /// Verifies that the given `RangeSet` does not contain any of the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotContain(150, 320, 650);
+  /// ```
+  ///
+  /// @param values the values that should not be present in actual `RangeSet`
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` contains any of the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty.
   @SafeVarargs
   public final RangeSetAssert<T> doesNotContain(T... values) {
     isNotNull();
@@ -265,26 +262,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetDoesNotContainGivenValues(actual, values);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not contain any of the given values.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotContain(Arrays.asList(150, 320, 650));</code></pre>
-   *
-   * @param values the values that should not be present in actual {@code RangeSet}
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} contains any of the given {@code values}.
-   * @throws NullPointerException if values are null.
-   * @throws IllegalArgumentException if values are empty.
-   */
+  /// Verifies that the given `RangeSet` does not contain any of the given values.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotContain(Arrays.asList(150, 320, 650));
+  /// ```
+  ///
+  /// @param values the values that should not be present in actual `RangeSet`
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` contains any of the given `values`.
+  /// @throws NullPointerException if values are null.
+  /// @throws IllegalArgumentException if values are empty.
   public RangeSetAssert<T> doesNotContainAll(Iterable<T> values) {
     isNotNull();
     assertDoesNotContainAll(values);
@@ -303,19 +300,19 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!elementsFound.isEmpty()) throwAssertionError(shouldNotContain(actual, values, elementsFound));
   }
 
-  /**
-   * Verifies that the actual {@code RangeSet} is empty.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * assertThat(rangeSet).isEmpty();</code></pre>
-   *
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} is not empty.
-   */
+  /// Verifies that the actual `RangeSet` is empty.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// assertThat(rangeSet).isEmpty();
+  /// ```
+  ///
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` is not empty.
   public RangeSetAssert<T> isEmpty() {
     isNotNull();
     assertEmpty();
@@ -326,23 +323,23 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!actual.isEmpty()) throwAssertionError(shouldBeEmpty(actual));
   }
 
-  /**
-   * Verifies that the actual {@code RangeSet} is not empty.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).isNotEmpty();</code></pre>
-   *
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} is empty.
-   */
+  /// Verifies that the actual `RangeSet` is not empty.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).isNotEmpty();
+  /// ```
+  ///
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` is empty.
   public RangeSetAssert<T> isNotEmpty() {
     isNotNull();
     assertNotEmpty();
@@ -353,18 +350,18 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (actual.isEmpty()) throwAssertionError(shouldNotBeEmpty());
   }
 
-  /**
-   * Verifies that the actual {@code RangeSet} is {@code null} or empty.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * assertThat(rangeSet).isNullOrEmpty();</code></pre>
-   *
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is not {@code null} or not empty.
-   */
+  /// Verifies that the actual `RangeSet` is `null` or empty.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// assertThat(rangeSet).isNullOrEmpty();
+  /// ```
+  ///
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is not `null` or not empty.
   public RangeSetAssert<T> isNullOrEmpty() {
     assertNullOrEmpty();
     return myself;
@@ -374,28 +371,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (actual != null && !actual.isEmpty()) throwAssertionError(shouldBeNullOrEmpty(actual));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} intersects all the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersects(Range.closed(50, 150),
-   *                                 Range.openClosed(170, 220),
-   *                                 Range.open(520, 570));</code></pre>
-   *
-   * @param ranges the ranges to check whether they intersect the given {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect all the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` intersects all the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersects(Range.closed(50, 150),
+  ///                                 Range.openClosed(170, 220),
+  ///                                 Range.open(520, 570));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether they intersect the given `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect all the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> intersects(Range<T>... ranges) {
     isNotNull();
@@ -410,26 +407,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetIntersectsGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} intersects all ranges from the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersectsAll(ImmutableRangeSet.of(Range.closed(50, 250)));</code></pre>
-   *
-   * @param rangeSet the range set to check whether it intersects the actual {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect all the ranges from the given range set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` intersects all ranges from the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersectsAll(ImmutableRangeSet.of(Range.closed(50, 250)));
+  /// ```
+  ///
+  /// @param rangeSet the range set to check whether it intersects the actual `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect all the ranges from the given range set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty while actual is not empty.
   public RangeSetAssert<T> intersectsAll(RangeSet<T> rangeSet) {
     isNotNull();
     assertIntersectsAll(rangeSet);
@@ -445,28 +442,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetIntersectsGivenValues(toArray(rangeSet.asRanges(), Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} intersects all the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersectsAll(Arrays.asList(Range.closed(50, 150),
-   *                                                  Range.openClosed(170, 220),
-   *                                                  Range.open(520, 570)));</code></pre>
-   *
-   * @param ranges the ranges to check whether they all intersect the given {@code RangeSet}.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect all the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` intersects all the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersectsAll(Arrays.asList(Range.closed(50, 150),
+  ///                                                  Range.openClosed(170, 220),
+  ///                                                  Range.open(520, 570)));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether they all intersect the given `RangeSet`.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect all the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   public RangeSetAssert<T> intersectsAll(Iterable<Range<T>> ranges) {
     isNotNull();
     assertIntersectsAll(ranges);
@@ -486,28 +483,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!notIntersected.isEmpty()) throwAssertionError(shouldIntersect(actual, ranges, notIntersected));
   }
 
-  /**
-   * Verifies that the given {@link RangeSet} intersects at least one of the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersectsAnyOf(Range.closed(50, 150),
-   *                                      Range.open(170, 190),
-   *                                      Range.open(600, 670));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} intersects at least one of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect any of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given [RangeSet] intersects at least one of the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersectsAnyOf(Range.closed(50, 150),
+  ///                                      Range.open(170, 190),
+  ///                                      Range.open(600, 670));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` intersects at least one of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect any of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> intersectsAnyOf(Range<T>... ranges) {
     isNotNull();
@@ -522,28 +519,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetIntersectsAnyOfGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} intersects at least one of the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersectsAnyRangesOf(Arrays.asList(Range.closed(50, 150),
-   *                                                          Range.open(170, 190),
-   *                                                          Range.open(600, 670));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} intersects at least one of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect any of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` intersects at least one of the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersectsAnyRangesOf(Arrays.asList(Range.closed(50, 150),
+  ///                                                          Range.open(170, 190),
+  ///                                                          Range.open(600, 670));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` intersects at least one of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect any of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   public RangeSetAssert<T> intersectsAnyRangesOf(Iterable<Range<T>> ranges) {
     isNotNull();
     assertIntersectsAnyRangesOf(ranges);
@@ -558,28 +555,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetIntersectsAnyOfGivenValues(toArray(ranges, Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} intersects at least one range of the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).intersectsAnyRangesOf(ImmutableRangeSet.of(Range.close(50, 150)));</code></pre>
-   *
-   * @param rangeSet the range set with ranges to check whether the actual {@code RangeSet} intersects at least one of
-   *                 them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not intersect any of the ranges from the given ranges
-   *         set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` intersects at least one range of the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).intersectsAnyRangesOf(ImmutableRangeSet.of(Range.close(50, 150)));
+  /// ```
+  ///
+  /// @param rangeSet the range set with ranges to check whether the actual `RangeSet` intersects at least one of
+  ///                 them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not intersect any of the ranges from the given ranges
+  ///         set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty while actual is not empty.
   public RangeSetAssert<T> intersectsAnyRangesOf(RangeSet<T> rangeSet) {
     isNotNull();
     assertIntersectsAnyRangesOf(rangeSet);
@@ -599,28 +596,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!intersects) throwAssertionError(shouldIntersectAnyOf(actual, ranges));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not intersect the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotIntersect(Range.closed(120, 150),
-   *                                       Range.open(302, 490),
-   *                                       Range.open(600, 670));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} does not intersect them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} intersects the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty.
-   */
+  /// Verifies that the given `RangeSet` does not intersect the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotIntersect(Range.closed(120, 150),
+  ///                                       Range.open(302, 490),
+  ///                                       Range.open(600, 670));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` does not intersect them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` intersects the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty.
   @SafeVarargs
   public final RangeSetAssert<T> doesNotIntersect(Range<T>... ranges) {
     isNotNull();
@@ -634,26 +631,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetDoesNotIntersectGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not intersect ranges from the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotIntersectAnyRangeFrom(ImmutableRangeSet.of(Range.close(120, 170)));</code></pre>
-   *
-   * @param rangeSet the range set to check whether the actual {@code RangeSet} does not intersect ranges from it.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} intersects the ranges from the given range set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty.
-   */
+  /// Verifies that the given `RangeSet` does not intersect ranges from the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotIntersectAnyRangeFrom(ImmutableRangeSet.of(Range.close(120, 170)));
+  /// ```
+  ///
+  /// @param rangeSet the range set to check whether the actual `RangeSet` does not intersect ranges from it.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` intersects the ranges from the given range set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty.
   public RangeSetAssert<T> doesNotIntersectAnyRangeFrom(RangeSet<T> rangeSet) {
     isNotNull();
     assertDoesNotIntersectAnyRangeFrom(rangeSet);
@@ -667,28 +664,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetDoesNotIntersectGivenValues(toArray(rangeSet.asRanges(), Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not intersect all the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotIntersectAnyRangeFrom(Arrays.asList(Range.closed(120, 150),
-   *                                                                 Range.open(302, 490),
-   *                                                                 Range.open(600, 670));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} does not intersect them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} intersects all the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty.
-   */
+  /// Verifies that the given `RangeSet` does not intersect all the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotIntersectAnyRangeFrom(Arrays.asList(Range.closed(120, 150),
+  ///                                                                 Range.open(302, 490),
+  ///                                                                 Range.open(600, 670));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` does not intersect them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` intersects all the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty.
   public RangeSetAssert<T> doesNotIntersectAnyRangeFrom(Iterable<Range<T>> ranges) {
     isNotNull();
     assertDoesNotIntersectAnyRangeFrom(ranges);
@@ -707,28 +704,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!intersected.isEmpty()) throwAssertionError(shouldNotIntersect(actual, ranges, intersected));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).encloses(Range.closed(0, 10),
-   *                               Range.open(50, 60),
-   *                               Range.open(90, 100));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} encloses them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).encloses(Range.closed(0, 10),
+  ///                               Range.open(50, 60),
+  ///                               Range.open(90, 100));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` encloses them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> encloses(Range<T>... ranges) {
     isNotNull();
@@ -743,28 +740,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetEnclosesGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses all the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).enclosesAll(Arrays.asList(Range.closed(0, 10),
-   *                                                Range.open(50, 60),
-   *                                                Range.open(90, 100)));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} encloses all of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose all the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses all the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).enclosesAll(Arrays.asList(Range.closed(0, 10),
+  ///                                                Range.open(50, 60),
+  ///                                                Range.open(90, 100)));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` encloses all of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose all the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   public RangeSetAssert<T> enclosesAll(Iterable<Range<T>> ranges) {
     isNotNull();
     assertEnclosesAll(ranges);
@@ -779,26 +776,26 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetEnclosesGivenValues(toArray(ranges, Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses all ranges from the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).enclosesAll(ImmutableRangeSet.of(Range.closed(0, 50));</code></pre>
-   *
-   * @param rangeSet the range set to check whether the actual {@code RangeSet} encloses all range from it.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose all ranges from the given range set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses all ranges from the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).enclosesAll(ImmutableRangeSet.of(Range.closed(0, 50));
+  /// ```
+  ///
+  /// @param rangeSet the range set to check whether the actual `RangeSet` encloses all range from it.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose all ranges from the given range set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty while actual is not empty.
   public RangeSetAssert<T> enclosesAll(RangeSet<T> rangeSet) {
     isNotNull();
     assertEnclosesAll(rangeSet);
@@ -818,28 +815,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!notEnclosed.isEmpty()) throwAssertionError(shouldEnclose(actual, ranges, notEnclosed));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses at least one of the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).enclosesAnyOf(Range.closed(-10, 10),
-   *                                    Range.open(150, 260),
-   *                                    Range.open(290, 296));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} encloses at least one of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose at least one of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses at least one of the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).enclosesAnyOf(Range.closed(-10, 10),
+  ///                                    Range.open(150, 260),
+  ///                                    Range.open(290, 296));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` encloses at least one of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose at least one of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   @SafeVarargs
   public final RangeSetAssert<T> enclosesAnyOf(Range<T>... ranges) {
     isNotNull();
@@ -854,28 +851,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetEnclosesAnyOfGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses at least one range of the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).enclosesAnyRangesOf(Arrays.asList(Range.closed(-10, 10),
-   *                                                        Range.open(150, 260),
-   *                                                        Range.open(290, 296)));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} encloses at least one of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose at least one of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses at least one range of the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).enclosesAnyRangesOf(Arrays.asList(Range.closed(-10, 10),
+  ///                                                        Range.open(150, 260),
+  ///                                                        Range.open(290, 296)));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` encloses at least one of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose at least one of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty while actual is not empty.
   public RangeSetAssert<T> enclosesAnyRangesOf(Iterable<Range<T>> ranges) {
     isNotNull();
     assertEnclosesAnyRangesOf(ranges);
@@ -890,32 +887,32 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetEnclosesAnyOfGivenValues(toArray(ranges, Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} encloses at least one range from the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * RangeSet&lt;Integer&gt; enclosedSet = TreeRangeSet.create();
-   *
-   * enclosedSet.add(Range.closed(-10, 10));
-   * enclosedSet.add(Range.open(150, 260));
-   * enclosedSet.add(Range.open(290, 296));
-   *
-   * assertThat(rangeSet).enclosesAll(enclosedSet);</code></pre>
-   *
-   * @param rangeSet the range set to check whether the actual {@code RangeSet} encloses at least one range from it.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} does not enclose at least one range from the given range set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty while actual is not empty.
-   */
+  /// Verifies that the given `RangeSet` encloses at least one range from the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// RangeSet<Integer> enclosedSet = TreeRangeSet.create();
+  ///
+  /// enclosedSet.add(Range.closed(-10, 10));
+  /// enclosedSet.add(Range.open(150, 260));
+  /// enclosedSet.add(Range.open(290, 296));
+  ///
+  /// assertThat(rangeSet).enclosesAll(enclosedSet);
+  /// ```
+  ///
+  /// @param rangeSet the range set to check whether the actual `RangeSet` encloses at least one range from it.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` does not enclose at least one range from the given range set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty while actual is not empty.
   public RangeSetAssert<T> enclosesAnyRangesOf(RangeSet<T> rangeSet) {
     isNotNull();
     assertEnclosesAnyRangesOf(rangeSet);
@@ -935,28 +932,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     if (!match) throwAssertionError(shouldEncloseAnyOf(actual, ranges));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not enclose the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotEnclose(Range.closed(-10, 10),
-   *                                     Range.open(150, 160),
-   *                                     Range.open(590, 700));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} does not enclose them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} encloses any of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty.
-   */
+  /// Verifies that the given `RangeSet` does not enclose the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotEnclose(Range.closed(-10, 10),
+  ///                                     Range.open(150, 160),
+  ///                                     Range.open(590, 700));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` does not enclose them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` encloses any of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty.
   @SafeVarargs
   public final RangeSetAssert<T> doesNotEnclose(Range<T>... ranges) {
     isNotNull();
@@ -970,28 +967,28 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetDoesNotEncloseGivenValues(ranges);
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not enclose any of the given ranges.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * assertThat(rangeSet).doesNotEncloseAnyRangesOf(Arrays.asList(Range.closed(-10, 10),
-   *                                                              Range.open(150, 160),
-   *                                                              Range.open(590, 700));</code></pre>
-   *
-   * @param ranges the ranges to check whether the actual {@code RangeSet} does not enclose any of them.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} encloses any of the given ranges.
-   * @throws NullPointerException if ranges are null.
-   * @throws IllegalArgumentException if ranges are empty.
-   */
+  /// Verifies that the given `RangeSet` does not enclose any of the given ranges.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// assertThat(rangeSet).doesNotEncloseAnyRangesOf(Arrays.asList(Range.closed(-10, 10),
+  ///                                                              Range.open(150, 160),
+  ///                                                              Range.open(590, 700));
+  /// ```
+  ///
+  /// @param ranges the ranges to check whether the actual `RangeSet` does not enclose any of them.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` encloses any of the given ranges.
+  /// @throws NullPointerException if ranges are null.
+  /// @throws IllegalArgumentException if ranges are empty.
   public RangeSetAssert<T> doesNotEncloseAnyRangesOf(Iterable<Range<T>> ranges) {
     isNotNull();
     assertDoesNotEncloseAnyRangesOf(ranges);
@@ -1005,32 +1002,32 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
     assertRangeSetDoesNotEncloseGivenValues(toArray(ranges, Range.class));
   }
 
-  /**
-   * Verifies that the given {@code RangeSet} does not enclose any range from the given range set.
-   * <p>
-   * Example:
-   *
-   * <pre><code class='java'> RangeSet&lt;Integer&gt; rangeSet = TreeRangeSet.create();
-   *
-   * rangeSet.add(Range.closed(0, 100));
-   * rangeSet.add(Range.closed(200, 300));
-   * rangeSet.add(Range.closed(500, 600));
-   *
-   * RangeSet&lt;Integer&gt; enclosedSet = TreeRangeSet.create();
-   *
-   * enclosedSet.add(Range.closed(-10, 10));
-   * enclosedSet.add(Range.open(150, 360));
-   * enclosedSet.add(Range.open(590, 690));
-   *
-   * assertThat(rangeSet).doesNotEncloseAnyRangesOf(enclosedSet);</code></pre>
-   *
-   * @param rangeSet the range set to check whether the actual {@code RangeSet} does not enclose any ranges from it.
-   * @return this {@link RangeSetAssert} for assertions chaining.
-   * @throws AssertionError if the actual {@code RangeSet} is {@code null}.
-   * @throws AssertionError if the actual {@code RangeSet} encloses any range from the given range set.
-   * @throws NullPointerException if range set is null.
-   * @throws IllegalArgumentException if range set is empty.
-   */
+  /// Verifies that the given `RangeSet` does not enclose any range from the given range set.
+  ///
+  /// Example:
+  ///
+  /// ```java
+  /// RangeSet<Integer> rangeSet = TreeRangeSet.create();
+  ///
+  /// rangeSet.add(Range.closed(0, 100));
+  /// rangeSet.add(Range.closed(200, 300));
+  /// rangeSet.add(Range.closed(500, 600));
+  ///
+  /// RangeSet<Integer> enclosedSet = TreeRangeSet.create();
+  ///
+  /// enclosedSet.add(Range.closed(-10, 10));
+  /// enclosedSet.add(Range.open(150, 360));
+  /// enclosedSet.add(Range.open(590, 690));
+  ///
+  /// assertThat(rangeSet).doesNotEncloseAnyRangesOf(enclosedSet);
+  /// ```
+  ///
+  /// @param rangeSet the range set to check whether the actual `RangeSet` does not enclose any ranges from it.
+  /// @return this [RangeSetAssert] for assertions chaining.
+  /// @throws AssertionError if the actual `RangeSet` is `null`.
+  /// @throws AssertionError if the actual `RangeSet` encloses any range from the given range set.
+  /// @throws NullPointerException if range set is null.
+  /// @throws IllegalArgumentException if range set is empty.
   public RangeSetAssert<T> doesNotEncloseAnyRangesOf(RangeSet<T> rangeSet) {
     isNotNull();
     assertDoesNotEncloseAnyRangesOf(rangeSet);

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
@@ -566,7 +566,7 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
   /// rangeSet.add(Range.closed(200, 300));
   /// rangeSet.add(Range.closed(500, 600));
   ///
-  /// assertThat(rangeSet).intersectsAnyRangesOf(ImmutableRangeSet.of(Range.close(50, 150)));
+  /// assertThat(rangeSet).intersectsAnyRangesOf(ImmutableRangeSet.of(Range.closed(50, 150)));
   /// ```
   ///
   /// @param rangeSet the range set with ranges to check whether the actual `RangeSet` intersects at least one of
@@ -642,7 +642,7 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
   /// rangeSet.add(Range.closed(200, 300));
   /// rangeSet.add(Range.closed(500, 600));
   ///
-  /// assertThat(rangeSet).doesNotIntersectAnyRangeFrom(ImmutableRangeSet.of(Range.close(120, 170)));
+  /// assertThat(rangeSet).doesNotIntersectAnyRangeFrom(ImmutableRangeSet.of(Range.closed(120, 170)));
   /// ```
   ///
   /// @param rangeSet the range set to check whether the actual `RangeSet` does not intersect ranges from it.

--- a/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/RangeSetAssert.java
@@ -787,7 +787,7 @@ public class RangeSetAssert<T extends Comparable<T>> extends AbstractAssert<Rang
   /// rangeSet.add(Range.closed(200, 300));
   /// rangeSet.add(Range.closed(500, 600));
   ///
-  /// assertThat(rangeSet).enclosesAll(ImmutableRangeSet.of(Range.closed(0, 50));
+  /// assertThat(rangeSet).enclosesAll(ImmutableRangeSet.of(Range.closed(0, 50)));
   /// ```
   ///
   /// @param rangeSet the range set to check whether the actual `RangeSet` encloses all range from it.

--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -33,35 +33,32 @@ import org.assertj.core.error.ShouldNotBeEmpty;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, Table<R, C, V>> {
 
   protected TableAssert(Table<R, C, V> actual) {
     super(actual, TableAssert.class);
   }
 
-  /**
-   * Verifies that the actual {@link Table} has the expected number of rows.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table &lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).hasRowCount(2);</code></pre>
-   *
-   * @param expectedSize The columns to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if the expected size is negative
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not have the expected row size.
-   */
+  /// Verifies that the actual [Table] has the expected number of rows.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table <Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).hasRowCount(2);
+  /// ```
+  ///
+  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if the expected size is negative
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not have the expected row size.
   public TableAssert<R, C, V> hasRowCount(int expectedSize) {
     isNotNull();
     checkExpectedSizeArgument(expectedSize);
@@ -72,26 +69,25 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} has the expected number of columns.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).hasColumnCount(3);</code></pre>
-   *
-   * @param expectedSize The columns to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if the expected size is negative
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not have the expected column size.
-   */
+  /// Verifies that the actual [Table] has the expected number of columns.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).hasColumnCount(3);
+  /// ```
+  ///
+  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if the expected size is negative
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not have the expected column size.
   public TableAssert<R, C, V> hasColumnCount(int expectedSize) {
     isNotNull();
     checkExpectedSizeArgument(expectedSize);
@@ -102,26 +98,25 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} has the expected number of cells.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).hasSize(3);</code></pre>
-   *
-   * @param expectedSize The columns to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if the expected size is negative
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not have the expected number of cells.
-   */
+  /// Verifies that the actual [Table] has the expected number of cells.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).hasSize(3);
+  /// ```
+  ///
+  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if the expected size is negative
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not have the expected number of cells.
   public TableAssert<R, C, V> hasSize(int expectedSize) {
     isNotNull();
     checkExpectedSizeArgument(expectedSize);
@@ -132,26 +127,25 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} contains the given rows.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).containsRows(1, 2);</code></pre>
-   *
-   * @param rows The columns to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if no param rows have been set.
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not contain the given rows.
-   */
+  /// Verifies that the actual [Table] contains the given rows.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).containsRows(1, 2);
+  /// ```
+  ///
+  /// @param rows The columns to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if no param rows have been set.
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not contain the given rows.
   public TableAssert<R, C, V> containsRows(@SuppressWarnings("unchecked") R... rows) {
     isNotNull();
     checkArgument(rows != null, "The rows to look for should not be null.");
@@ -170,26 +164,25 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} contains the given columns.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).containsColumns(3, 4);</code></pre>
-   *
-   * @param columns The columns to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if no param columns have been set.
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not contain the given columns.
-   */
+  /// Verifies that the actual [Table] contains the given columns.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).containsColumns(3, 4);
+  /// ```
+  ///
+  /// @param columns The columns to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if no param columns have been set.
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not contain the given columns.
   public TableAssert<R, C, V> containsColumns(@SuppressWarnings("unchecked") C... columns) {
     isNotNull();
     checkArgument(columns != null, "The columns to look for should not be null.");
@@ -209,26 +202,25 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} contains the given values for any key.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).containsValues("Franklin Pierce", "Millard Fillmore");</code></pre>
-   *
-   * @param values The values to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws IllegalArgumentException if no param values have been set.
-   * @throws AssertionError           if the actual {@link Table} is {@code null}.
-   * @throws AssertionError           if the actual {@link Table} does not contain the given values.
-   */
+  /// Verifies that the actual [Table] contains the given values for any key.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).containsValues("Franklin Pierce", "Millard Fillmore");
+  /// ```
+  ///
+  /// @param values The values to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws IllegalArgumentException if no param values have been set.
+  /// @throws AssertionError           if the actual [Table] is `null`.
+  /// @throws AssertionError           if the actual [Table] does not contain the given values.
   public TableAssert<R, C, V> containsValues(@SuppressWarnings("unchecked") V... values) {
     isNotNull();
     checkArgument(values != null, "The values to look for should not be null.");
@@ -248,29 +240,28 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} contains the mapping of row/column to value.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   * actual.put(1, 4, "Franklin Pierce");
-   * actual.put(2, 5, "Grover Cleveland");
-   *
-   * assertThat(actual).containsCell(1, 3, "Millard Fillmore");</code></pre>
-   *
-   * @param row The row key to lookup in the actual {@link Table}
-   * @param column The column key to lookup in the actual {@link Table}
-   * @param expectedValue The value to look for in the actual {@link Table}
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws AssertionError if the actual {@link Table} is {@code null}.
-   * @throws AssertionError if the row key is {@code null}.
-   * @throws AssertionError if the column key is {@code null}.
-   * @throws AssertionError if the expected value is {@code null}.
-   */
+  /// Verifies that the actual [Table] contains the mapping of row/column to value.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  /// actual.put(1, 4, "Franklin Pierce");
+  /// actual.put(2, 5, "Grover Cleveland");
+  ///
+  /// assertThat(actual).containsCell(1, 3, "Millard Fillmore");
+  /// ```
+  ///
+  /// @param row The row key to lookup in the actual [Table]
+  /// @param column The column key to lookup in the actual [Table]
+  /// @param expectedValue The value to look for in the actual [Table]
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws AssertionError if the actual [Table] is `null`.
+  /// @throws AssertionError if the row key is `null`.
+  /// @throws AssertionError if the column key is `null`.
+  /// @throws AssertionError if the expected value is `null`.
   public TableAssert<R, C, V> containsCell(R row, C column, V expectedValue) {
     isNotNull();
     checkArgument(row != null, "The row to look for should not be null.");
@@ -285,19 +276,18 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     return myself;
   }
 
-  /**
-   * Verifies that the actual {@link Table} is empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * assertThat(actual).isEmpty();</code></pre>
-   *
-   * @throws AssertionError if the actual {@link Table} is {@code null}.
-   * @throws AssertionError if the actual {@link Table} is not empty.
-   */
+  /// Verifies that the actual [Table] is empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// assertThat(actual).isEmpty();
+  /// ```
+  ///
+  /// @throws AssertionError if the actual [Table] is `null`.
+  /// @throws AssertionError if the actual [Table] is not empty.
   public void isEmpty() {
     isNotNull();
     if (!actual.isEmpty()) {
@@ -305,24 +295,23 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
     }
   }
 
-  /**
-   * Verifies that the actual {@link Table} is not empty.
-   *
-   * <p>
-   * Example :
-   *
-   * <pre><code class='java'> Table&lt;Integer, Integer, String&gt; actual = HashBasedTable.create();
-   *
-   * actual.put(1, 3, "Millard Fillmore");
-   *
-   * assertThat(actual).isNotEmpty();</code></pre>
-   *
-   * @return this {@link TableAssert} for assertion chaining.
-   * @throws AssertionError if the actual {@link Table} is {@code null}.
-   * @throws AssertionError if the actual {@link Table} is empty.
-   *
-   * @since 3.27.0
-   */
+  /// Verifies that the actual [Table] is not empty.
+  ///
+  /// Example :
+  ///
+  /// ```java
+  /// Table<Integer, Integer, String> actual = HashBasedTable.create();
+  ///
+  /// actual.put(1, 3, "Millard Fillmore");
+  ///
+  /// assertThat(actual).isNotEmpty();
+  /// ```
+  ///
+  /// @return this [TableAssert] for assertion chaining.
+  /// @throws AssertionError if the actual [Table] is `null`.
+  /// @throws AssertionError if the actual [Table] is empty.
+  ///
+  /// @since 3.27.0
   public TableAssert<R, C, V> isNotEmpty() {
     isNotNull();
     if (actual.isEmpty()) {

--- a/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/api/TableAssert.java
@@ -54,7 +54,7 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
   /// assertThat(actual).hasRowCount(2);
   /// ```
   ///
-  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @param expectedSize the expected number of rows in the actual [Table]
   /// @return this [TableAssert] for assertion chaining.
   /// @throws IllegalArgumentException if the expected size is negative
   /// @throws AssertionError           if the actual [Table] is `null`.
@@ -83,7 +83,7 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
   /// assertThat(actual).hasColumnCount(3);
   /// ```
   ///
-  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @param expectedSize the expected number of columns in the actual [Table]
   /// @return this [TableAssert] for assertion chaining.
   /// @throws IllegalArgumentException if the expected size is negative
   /// @throws AssertionError           if the actual [Table] is `null`.
@@ -112,7 +112,7 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
   /// assertThat(actual).hasSize(3);
   /// ```
   ///
-  /// @param expectedSize The columns to look for in the actual [Table]
+  /// @param expectedSize the expected number of cells in the actual [Table]
   /// @return this [TableAssert] for assertion chaining.
   /// @throws IllegalArgumentException if the expected size is negative
   /// @throws AssertionError           if the actual [Table] is `null`.
@@ -141,7 +141,7 @@ public class TableAssert<R, C, V> extends AbstractAssert<TableAssert<R, C, V>, T
   /// assertThat(actual).containsRows(1, 2);
   /// ```
   ///
-  /// @param rows The columns to look for in the actual [Table]
+  /// @param rows The rows to look for in the actual [Table]
   /// @return this [TableAssert] for assertion chaining.
   /// @throws IllegalArgumentException if no param rows have been set.
   /// @throws AssertionError           if the actual [Table] is `null`.

--- a/assertj-guava/src/main/java/org/assertj/guava/data/MapEntry.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/data/MapEntry.java
@@ -20,29 +20,25 @@ import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Objects.hashCodeFor;
 import static org.assertj.core.util.Strings.quote;
 
-/**
- * This is generic version of {@link org.assertj.core.data.MapEntry}
- *
- * @param <K> key type
- * @param <V> value type
- *
- * @deprecated use {@link org.assertj.core.data.MapEntry org.assertj.core.data.MapEntry} instead.
- */
+/// This is generic version of [org.assertj.core.data.MapEntry]
+///
+/// @param <K> key type
+/// @param <V> value type
+///
+/// @deprecated use [org.assertj.core.data.MapEntry][org.assertj.core.data.MapEntry] instead.
 @Deprecated
 public final class MapEntry<K, V> {
   public final K key;
 
   public final V value;
 
-  /**
-   * Creates a new {@link MapEntry}.
-   *
-   * @param <K> key type
-   * @param <V> value type
-   * @param key the key of the entry to create.
-   * @param value the value of the entry to create.
-   * @return the created {@code MapEntry}.
-   */
+  /// Creates a new [MapEntry].
+  ///
+  /// @param <K> key type
+  /// @param <V> value type
+  /// @param key the key of the entry to create.
+  /// @param value the value of the entry to create.
+  /// @return the created `MapEntry`.
   public static <K, V> MapEntry<K, V> entry(K key, V value) {
     return new MapEntry<>(key, value);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/data/MapEntry.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/data/MapEntry.java
@@ -25,9 +25,10 @@ import static org.assertj.core.util.Strings.quote;
 /// @param <K> key type
 /// @param <V> value type
 ///
-/// @deprecated use [org.assertj.core.data.MapEntry][org.assertj.core.data.MapEntry] instead.
+/// @deprecated use [org.assertj.core.data.MapEntry] instead.
 @Deprecated
 public final class MapEntry<K, V> {
+
   public final K key;
 
   public final V value;

--- a/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainAtLeastTimes.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainAtLeastTimes.java
@@ -20,11 +20,9 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.Multiset;
 
-/**
- * Creates an error message stating that a given value appears in a {@link Multiset} fewer times than expected
- *
- * @author Max Daniline
- */
+/// Creates an error message stating that a given value appears in a [Multiset] fewer times than expected
+///
+/// @author Max Daniline
 public class MultisetShouldContainAtLeastTimes extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldContainAtLeastTimes(final Multiset<?> actual, final Object expected,

--- a/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainAtMostTimes.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainAtMostTimes.java
@@ -20,11 +20,9 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.Multiset;
 
-/**
- * Creates an error message stating that a given value appears in a {@link Multiset} more times than expected
- *
- * @author Max Daniline
- */
+/// Creates an error message stating that a given value appears in a [Multiset] more times than expected
+///
+/// @author Max Daniline
 public class MultisetShouldContainAtMostTimes extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldContainAtMostTimes(final Multiset<?> actual, final Object expected,

--- a/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainTimes.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainTimes.java
@@ -20,7 +20,7 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.Multiset;
 
-/// Creates an error message stating that a given value appears in a [Multiset] a different number of to the expected value
+/// Creates an error message stating that a given value appears in a [Multiset] a different number of times than expected
 ///
 /// @author Max Daniline
 public class MultisetShouldContainTimes extends BasicErrorMessageFactory {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainTimes.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/MultisetShouldContainTimes.java
@@ -20,11 +20,9 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.Multiset;
 
-/**
- * Creates an error message stating that a given value appears in a {@link Multiset} a different number of to the expected value
- *
- * @author Max Daniline
- */
+/// Creates an error message stating that a given value appears in a [Multiset] a different number of to the expected value
+///
+/// @author Max Daniline
 public class MultisetShouldContainTimes extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldContainTimes(final Multiset<?> actual, final Object expected,

--- a/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBeAbsent.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBeAbsent.java
@@ -20,12 +20,10 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.base.Optional;
 
-/**
- * Creates an error message indicating that an Optional which should be absent is actually present
- * 
- * @author Kornel Kiełczewski
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an Optional which should be absent is actually present
+///
+/// @author Kornel Kiełczewski
+/// @author Joel Costigliola
 public final class OptionalShouldBeAbsent extends BasicErrorMessageFactory {
 
   public static <T> ErrorMessageFactory shouldBeAbsent(final Optional<T> actual) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBePresent.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBePresent.java
@@ -20,13 +20,10 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.base.Optional;
 
-/**
- * 
- * Creates an error message indicating that an Optional which should be present is absent
- * 
- * @author Kornel Kiełczewski
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an Optional which should be present is absent
+///
+/// @author Kornel Kiełczewski
+/// @author Joel Costigliola
 public final class OptionalShouldBePresent extends BasicErrorMessageFactory {
 
   public static <T> ErrorMessageFactory shouldBePresent(final Optional<T> actual) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBePresentWithValue.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/OptionalShouldBePresentWithValue.java
@@ -20,13 +20,10 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.base.Optional;
 
-/**
- * 
- * Creates an error message indicating that an Optional should contain an expected value
- * 
- * @author Kornel Kiełczewski
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an Optional should contain an expected value
+///
+/// @author Kornel Kiełczewski
+/// @author Joel Costigliola
 public final class OptionalShouldBePresentWithValue extends BasicErrorMessageFactory {
 
   public static <T> ErrorMessageFactory shouldBePresentWithValue(final Optional<T> actual, final Object value) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEnclose.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEnclose.java
@@ -18,26 +18,22 @@ package org.assertj.guava.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * Creates an error message indicating that the given {@link com.google.common.collect.RangeSet} does not enclose 
- * neither another one {@link com.google.common.collect.RangeSet} nor some set of 
- * {@link com.google.common.collect.Range}.
- *
- * @author Ilya Koshaleu
- */
+/// Creates an error message indicating that the given [com.google.common.collect.RangeSet] does not enclose
+/// neither another one [com.google.common.collect.RangeSet] nor some set of
+/// [com.google.common.collect.Range].
+///
+/// @author Ilya Koshaleu
 public class RangeSetShouldEnclose extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldEnclose(Object actual, Object expected, Iterable<?> notEnclosed) {
     return new RangeSetShouldEnclose(actual, expected, notEnclosed);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   *
-   * @param actual actual {@code RangeSet}.
-   * @param expected expected range to check for enclosing.
-   * @param notEnclosed list of objects that have to be enclosed, but they haven't.
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual `RangeSet`.
+  /// @param expected expected range to check for enclosing.
+  /// @param notEnclosed list of objects that have to be enclosed, but they haven't.
   private RangeSetShouldEnclose(Object actual, Object expected, Object notEnclosed) {
     super("%nExpecting:%n  %s%nto enclose%n  %s%nbut it does not enclose%n  %s%n", actual, expected, notEnclosed);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEncloseAnyOf.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEncloseAnyOf.java
@@ -18,24 +18,20 @@ package org.assertj.guava.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * Creates an error message indicating that the given {@link com.google.common.collect.RangeSet} does not enclose
- * at lease one element of expected objects.
- *
- * @author Ilya Koshaleu
- */
+/// Creates an error message indicating that the given [com.google.common.collect.RangeSet] does not enclose
+/// at lease one element of expected objects.
+///
+/// @author Ilya Koshaleu
 public class RangeSetShouldEncloseAnyOf extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldEncloseAnyOf(Object actual, Object expected) {
     return new RangeSetShouldEncloseAnyOf(actual, expected);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   *
-   * @param actual actual {@code RangeSet}.
-   * @param expected expected range to check for enclosing
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual `RangeSet`.
+  /// @param expected expected range to check for enclosing
   private RangeSetShouldEncloseAnyOf(Object actual, Object expected) {
     super("%nExpecting:%n  %s%nto enclose any of%n  %s%n", actual, expected);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEncloseAnyOf.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldEncloseAnyOf.java
@@ -19,7 +19,7 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
 /// Creates an error message indicating that the given [com.google.common.collect.RangeSet] does not enclose
-/// at lease one element of expected objects.
+/// at least one element of expected objects.
 ///
 /// @author Ilya Koshaleu
 public class RangeSetShouldEncloseAnyOf extends BasicErrorMessageFactory {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersect.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersect.java
@@ -21,25 +21,21 @@ import org.assertj.core.error.ErrorMessageFactory;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
-/**
- * Creates an error message indicating that the given {@link RangeSet} does not intersect
- * either another one {@link RangeSet} or some set of {@link Range}.
- *
- * @author Ilya Koshaleu
- */
+/// Creates an error message indicating that the given [RangeSet] does not intersect
+/// either another one [RangeSet] or some set of [Range].
+///
+/// @author Ilya Koshaleu
 public class RangeSetShouldIntersect extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldIntersect(RangeSet<?> actual, Object expected, Iterable<?> notIntersected) {
     return new RangeSetShouldIntersect(actual, expected, notIntersected);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   *
-   * @param actual actual {@link RangeSet}.
-   * @param expected expected {@link RangeSet} that have to be intersected.
-   * @param notIntersected not intersected ranges.
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual [RangeSet].
+  /// @param expected expected [RangeSet] that have to be intersected.
+  /// @param notIntersected not intersected ranges.
   private RangeSetShouldIntersect(Object actual, Object expected, Object notIntersected) {
     super("%nExpecting:%n  %s%nto intersect%n  %s%nbut it does not intersect%n  %s%n",
           actual, expected, notIntersected);

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersect.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersect.java
@@ -18,11 +18,10 @@ package org.assertj.guava.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
 /// Creates an error message indicating that the given [RangeSet] does not intersect
-/// either another one [RangeSet] or some set of [Range].
+/// either another one [RangeSet] or some set of [com.google.common.collect.Range].
 ///
 /// @author Ilya Koshaleu
 public class RangeSetShouldIntersect extends BasicErrorMessageFactory {
@@ -31,11 +30,6 @@ public class RangeSetShouldIntersect extends BasicErrorMessageFactory {
     return new RangeSetShouldIntersect(actual, expected, notIntersected);
   }
 
-  /// Creates a new `[BasicErrorMessageFactory]`.
-  ///
-  /// @param actual actual [RangeSet].
-  /// @param expected expected [RangeSet] that have to be intersected.
-  /// @param notIntersected not intersected ranges.
   private RangeSetShouldIntersect(Object actual, Object expected, Object notIntersected) {
     super("%nExpecting:%n  %s%nto intersect%n  %s%nbut it does not intersect%n  %s%n",
           actual, expected, notIntersected);

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersectAnyOf.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersectAnyOf.java
@@ -20,24 +20,20 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.RangeSet;
 
-/**
- * Creates an error message indicating that the given {@link com.google.common.collect.RangeSet} does not intersect
- * at lease one element of expected objects.
- *
- * @author Ilya Koshaleu
- */
+/// Creates an error message indicating that the given [com.google.common.collect.RangeSet] does not intersect
+/// at lease one element of expected objects.
+///
+/// @author Ilya Koshaleu
 public class RangeSetShouldIntersectAnyOf extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldIntersectAnyOf(RangeSet<?> actual, Object expected) {
     return new RangeSetShouldIntersectAnyOf(actual, expected);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   *
-   * @param actual actual {@link com.google.common.collect.RangeSet}.
-   * @param expected expected range to intersect.
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual [com.google.common.collect.RangeSet].
+  /// @param expected expected range to intersect.
   private RangeSetShouldIntersectAnyOf(Object actual, Object expected) {
     super("%nExpecting:%n  %s%nto intersect at least one range of the given:%n  %s%n", actual, expected);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersectAnyOf.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldIntersectAnyOf.java
@@ -21,7 +21,7 @@ import org.assertj.core.error.ErrorMessageFactory;
 import com.google.common.collect.RangeSet;
 
 /// Creates an error message indicating that the given [com.google.common.collect.RangeSet] does not intersect
-/// at lease one element of expected objects.
+/// at least one element of expected objects.
 ///
 /// @author Ilya Koshaleu
 public class RangeSetShouldIntersectAnyOf extends BasicErrorMessageFactory {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotEnclose.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotEnclose.java
@@ -18,22 +18,18 @@ package org.assertj.guava.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 public class RangeSetShouldNotEnclose extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldNotEnclose(Object actual, Object expected, Iterable<?> enclosed) {
     return new RangeSetShouldNotEnclose(actual, expected, enclosed);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   * 
-   * @param actual actual {@code RangeSet}.
-   * @param expected expected value.
-   * @param enclosed list of values that haven't to be enclosed, but they have. 
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual `RangeSet`.
+  /// @param expected expected value.
+  /// @param enclosed list of values that haven't to be enclosed, but they have.
   private RangeSetShouldNotEnclose(Object actual, Object expected, Object enclosed) {
     super("%nExpecting:%n  %s%nnot to enclose%n  %s%nbut it encloses%n  %s%n", actual, expected, enclosed);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotEnclose.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotEnclose.java
@@ -29,7 +29,7 @@ public class RangeSetShouldNotEnclose extends BasicErrorMessageFactory {
   ///
   /// @param actual actual `RangeSet`.
   /// @param expected expected value.
-  /// @param enclosed list of values that haven't to be enclosed, but they have.
+  /// @param enclosed list of values that should not be enclosed, but they are.
   private RangeSetShouldNotEnclose(Object actual, Object expected, Object enclosed) {
     super("%nExpecting:%n  %s%nnot to enclose%n  %s%nbut it encloses%n  %s%n", actual, expected, enclosed);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotIntersect.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotIntersect.java
@@ -34,7 +34,7 @@ public class RangeSetShouldNotIntersect extends BasicErrorMessageFactory {
   ///
   /// @param actual actual `RangeSet`.
   /// @param unexpected ranges that should not be intersected.
-  /// @param intersected list of ranges that haven't be intersected, but they have.
+  /// @param intersected list of ranges that should not intersect, but they do.
   private RangeSetShouldNotIntersect(Object actual, Object unexpected, Object intersected) {
     super("%nExpecting:%n  %s%nnot to intersect%n  %s%nbut it intersects%n  %s%n",
           actual, unexpected, intersected);

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotIntersect.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeSetShouldNotIntersect.java
@@ -18,9 +18,7 @@ package org.assertj.guava.error;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author Ilya Koshaleu
- */
+/// @author Ilya Koshaleu
 public class RangeSetShouldNotIntersect extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldNotIntersect(Object actual, Object unexpected, Iterable<?> intersected) {
@@ -32,13 +30,11 @@ public class RangeSetShouldNotIntersect extends BasicErrorMessageFactory {
     return new RangeSetShouldNotIntersect(actual, unexpected, intersected);
   }
 
-  /**
-   * Creates a new <code>{@link BasicErrorMessageFactory}</code>.
-   * 
-   * @param actual actual {@code RangeSet}.
-   * @param unexpected ranges that should not be intersected.
-   * @param intersected list of ranges that haven't be intersected, but they have.
-   */
+  /// Creates a new `[BasicErrorMessageFactory]`.
+  ///
+  /// @param actual actual `RangeSet`.
+  /// @param unexpected ranges that should not be intersected.
+  /// @param intersected list of ranges that haven't be intersected, but they have.
   private RangeSetShouldNotIntersect(Object actual, Object unexpected, Object intersected) {
     super("%nExpecting:%n  %s%nnot to intersect%n  %s%nbut it intersects%n  %s%n",
           actual, unexpected, intersected);

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheLowerBound.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheLowerBound.java
@@ -27,12 +27,10 @@ public class RangeShouldBeClosedInTheLowerBound extends BasicErrorMessageFactory
                                                   "%nExpecting:%n  %s%nto be closed in the lower bound but was opened", actual);
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   public RangeShouldBeClosedInTheLowerBound(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheUpperBound.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeClosedInTheUpperBound.java
@@ -27,12 +27,10 @@ public class RangeShouldBeClosedInTheUpperBound extends BasicErrorMessageFactory
                                                   "%nExpecting:%n  %s%nto be closed in the upper bound but was opened", actual);
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   public RangeShouldBeClosedInTheUpperBound(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheLowerBound.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheLowerBound.java
@@ -27,12 +27,10 @@ public class RangeShouldBeOpenedInTheLowerBound extends BasicErrorMessageFactory
                                                   "%nExpecting:%n  %s%nto be opened in the lower bound but was closed", actual);
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   public RangeShouldBeOpenedInTheLowerBound(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheUpperBound.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldBeOpenedInTheUpperBound.java
@@ -27,12 +27,10 @@ public class RangeShouldBeOpenedInTheUpperBound extends BasicErrorMessageFactory
                                                   "%nExpecting:%n  %s%nto be opened in the upper bound but was closed", actual);
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   public RangeShouldBeOpenedInTheUpperBound(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldHaveLowerEndpointEqual.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldHaveLowerEndpointEqual.java
@@ -34,12 +34,10 @@ public class RangeShouldHaveLowerEndpointEqual extends BasicErrorMessageFactory 
                                                  actual, value, actual.lowerEndpoint());
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   private RangeShouldHaveLowerEndpointEqual(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldHaveUpperEndpointEqual.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/RangeShouldHaveUpperEndpointEqual.java
@@ -34,12 +34,10 @@ public class RangeShouldHaveUpperEndpointEqual extends BasicErrorMessageFactory 
                                                  actual, value, actual.upperEndpoint());
   }
 
-  /**
-   * Creates a new <code>{@link org.assertj.core.error.BasicErrorMessageFactory}</code>.
-   *
-   * @param format the format string.
-   * @param arguments arguments referenced by the format specifiers in the format string.
-   */
+  /// Creates a new `[org.assertj.core.error.BasicErrorMessageFactory]`.
+  ///
+  /// @param format the format string.
+  /// @param arguments arguments referenced by the format specifiers in the format string.
   private RangeShouldHaveUpperEndpointEqual(final String format, final Object... arguments) {
     super(format, arguments);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainKeys.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainKeys.java
@@ -20,12 +20,10 @@ import java.util.Set;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * Creates an error message indicating that an assertion that verifies a map contains some keys failed. TODO : move to
- * assertj-core to replace {@link org.assertj.core.error.ShouldContainKeys}.
- *
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an assertion that verifies a map contains some keys failed. TODO : move to
+/// assertj-core to replace [org.assertj.core.error.ShouldContainKeys].
+///
+/// @author Joel Costigliola
 public class ShouldContainKeys extends BasicErrorMessageFactory {
 
   private ShouldContainKeys(Object actual, Object key) {
@@ -36,14 +34,12 @@ public class ShouldContainKeys extends BasicErrorMessageFactory {
     super("%nExpecting:%n  %s%nto contain keys:%n  %s%nbut could not find:%n  %s", actual, keys, keysNotFound);
   }
 
-  /**
-   * Creates a new <code>{@link ShouldContainKeys}</code>.
-   *
-   * @param actual the actual value in the failed assertion.
-   * @param keys the expected keys.
-   * @param keysNotFound the missing keys.
-   * @return the created {@code ErrorMessageFactory}.
-   */
+  /// Creates a new `[ShouldContainKeys]`.
+  ///
+  /// @param actual the actual value in the failed assertion.
+  /// @param keys the expected keys.
+  /// @param keysNotFound the missing keys.
+  /// @return the created `ErrorMessageFactory`.
   public static ErrorMessageFactory shouldContainKeys(Object actual, Object[] keys, Set<?> keysNotFound) {
     return keys.length == 1 ? new ShouldContainKeys(actual, keys[0]) : new ShouldContainKeys(actual, keys, keysNotFound);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainValues.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainValues.java
@@ -21,12 +21,10 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.error.ShouldContainValue;
 
-/**
- * Creates an error message indicating that an assertion that verifies a map contains some values failed. TODO : move to
- * assertj-core to replace {@link ShouldContainValue}
- *
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an assertion that verifies a map contains some values failed. TODO : move to
+/// assertj-core to replace [ShouldContainValue]
+///
+/// @author Joel Costigliola
 public class ShouldContainValues extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory shouldContainValues(Object actual, Object[] values, Set<?> valuesNotFound) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainValues.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/ShouldContainValues.java
@@ -19,13 +19,12 @@ import java.util.Set;
 
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
-import org.assertj.core.error.ShouldContainValue;
 
-/// Creates an error message indicating that an assertion that verifies a map contains some values failed. TODO : move to
-/// assertj-core to replace [ShouldContainValue]
+/// Creates an error message indicating that an assertion that verifies a map contains some values failed.
 ///
 /// @author Joel Costigliola
 public class ShouldContainValues extends BasicErrorMessageFactory {
+  // TODO: move to assertj-core to replace org.assertj.core.error.ShouldContainValue
 
   public static ErrorMessageFactory shouldContainValues(Object actual, Object[] values, Set<?> valuesNotFound) {
     return values.length == 1 ? new ShouldContainValues(actual, values[0])

--- a/assertj-guava/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
@@ -20,7 +20,7 @@ import static java.lang.String.format;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/// Creates an error message indicating that an assertion that verifies that a value have certain size failed.
+/// Creates an error message indicating that an assertion that verifies that a value has a certain size failed.
 ///
 /// @author Joel Costigliola
 public class ShouldHaveSize extends BasicErrorMessageFactory {
@@ -39,4 +39,5 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
     // it will format sizes in hexadecimal while we only want actual to be formatted in hexadecimal
     super(format("%nExpected size: %s but was: %s in:%n%s", expectedSize, actualSize, "%s"), actual);
   }
+
 }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/ShouldHaveSize.java
@@ -20,20 +20,16 @@ import static java.lang.String.format;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * Creates an error message indicating that an assertion that verifies that a value have certain size failed.
- * 
- * @author Joel Costigliola
- */
+/// Creates an error message indicating that an assertion that verifies that a value have certain size failed.
+///
+/// @author Joel Costigliola
 public class ShouldHaveSize extends BasicErrorMessageFactory {
 
-  /**
-   * Creates a new <code>{@link org.assertj.guava.error.ShouldHaveSize}</code>.
-   * @param actual the actual value in the failed assertion.
-   * @param actualSize the size of {@code actual}.
-   * @param expectedSize the expected size.
-   * @return the created {@code ErrorMessageFactory}.
-   */
+  /// Creates a new `[org.assertj.guava.error.ShouldHaveSize]`.
+  /// @param actual the actual value in the failed assertion.
+  /// @param actualSize the size of `actual`.
+  /// @param expectedSize the expected size.
+  /// @return the created `ErrorMessageFactory`.
   public static ErrorMessageFactory shouldHaveSize(Object actual, long actualSize, long expectedSize) {
     return new ShouldHaveSize(actual, actualSize, expectedSize);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainCell.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainCell.java
@@ -22,24 +22,20 @@ import org.assertj.core.error.ErrorMessageFactory;
 
 import com.google.common.collect.Table;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableShouldContainCell extends BasicErrorMessageFactory {
 
-  /**
-   * Creates a new <code>{@link TableShouldContainCell}</code>.
-   * @param actual the actual value in the failed assertion.
-   * @param row the row where actualValue was read.
-   * @param column the column where actualValue was read.
-   * @param expectedValue the expected value of the cell.
-   * @param actualValue the expected actual value of the cell.
-   *
-  * @param <R> the type of the table row keys
-  * @param <C> the type of the table column keys
-  * @param <V> the type of the mapped values
-   * @return the created {@code ErrorMessageFactory}.
-   */
+  /// Creates a new `[TableShouldContainCell]`.
+  /// @param actual the actual value in the failed assertion.
+  /// @param row the row where actualValue was read.
+  /// @param column the column where actualValue was read.
+  /// @param expectedValue the expected value of the cell.
+  /// @param actualValue the expected actual value of the cell.
+  ///
+  /// @param <R> the type of the table row keys
+  /// @param <C> the type of the table column keys
+  /// @param <V> the type of the mapped values
+  /// @return the created `ErrorMessageFactory`.
   public static <R, C, V> ErrorMessageFactory tableShouldContainCell(Table<R, C, V> actual, R row, C column, V expectedValue,
                                                                      V actualValue) {
     return new TableShouldContainCell(actual, row, column, expectedValue, actualValue);

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainColumns.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainColumns.java
@@ -20,9 +20,7 @@ import java.util.Set;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableShouldContainColumns extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory tableShouldContainColumns(Object actual, Object[] columns, Set<?> columnsNotFound) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainRows.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldContainRows.java
@@ -20,9 +20,7 @@ import java.util.Set;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author Jan Gorman
- */
+/// @author Jan Gorman
 public class TableShouldContainRows extends BasicErrorMessageFactory {
 
   public static ErrorMessageFactory tableShouldContainRows(Object actual, Object[] rows, Set<?> rowsNotFound) {

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveColumnCount.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveColumnCount.java
@@ -20,18 +20,14 @@ import static java.lang.String.format;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableShouldHaveColumnCount extends BasicErrorMessageFactory {
 
-  /**
-   * Creates a new <code>{@link TableShouldHaveColumnCount}</code>.
-   * @param actual the actual value in the failed assertion.
-   * @param actualSize the number of column keys in {@code actual}.
-   * @param expectedSize the expected number of column keys.
-   * @return the created {@code ErrorMessageFactory}.
-   */
+  /// Creates a new `[TableShouldHaveColumnCount]`.
+  /// @param actual the actual value in the failed assertion.
+  /// @param actualSize the number of column keys in `actual`.
+  /// @param expectedSize the expected number of column keys.
+  /// @return the created `ErrorMessageFactory`.
   public static ErrorMessageFactory tableShouldHaveColumnCount(Object actual, int actualSize, int expectedSize) {
     return new TableShouldHaveColumnCount(actual, actualSize, expectedSize);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCount.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/error/TableShouldHaveRowCount.java
@@ -20,18 +20,14 @@ import static java.lang.String.format;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
-/**
- * @author David Harris
- */
+/// @author David Harris
 public class TableShouldHaveRowCount extends BasicErrorMessageFactory {
 
-  /**
-   * Creates a new <code>{@link TableShouldHaveRowCount}</code>.
-   * @param actual the actual value in the failed assertion.
-   * @param actualSize the number of row keys in {@code actual}.
-   * @param expectedSize the expected number of row keys.
-   * @return the created {@code ErrorMessageFactory}.
-   */
+  /// Creates a new `[TableShouldHaveRowCount]`.
+  /// @param actual the actual value in the failed assertion.
+  /// @param actualSize the number of row keys in `actual`.
+  /// @param expectedSize the expected number of row keys.
+  /// @return the created `ErrorMessageFactory`.
   public static ErrorMessageFactory tableShouldHaveRowCount(Object actual, int actualSize, int expectedSize) {
     return new TableShouldHaveRowCount(actual, actualSize, expectedSize);
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/util/ExceptionUtils.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/util/ExceptionUtils.java
@@ -33,7 +33,7 @@ public class ExceptionUtils {
     }
   }
 
-  /// protected to avoid direct instanciation but allowing subclassing.
+  /// protected to avoid direct instantiation but allowing subclassing.
   protected ExceptionUtils() {
     // empty
   }

--- a/assertj-guava/src/main/java/org/assertj/guava/util/ExceptionUtils.java
+++ b/assertj-guava/src/main/java/org/assertj/guava/util/ExceptionUtils.java
@@ -19,15 +19,13 @@ import static java.lang.String.format;
 
 public class ExceptionUtils {
 
-  /**
-   * Throws a {@link IllegalArgumentException} if given condition is true with message formatted with given arguments
-   * using {@link String#format(String, Object...)}.
-   * 
-   * @param condition condition that will trigger the {@link IllegalArgumentException} if true
-   * @param exceptionMessage message set in thrown IllegalArgumentException
-   * @param exceptionMessageArgs arguments to be used to format exceptionMessage
-   * @throws IllegalArgumentException if condition is true
-   */
+  /// Throws a [IllegalArgumentException] if given condition is true with message formatted with given arguments
+  /// using [String#format(String, Object...)].
+  ///
+  /// @param condition condition that will trigger the [IllegalArgumentException] if true
+  /// @param exceptionMessage message set in thrown IllegalArgumentException
+  /// @param exceptionMessageArgs arguments to be used to format exceptionMessage
+  /// @throws IllegalArgumentException if condition is true
   public static void throwIllegalArgumentExceptionIfTrue(boolean condition, String exceptionMessage,
                                                          Object... exceptionMessageArgs) {
     if (condition) {
@@ -35,9 +33,7 @@ public class ExceptionUtils {
     }
   }
 
-  /**
-   * protected to avoid direct instanciation but allowing subclassing.
-   */
+  /// protected to avoid direct instanciation but allowing subclassing.
   protected ExceptionUtils() {
     // empty
   }

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                 <include>src/test/java/**/*.java</include>
               </includes>
               <eclipse>
+                <version>4.40</version> <!-- FIXME evaluate removal -->
                 <file>${rootDirectory}/eclipse/assertj-eclipse-formatter.xml</file>
               </eclipse>
               <importOrder>


### PR DESCRIPTION
This migrates the `assertj-guava` Javadoc to the Markdown syntax.

Relates to:
* #3977

Blocked by:
* https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5220