### PR TITLE
Clarify `isNotEqualTo` limitations on testing `equals` and `hashCode`

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/Assert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/Assert.java
@@ -72,13 +72,13 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * For comprehensive testing of the {@code equals} and {@code hashCode} contracts, consider using
    * dedicated libraries such as:
    *
-   *  <ul>
+   * <ul>
    * <li><a href="https://jqno.nl/equalsverifier/">EqualsVerifier</a></li>
    * <li>Guava's <a href="https://javadoc.io/doc/com.google.guava/guava-testlib/latest/com/google/common/testing/EqualsTester.html">EqualsTester</a></li>
    * </ul>
    *
    * To verify that two objects have the same field values without relying on {@code equals}, use
-   * the {@link AbstractObjectAssert#usingRecursiveComparison() recursive comparison}.
+   * the {@linkplain AbstractObjectAssert#usingRecursiveComparison() recursive comparison}.
    *
    * @param expected the expected value to compare the actual value to.
    * @return {@code this} assertion object.
@@ -97,6 +97,36 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * // assertions fail
    * assertThat(&quot;abc&quot;).isNotEqualTo(&quot;abc&quot;);
    * assertThat(new HashMap&lt;String, Integer&gt;()).isNotEqualTo(new HashMap&lt;String, Integer&gt;());</code></pre>
+   *
+   * <b>Note on testing {@link Object#equals(Object) equals} and {@link Object#hashCode() hashCode}
+   * contracts</b>
+   * <p>
+   * {@code isNotEqualTo} uses a comparison strategy to determine equality and is <b>not</b> designed
+   * to validate the correctness of {@code equals} or {@code hashCode} implementations. By default,
+   * the comparison strategy delegates to the object's {@code equals} method (or performs deep
+   * equality for arrays).
+   * This means {@code isNotEqualTo} only verifies the <i>outcome</i> of a single equality check;
+   * it does not validate that the full {@code equals} contract (reflexivity, symmetry,
+   * transitivity, consistency, and null-handling) is satisfied.
+   * <p>
+   * If the {@code equals} implementation returns an incorrect result, {@code isNotEqualTo} will
+   * accept that result without detecting the bug.
+   * <p>
+   * Additionally, the comparison strategy can be customized via
+   * {@link #usingComparator(Comparator)} or {@link #usingEquals(BiPredicate)}.
+   * In these cases, {@code isNotEqualTo} bypasses {@code equals} entirely in favor of the provided
+   * logic.
+   * <p>
+   * For comprehensive testing of the {@code equals} and {@code hashCode} contracts, consider using
+   * dedicated libraries such as:
+   *
+   * <ul>
+   * <li><a href="https://jqno.nl/equalsverifier/">EqualsVerifier</a></li>
+   * <li>Guava's <a href="https://javadoc.io/doc/com.google.guava/guava-testlib/latest/com/google/common/testing/EqualsTester.html">EqualsTester</a></li>
+   * </ul>
+   *
+   * To verify that two objects do not have the same field values without relying on {@code equals}, use
+   * the {@linkplain AbstractObjectAssert#usingRecursiveComparison() recursive comparison}.
    *
    * @param other the expected value to compare the actual value to.
    * @return {@code this} assertion object.


### PR DESCRIPTION
* Follow up to #3865
* Relates to #4101
