### PR TITLE
feat: add allElementsAreEqual assertion for iterables

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -548,6 +548,31 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return executeAssertion(() -> iterables.assertDoesNotHaveDuplicates(info, actual));
   }
 
+  /**
+   * Verifies that all the elements of the actual iterable are equal to each other, using the {@link Object#equals(Object)}
+   * implementation of the elements (or the comparator set with {@link #usingElementComparator(java.util.Comparator)}).
+   * <p>
+   * This is convenient when the reference element cannot easily be extracted from the iterable, for example when the
+   * iterable is produced by a chain of {@code filteredOn}/{@code extracting} calls.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions succeed
+   * assertThat(list(&quot;a&quot;, &quot;a&quot;, &quot;a&quot;)).allElementsAreEqual();
+   * assertThat(list(&quot;a&quot;)).allElementsAreEqual();
+   * assertThat(emptyList()).allElementsAreEqual();
+   *
+   * // assertion fails
+   * assertThat(list(&quot;a&quot;, &quot;a&quot;, &quot;b&quot;)).allElementsAreEqual();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual iterable is {@code null}.
+   * @throws AssertionError if the actual iterable contains at least two elements that are not equal.
+   * @since 4.0.0
+   */
+  public SELF allElementsAreEqual() {
+    return executeAssertion(() -> iterables.assertAllElementsAreEqual(info, actual));
+  }
+
   @Override
   @SafeVarargs
   public final SELF startsWith(ELEMENT... sequence) {

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveAllElementsEqual.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveAllElementsEqual.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.api.comparisonstrategy.ComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that all the elements of a group are equal failed. A group
+ * of elements can be a collection, an array or a {@code String}.
+ */
+public class ShouldHaveAllElementsEqual extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldHaveAllElementsEqual}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param first the first element of {@code actual}, all other elements are expected to be equal to it.
+   * @param notEqualElements the elements of {@code actual} that are not equal to {@code first}.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return an instance of {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveAllElementsEqual(Object actual, Object first, Object notEqualElements,
+                                                               ComparisonStrategy comparisonStrategy) {
+    return new ShouldHaveAllElementsEqual(actual, first, notEqualElements, comparisonStrategy);
+  }
+
+  private ShouldHaveAllElementsEqual(Object actual, Object first, Object notEqualElements,
+                                     ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting all elements to be equal to:%n  %s%nbut the following element(s) were not:%n  %s%nin:%n  %s%n%s",
+          first, notEqualElements, actual, comparisonStrategy);
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -52,6 +52,7 @@ import static org.assertj.core.error.ShouldContainSubsequence.actualDoesNotHaveE
 import static org.assertj.core.error.ShouldContainSubsequence.shouldContainSubsequence;
 import static org.assertj.core.error.ShouldContainsOnlyOnce.shouldContainsOnlyOnce;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
+import static org.assertj.core.error.ShouldHaveAllElementsEqual.shouldHaveAllElementsEqual;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.error.ShouldNotContainNull.shouldNotContainNull;
@@ -725,6 +726,29 @@ public class Iterables {
     Iterable<?> duplicates = comparisonStrategy.duplicatesFrom(actual);
     if (!isNullOrEmpty(duplicates))
       throw failures.failure(info, shouldNotHaveDuplicates(actual, duplicates, comparisonStrategy));
+  }
+
+  /**
+   * Asserts that all the elements of the given {@code Iterable} are equal to each other. An empty or single-element
+   * {@code Iterable} passes as there is nothing that can differ.
+   *
+   * @param info   contains information about the assertion.
+   * @param actual the given {@code Iterable}.
+   * @throws AssertionError if the given {@code Iterable} is {@code null}.
+   * @throws AssertionError if the given {@code Iterable} contains at least two elements that are not equal.
+   */
+  public void assertAllElementsAreEqual(AssertionInfo info, Iterable<?> actual) {
+    assertNotNull(info, actual);
+    Iterator<?> iterator = actual.iterator();
+    if (!iterator.hasNext()) return;
+    Object first = iterator.next();
+    List<Object> notEqualElements = new ArrayList<>();
+    while (iterator.hasNext()) {
+      Object element = iterator.next();
+      if (!areEqual(first, element)) notEqualElements.add(element);
+    }
+    if (!notEqualElements.isEmpty())
+      throw failures.failure(info, shouldHaveAllElementsEqual(actual, first, notEqualElements, comparisonStrategy));
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_allElementsAreEqual_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/iterable/IterableAssert_allElementsAreEqual_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+
+/**
+ * Tests for <code>{@link AbstractIterableAssert#allElementsAreEqual()}</code>.
+ */
+class IterableAssert_allElementsAreEqual_Test extends IterableAssertBaseTest {
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.allElementsAreEqual();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertAllElementsAreEqual(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllElementsAreEqual_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/iterables/Iterables_assertAllElementsAreEqual_Test.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.internal.iterables;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveAllElementsEqual.shouldHaveAllElementsEqual;
+import static org.assertj.core.testkit.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.comparisonstrategy.StandardComparisonStrategy;
+import org.assertj.core.internal.Iterables;
+import org.assertj.core.internal.IterablesBaseTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Iterables#assertAllElementsAreEqual(AssertionInfo, Iterable)}</code>.
+ */
+class Iterables_assertAllElementsAreEqual_Test extends IterablesBaseTest {
+
+  @Test
+  void should_pass_if_all_elements_are_equal() {
+    // GIVEN
+    List<String> actual = newArrayList("Yoda", "Yoda", "Yoda");
+    // WHEN/THEN
+    iterables.assertAllElementsAreEqual(someInfo(), actual);
+  }
+
+  @Test
+  void should_pass_if_actual_has_only_one_element() {
+    // GIVEN
+    List<String> actual = newArrayList("Yoda");
+    // WHEN/THEN
+    iterables.assertAllElementsAreEqual(someInfo(), actual);
+  }
+
+  @Test
+  void should_pass_if_actual_is_empty() {
+    // WHEN/THEN
+    iterables.assertAllElementsAreEqual(someInfo(), emptyList());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError error = expectAssertionError(() -> iterables.assertAllElementsAreEqual(someInfo(), null));
+    // THEN
+    then(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_and_report_all_elements_that_are_not_equal_to_the_first() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    List<String> actual = newArrayList("Yoda", "Yoda", "Luke", "Yoda", "Leia");
+    // WHEN
+    expectAssertionError(() -> iterables.assertAllElementsAreEqual(info, actual));
+    // THEN
+    verify(failures).failure(info, shouldHaveAllElementsEqual(actual, "Yoda", newArrayList("Luke", "Leia"),
+                                                              StandardComparisonStrategy.instance()));
+  }
+
+  @Test
+  void should_produce_a_readable_error_message() {
+    // GIVEN
+    List<String> actual = newArrayList("a", "b");
+    // WHEN
+    AssertionError error = expectAssertionError(() -> iterables.assertAllElementsAreEqual(someInfo(), actual));
+    // THEN
+    then(error).hasMessageContaining("Expecting all elements to be equal to:")
+               .hasMessageContaining("\"a\"")
+               .hasMessageContaining("but the following element(s) were not:")
+               .hasMessageContaining("[\"b\"]");
+  }
+
+  // ------------------------------------------------------------------------------------------------------------------
+  // tests using a custom comparison strategy
+  // ------------------------------------------------------------------------------------------------------------------
+
+  @Test
+  void should_pass_if_all_elements_are_equal_according_to_custom_comparison_strategy() {
+    // GIVEN
+    List<String> actual = newArrayList("Yoda", "YODA", "yoda");
+    // WHEN/THEN
+    iterablesWithCaseInsensitiveComparisonStrategy.assertAllElementsAreEqual(someInfo(), actual);
+  }
+
+  @Test
+  void should_fail_if_elements_are_not_equal_according_to_custom_comparison_strategy() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    List<String> actual = newArrayList("Yoda", "YODA", "Luke");
+    // WHEN
+    expectAssertionError(() -> iterablesWithCaseInsensitiveComparisonStrategy.assertAllElementsAreEqual(info, actual));
+    // THEN
+    verify(failures).failure(info, shouldHaveAllElementsEqual(actual, "Yoda", newArrayList("Luke"), comparisonStrategy));
+  }
+
+}


### PR DESCRIPTION
Closes #4302

## Why

There is currently no chaining-friendly way to assert that all elements of an iterable are equal to each other. The workaround `assertThat(list).allMatch(e -> e.equals(list.get(0)))` requires a direct reference to the first element, which is awkward when the iterable is produced by a chain of `filteredOn`/`extracting` calls and cannot be easily referenced. As discussed in the issue, @joel-costigliola agreed to add `allElementsAreEqual` (equality-based, not reference-based).

## What

Adds `allElementsAreEqual()` to `AbstractIterableAssert`, so it is available on all `Iterable`-based assertions:

```java
assertThat(dataLines).allElementsAreEqual();
```

- Passes when all elements are equal, and (vacuously) for empty or single-element iterables — consistent with `allMatch`/`allSatisfy`.
- Fails otherwise, reporting every element that is not equal to the first.
- Honors a custom element comparator set via `usingElementComparator(...)` (the assertion goes through the internal `comparisonStrategy`).

New error factory `ShouldHaveAllElementsEqual` produces a message such as:

```
Expecting all elements to be equal to:
  "a"
but the following element(s) were not:
  ["b"]
in:
  ["a", "b"]
```

## Tests

- `Iterables_assertAllElementsAreEqual_Test` — engine behaviour: all-equal, single-element and empty pass; null actual; failure reports all unequal elements; readable error message; and the custom (case-insensitive) comparison-strategy pass/fail paths.
- `IterableAssert_allElementsAreEqual_Test` — verifies the public API delegates to the internal engine (`IterableAssertBaseTest`).

Verification done: ran `./mvnw -pl assertj-core test` for both new test classes (10 tests, all green); `spotless:apply` and `license:format` produce no further changes.

I followed the discussion in #4302; if you would prefer this also exposed on `ObjectEnumerableAssert` (arrays) or want the pair/fold assertions tracked separately, happy to adjust.