### PR TITLE
fix: take trailing newlines into account in hasContent (#2993)

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -441,10 +441,12 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
-   * Verifies that the text content of the actual {@code File} is <b>exactly</b> equal to the given one <b>except for newlines wich are ignored</b>.
+   * Verifies that the text content of the actual {@code File} is <b>exactly</b> equal to the given one. Newlines are
+   * taken into account (including a single trailing newline).
    * <p>
-   * This will change in AssertJ 4.0 where newlines will be taken into account, in the meantime, to get this behavior
-   * one can use {@link #content()} and then chain with {@link AbstractStringAssert#isEqualTo(String)}.
+   * Line ending style ({@code \n}, {@code \r}, {@code \r\n}) is normalized when comparing lines. For more granular
+   * string assertions on the content (for example ignoring newlines), use {@link #content()} and chain string
+   * assertions such as {@link AbstractStringAssert#isEqualToIgnoringNewlines(CharSequence)}.
    * <p>
    * The charset to use when reading the file should be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
@@ -457,13 +459,14 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * // The following assertion succeeds (default charset is used):
    * assertThat(xFile).hasContent(&quot;The Truth Is Out There&quot;);
    *
-   * // The following assertion fails:
+   * // The following assertions fail (content differs / trailing newline differs):
    * assertThat(xFile).hasContent(&quot;La Vérité Est Ailleurs&quot;);
+   * assertThat(xFile).hasContent(&quot;The Truth Is Out There\n&quot;);
    *
    * // using a specific charset
    * Charset turkishCharset = Charset.forName(&quot;windows-1254&quot;);
    *
-   * File xFileTurkish = Files.write(Paths.get(&quot;xfile.turk&quot;), Collections.singleton(&quot;Gerçek&quot;), turkishCharset).toFile();
+   * File xFileTurkish = Files.write(Paths.get(&quot;xfile.turk&quot;), &quot;Gerçek&quot;.getBytes(turkishCharset)).toFile();
    *
    * // The following assertion succeeds:
    * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent(&quot;Gerçek&quot;);

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractInputStreamAssert.java
@@ -234,10 +234,12 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
   }
 
   /**
-   * Verifies that the content of the actual {@code InputStream} is equal to the given {@code String} <b>except for newlines which are ignored</b>.
+   * Verifies that the content of the actual {@code InputStream} is equal to the given {@code String}. Newlines are
+   * taken into account (including a single trailing newline).
    * <p>
-   * This will change in AssertJ 4.0 where newlines will be taken into account, in the meantime, to get this behavior
-   * one can use {@link #asString(Charset)} and then chain with {@link AbstractStringAssert#isEqualTo(String)}.
+   * Line ending style ({@code \n}, {@code \r}, {@code \r\n}) is normalized when comparing lines. For more granular
+   * string assertions on the content (for example ignoring newlines), use {@link #asString(Charset)} and chain string
+   * assertions such as {@link AbstractStringAssert#isEqualToIgnoringNewlines(CharSequence)}.
    * <p>
    * The {@link Charset#defaultCharset() default charset} is used for decoding the bytes of the stream to a String.
    * To use a different charset for decoding, use {@link #asString(Charset)}.
@@ -251,7 +253,8 @@ public abstract class AbstractInputStreamAssert<SELF extends AbstractInputStream
    *
    * // assertions will fail
    * assertThat(new ByteArrayInputStream("a".getBytes())).hasContent("");
-   * assertThat(new ByteArrayInputStream("a".getBytes())).hasContent("ab");</code></pre>
+   * assertThat(new ByteArrayInputStream("a".getBytes())).hasContent("ab");
+   * assertThat(new ByteArrayInputStream("a".getBytes())).hasContent("a\n");</code></pre>
    *
    * @param expected the given {@code String} to compare the actual {@code InputStream} to.
    * @return {@code this} assertion object.

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -276,10 +276,11 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
 
   /**
    * Verifies that the text content of the actual {@code Path} (which must be a readable file) is <b>exactly</b> equal
-   * to the given one <b>except for newlines wich are ignored</b>.
+   * to the given one. Newlines are taken into account (including a single trailing newline).
    * <p>
-   * This will change in AssertJ 4.0 where newlines will be taken into account, in the meantime, to get this behavior
-   * one can use {@link #content()} and then chain with {@link AbstractStringAssert#isEqualTo(String)}.
+   * Line ending style ({@code \n}, {@code \r}, {@code \r\n}) is normalized when comparing lines. For more granular
+   * string assertions on the content (for example ignoring newlines), use {@link #content()} and chain string
+   * assertions such as {@link AbstractStringAssert#isEqualToIgnoringNewlines(CharSequence)}.
    * <p>
    * The charset to use when reading the actual path should be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
@@ -292,13 +293,14 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * // The following assertion succeeds (default charset is used):
    * assertThat(xFile).hasContent("The Truth Is Out There");
    *
-   * // The following assertion fails:
+   * // The following assertions fail (content differs / trailing newline differs):
    * assertThat(xFile).hasContent("La Vérité Est Ailleurs");
+   * assertThat(xFile).hasContent("The Truth Is Out There\n");
    *
    * // using a specific charset
    * Charset turkishCharset = Charset.forName("windows-1254");
    *
-   * Path xFileTurkish = Files.write(Paths.get("xfile.turk"), Collections.singleton("Gerçek Başka bir yerde mi"), turkishCharset);
+   * Path xFileTurkish = Files.write(Paths.get("xfile.turk"), "Gerçek Başka bir yerde mi".getBytes(turkishCharset));
    *
    * // The following assertion succeeds:
    * assertThat(xFileTurkish).usingCharset(turkishCharset).hasContent("Gerçek Başka bir yerde mi");

--- a/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Diff.java
@@ -28,6 +28,7 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.util.diff.Delta;
@@ -155,12 +156,24 @@ public class Diff {
     }
   }
 
+  // Reads all content then splits on any line terminator (\n, \r, \r\n). A trailing terminator is kept as a final
+  // empty line so that "a" and "a\n" are not considered equal (see https://github.com/assertj/assertj/issues/2993).
+  // BufferedReader.readLine() would drop that distinction.
   private List<String> linesFromBufferedReader(BufferedReader reader) throws IOException {
-    String line;
-    List<String> lines = new ArrayList<>();
-    while ((line = reader.readLine()) != null) {
-      lines.add(line);
+    StringBuilder content = new StringBuilder();
+    char[] buffer = new char[8192];
+    int read;
+    while ((read = reader.read(buffer)) != -1) {
+      content.append(buffer, 0, read);
     }
-    return lines;
+    return splitLines(content.toString());
+  }
+
+  private static List<String> splitLines(String content) {
+    if (content.isEmpty()) {
+      return new ArrayList<>();
+    }
+    // limit -1 keeps trailing empty strings produced by a final line terminator
+    return new ArrayList<>(Arrays.asList(content.split("\\R", -1)));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
@@ -36,7 +36,7 @@ class FileAssert_size_Test {
               .isGreaterThan(4L)
               .isLessThan(20L)
               .isBetween(1L, 10L)
-              .returnToFile().hasContent("actual");
+              .returnToFile().hasContent("actual\n");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_size_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/path/PathAssert_size_Test.java
@@ -36,7 +36,7 @@ class PathAssert_size_Test {
               .isGreaterThan(4L)
               .isLessThan(20L)
               .isBetween(1L, 10L)
-              .returnToPath().hasContent("actual");
+              .returnToPath().hasContent("actual\n");
   }
 
   @Test

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Diff_diff_File_String_Test.java
@@ -61,7 +61,8 @@ class Diff_diff_File_String_Test {
   void should_return_empty_diff_list_if_file_and_string_have_equal_content() throws IOException {
     String[] content = array("line0", "line1");
     writer.write(actual, content);
-    String expected = "line0%nline1".formatted();
+    // TextFileWriter uses println, so the file ends with a trailing line separator
+    String expected = "line0%nline1%n".formatted();
     List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).isEmpty();
   }
@@ -69,7 +70,7 @@ class Diff_diff_File_String_Test {
   @Test
   void should_return_diffs_if_file_and_string_do_not_have_equal_content() throws IOException {
     writer.write(actual, StandardCharsets.UTF_8, "Touché");
-    String expected = "Touché";
+    String expected = "Touché%n".formatted();
     List<Delta<String>> diffs = diff.diff(actual, expected, StandardCharsets.ISO_8859_1);
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Changed content at line 1:%n"
@@ -82,7 +83,7 @@ class Diff_diff_File_String_Test {
   @Test
   void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0");
-    String expected = "line_0%nline_1".formatted();
+    String expected = "line_0%nline_1%n".formatted();
     List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
@@ -92,10 +93,21 @@ class Diff_diff_File_String_Test {
   @Test
   void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
     writer.write(actual, "line_0", "line_1");
-    String expected = "line_0";
+    String expected = "line_0%n".formatted();
     List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 2:%n"
                                                 + "  [\"line_1\"]%n"));
+  }
+
+  @Test
+  void should_return_diff_when_only_trailing_newline_differs() throws IOException {
+    // file without trailing newline
+    java.nio.file.Files.writeString(actual.toPath(), "line_0");
+    String expected = "line_0%n".formatted();
+    List<Delta<String>> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    assertThat(diffs).hasSize(1);
+    assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
+                                                + "  [\"\"]%n"));
   }
 }

--- a/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/internal/files/Files_assertHasContent_Test.java
@@ -93,7 +93,8 @@ class Files_assertHasContent_Test extends FilesBaseTest {
 
   @Test
   void should_pass_if_file_has_text_content() {
-    String expected = "actual";
+    // actual_file.txt contains "actual" followed by a trailing newline
+    String expected = "actual\n";
     underTest.assertHasContent(INFO, actual, expected, charset);
   }
 

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/Diff_diff_InputStream_String_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/inputstreams/Diff_diff_InputStream_String_Test.java
@@ -19,8 +19,10 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.tests.core.internal.inputstreams.Diff_diff_InputStream_Test.stream;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.assertj.core.internal.Diff;
@@ -127,6 +129,30 @@ class Diff_diff_InputStream_String_Test {
     assertThat(diffs).hasSize(1);
     assertThat(diffs.get(0)).hasToString(format("Extra content at line 1:%n"
                                                 + "  [\"\"]%n"));
+  }
+
+  @Test
+  void should_return_diff_when_expected_has_trailing_newline_and_actual_does_not() throws IOException {
+    // GIVEN
+    actual = stream("line_0");
+    expected = "line_0" + System.lineSeparator();
+    // WHEN
+    List<Delta<String>> diffs = diff.diff(actual, expected);
+    // THEN
+    assertThat(diffs).hasSize(1);
+    assertThat(diffs.get(0)).hasToString(format("Missing content at line 2:%n"
+                                                + "  [\"\"]%n"));
+  }
+
+  @Test
+  void should_return_empty_diff_when_actual_and_expected_both_end_with_trailing_newline() throws IOException {
+    // GIVEN
+    actual = new ByteArrayInputStream(("line_0" + System.lineSeparator()).getBytes(StandardCharsets.US_ASCII));
+    expected = "line_0" + System.lineSeparator();
+    // WHEN
+    List<Delta<String>> diffs = diff.diff(actual, expected);
+    // THEN
+    assertThat(diffs).isEmpty();
   }
 
   static String joinLines(String... lines) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasTextualContent_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/internal/paths/Paths_assertHasTextualContent_Test.java
@@ -101,6 +101,38 @@ class Paths_assertHasTextualContent_Test extends PathsBaseTest {
   }
 
   @Test
+  void should_pass_if_actual_and_expected_both_end_with_a_trailing_newline() throws IOException {
+    // GIVEN
+    Path actual = Files.writeString(tempDir.resolve("actual"), "Content\n");
+    // WHEN/THEN
+    underTest.assertHasTextualContent(INFO, actual, "Content\n", CHARSET);
+  }
+
+  @Test
+  void should_fail_if_expected_has_trailing_newline_but_actual_does_not() throws IOException {
+    // GIVEN
+    Path actual = Files.writeString(tempDir.resolve("actual"), "Content");
+    String expected = "Content\n";
+    List<Delta<String>> diffs = diff.diff(actual, expected, CHARSET);
+    // WHEN
+    var error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
+    // THEN
+    then(error).hasMessage(shouldHaveContent(actual, CHARSET, diffs).create(INFO.description(), INFO.representation()));
+  }
+
+  @Test
+  void should_fail_if_actual_has_trailing_newline_but_expected_does_not() throws IOException {
+    // GIVEN
+    Path actual = Files.writeString(tempDir.resolve("actual"), "Content\n");
+    String expected = "Content";
+    List<Delta<String>> diffs = diff.diff(actual, expected, CHARSET);
+    // WHEN
+    var error = expectAssertionError(() -> underTest.assertHasTextualContent(INFO, actual, expected, CHARSET));
+    // THEN
+    then(error).hasMessage(shouldHaveContent(actual, CHARSET, diffs).create(INFO.description(), INFO.representation()));
+  }
+
+  @Test
   void should_fail_if_actual_does_not_have_expected_textual_content() throws IOException {
     // GIVEN
     Path actual = Files.write(tempDir.resolve("actual"), "Content".getBytes(CHARSET));


### PR DESCRIPTION
#### Check List:
* Fixes #2993
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

### Description

Team decision on #2993: keep 3.x behavior, but in 4.0 take newlines into account for `hasContent`.

`Diff` used `BufferedReader.readLine()`, which drops the distinction between content with and without a single trailing line terminator (`"a"` vs `"a\n"`). That made:

```java
assertThat(path).hasContent("Hello, world!")
                .hasContent("Hello, world!\n"); // both passed
```

**Change:** read full text and split with `split("\\R", -1)` so a final terminator is kept as a trailing empty line. Line-ending *style* (`\n` / `\r` / `\r\n`) stays normalized; only presence/absence of a trailing terminator (and other real line differences) matters.

**Javadoc:** Path / File / InputStream `hasContent` no longer claim newlines are ignored; document exact comparison and point to `content()` / `asString()` + `isEqualToIgnoringNewlines` when that is desired.

**Tests:** trailing-newline pass/fail cases on `Paths_assertHasTextualContent`, `Diff` File/String and InputStream/String; existing File→String fixtures updated so expected strings include the trailing separator written by `TextFileWriter` / resource files.

Verified locally (JDK 25+/Homebrew OpenJDK 26, `./mvnw`):
- `Diff_diff_File_*`, `Files_assertHasContent_*`, size/hasContent unit tests
- `Paths_assertHasTextualContent_Test`, `Diff_diff_InputStream_*`, `InputStreamAssert_hasContent_Test`