### PR TITLE
Add tests for PathNaturalOrderComparator comparison and null-handling behaviour

### DIFF
--- a/assertj-core/src/test/java/org/assertj/core/util/PathNaturalOrderComparatorTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/util/PathNaturalOrderComparatorTest.java
@@ -17,6 +17,9 @@ package org.assertj.core.util;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -28,4 +31,40 @@ class PathNaturalOrderComparatorTest {
     then(PathNaturalOrderComparator.INSTANCE).hasToString("lexicographic comparator (Path natural order)");
   }
 
+  @Test
+  public void should_return_zero_when_comparing_equal_paths() {
+    Path a = Paths.get("/foo/bar");
+    then(PathNaturalOrderComparator.INSTANCE.compare(a, a)).isZero();
+  }
+
+  @Test
+  public void should_return_negative_when_first_path_is_less_than_second() {
+    Path a = Paths.get("/aaa");
+    Path b = Paths.get("/zzz");
+    then(PathNaturalOrderComparator.INSTANCE.compare(a, b)).isNegative();
+  }
+
+  @Test
+  public void should_return_positive_when_first_path_is_greater_than_second() {
+    Path a = Paths.get("/zzz");
+    Path b = Paths.get("/aaa");
+    then(PathNaturalOrderComparator.INSTANCE.compare(a, b)).isPositive();
+  }
+
+  @Test
+  public void should_return_negative_when_first_argument_is_null() {
+    Path p = Paths.get("/foo");
+    then(PathNaturalOrderComparator.INSTANCE.compare(null, p)).isEqualTo(-1);
+  }
+
+  @Test
+  public void should_return_positive_when_second_argument_is_null() {
+    Path p = Paths.get("/foo");
+    then(PathNaturalOrderComparator.INSTANCE.compare(p, null)).isEqualTo(1);
+  }
+
+  @Test
+  public void should_return_zero_when_both_arguments_are_null() {
+    then(PathNaturalOrderComparator.INSTANCE.compare(null, null)).isZero();
+  }
 }


### PR DESCRIPTION
Adds tests covering `PathNaturalOrderComparator`'s `compare` method: equal paths return zero, natural ordering returns negative/positive, and the inherited null-safe contract returns -1 for a null first argument, 1 for a null second argument, and 0 when both are null. Previously only the `toString` description was tested.

| metric | before | after |
|---|---|---|
| mutation score | 0% | 100% |
| test methods added | n/a | 6 |

The additions are append-only (no existing test is modified) and pass against the current code.

---

**How this was produced**

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant. Where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant. So every added test is verified to catch a concrete edge case the suite missed before, rather than being speculative or redundant. The change is additive only (no production code modified), and the module builds green under its CI JDK.
