### PR TITLE
Enable new Enforcer rules that inspect the compiled output

### DIFF
--- a/assertj-core/pom.xml
+++ b/assertj-core/pom.xml
@@ -239,18 +239,22 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-
-        <configuration>
-          <rules combine.children="append">
-            <bannedDependencies>
-              <excludes>
-                <exclude>org.assertj:assertj-core</exclude>
-                <exclude>org.hamcrest:hamcrest-core</exclude>
-                <exclude>*:*:*:jar:compile</exclude>
-              </excludes>
-            </bannedDependencies>
-          </rules>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <configuration>
+              <rules combine.children="append">
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.assertj:assertj-core</exclude>
+                    <exclude>org.hamcrest:hamcrest-core</exclude>
+                    <exclude>*:*:*:jar:compile</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/assertj-guava/pom.xml
+++ b/assertj-guava/pom.xml
@@ -64,19 +64,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules combine.children="append">
-            <bannedDependencies>
-              <includes>
-                <include>org.assertj:assertj-core</include>
-              </includes>
-              <excludes>
-                <exclude>org.assertj:assertj-guava</exclude>
-                <exclude>*:*:*:jar:compile</exclude>
-              </excludes>
-            </bannedDependencies>
-          </rules>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <configuration>
+              <rules combine.children="append">
+                <bannedDependencies>
+                  <includes>
+                    <include>org.assertj:assertj-core</include>
+                  </includes>
+                  <excludes>
+                    <exclude>org.assertj:assertj-guava</exclude>
+                    <exclude>*:*:*:jar:compile</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>biz.aQute.bnd</groupId>

--- a/assertj-tests/pom.xml
+++ b/assertj-tests/pom.xml
@@ -31,18 +31,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules combine.children="append">
-            <bannedDependencies>
-              <includes>
-                <include>*:*:*:jar:test</include>
-              </includes>
-              <excludes>
-                <exclude>*</exclude>
-              </excludes>
-            </bannedDependencies>
-          </rules>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <configuration>
+              <rules combine.children="append">
+                <bannedDependencies>
+                  <includes>
+                    <include>*:*:*:jar:test</include>
+                  </includes>
+                  <excludes>
+                    <exclude>*</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.6.4-SNAPSHOT</maven-enforcer-plugin.version> <!-- FIXME -->
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
@@ -242,11 +242,6 @@ limitations under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
-          <configuration>
-            <rules>
-              <dependencyConvergence />
-            </rules>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -405,9 +400,30 @@ limitations under the License.
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
+            <id>default</id>
             <goals>
               <goal>enforce</goal>
             </goals>
+            <configuration>
+              <rules>
+                <dependencyConvergence/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compiled-output</id>
+            <phase>process-classes</phase> <!-- Earliest phase to let rules inspect the compiled output -->
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banSplitPackages />
+                <banUnjustifiedOpens/>
+                <requireExplicitModules/>
+                <requireMinimalExports/>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This PR tests the changes introduced by:
* https://github.com/apache/maven-enforcer/pull/996
* https://github.com/apache/maven-enforcer/pull/1000

As the new version is not yet available, a local build of the Enforcer plugin is required.
