### PR TITLE
Enable `reactorModuleConvergence` Enforcer rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
           <configuration>
             <rules>
               <dependencyConvergence/>
+              <reactorModuleConvergence/>
             </rules>
           </configuration>
         </plugin>


### PR DESCRIPTION
This change enables the [Reactor Module Convergence](https://maven.apache.org/enforcer/enforcer-rules/reactorModuleConvergence.html) rule of the Maven Enforcer Plugin.
