### PR TITLE
fix: show Timestamp nanos in StandardRepresentation

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/assertj-core/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -33,6 +33,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -588,6 +589,23 @@ public class StandardRepresentation implements Representation {
     return ISO_DATE_FORMAT_WITH_MS.get().format(date);
   }
 
+  // Timestamp comparison uses nanos; SimpleDateFormat only shows millis — append sub-ms digits when present
+  // so failure messages do not look identical for values that differ only in nanos (see #4241).
+  private static String formatTimestamp(Timestamp timestamp) {
+    String withMillis = formatDate(timestamp);
+    int subMillisecondNanos = timestamp.getNanos() % 1_000_000;
+    if (subMillisecondNanos == 0) {
+      return withMillis;
+    }
+    // Drop trailing zeros (same idea as Instant.toString()).
+    String extra = "%06d".formatted(subMillisecondNanos);
+    int end = extra.length();
+    while (end > 0 && extra.charAt(end - 1) == '0') {
+      end--;
+    }
+    return withMillis + extra.substring(0, end);
+  }
+
   private static String formatCalendar(Calendar calendar) {
     return ISO_DATE_FORMAT_WITHOUT_MS.get().format(calendar.getTime());
   }
@@ -599,6 +617,9 @@ public class StandardRepresentation implements Representation {
    * @return the formatted value
    */
   protected String toStringOf(Date date) {
+    if (date instanceof Timestamp timestamp) {
+      return formatTimestamp(timestamp) + classNameDisambiguation(timestamp);
+    }
     return formatDate(date) + classNameDisambiguation(date);
   }
 

--- a/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isAfterOrEqualTo_with_Instant_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/date/DateAssert_isAfterOrEqualTo_with_Instant_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeAfterOrEqualTo.shouldBeAfterOrEqualTo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavioral tests for {@link org.assertj.core.api.AbstractDateAssert#isAfterOrEqualTo(Instant)}.
+ * <p>
+ * Covers the case where a millis-only {@link Timestamp} (e.g. from {@code System.currentTimeMillis()}) is
+ * compared to an {@link Instant} with sub-millisecond precision — comparison correctly fails due to nanos,
+ * and the failure message must show that precision (see issue #4241).
+ */
+class DateAssert_isAfterOrEqualTo_with_Instant_Test {
+
+  @Test
+  void should_pass_if_timestamp_is_after_or_equal_to_instant() {
+    // GIVEN
+    Instant instant = Instant.parse("2011-01-01T00:00:00.123456Z");
+    Timestamp later = Timestamp.from(instant.plusMillis(1));
+    Timestamp equalWithNanos = Timestamp.from(instant);
+    // WHEN/THEN
+    then(later).isAfterOrEqualTo(instant);
+    then(equalWithNanos).isAfterOrEqualTo(instant);
+  }
+
+  @Test
+  void should_fail_if_millis_only_timestamp_is_before_instant_with_sub_ms_precision() {
+    // GIVEN — Instant has micros; Timestamp from epoch millis truncates them
+    Instant withMicros = Instant.parse("2011-01-01T00:00:00.123456Z");
+    Timestamp actualMillisOnly = new Timestamp(withMicros.toEpochMilli());
+    // WHEN
+    var assertionError = expectAssertionError(() -> assertThat(actualMillisOnly).isAfterOrEqualTo(withMicros));
+    // THEN — message uses Timestamp.from(instant) as the comparison target (dateFrom)
+    then(assertionError).hasMessage(shouldBeAfterOrEqualTo(actualMillisOnly, Timestamp.from(withMicros)).create());
+    then(assertionError).hasMessageContaining("123456");
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldBeAfterOrEqualTo_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldBeAfterOrEqualTo_create_Test.java
@@ -22,6 +22,9 @@ import static org.assertj.core.internal.DatesBaseTest.parseDate;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.testkit.NeverEqualComparator.NEVER_EQUALS;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+
 import org.assertj.core.api.comparisonstrategy.ComparatorBasedComparisonStrategy;
 import org.assertj.core.description.Description;
 import org.assertj.core.description.TextDescription;
@@ -65,5 +68,27 @@ class ShouldBeAfterOrEqualTo_create_Test {
                             "  2012-01-01T00:00:00.000 (java.util.Date)%n" +
                             "when comparing values using '%s'",
                             NEVER_EQUALS.description());
+  }
+
+  @Test
+  void should_create_error_message_showing_Timestamp_nanos_so_values_are_distinguishable() {
+    // GIVEN — same millisecond, different nanos (typical Instant.now() vs currentTimeMillis case)
+    Instant withMicros = Instant.parse("2011-01-01T00:00:00.123456Z");
+    Timestamp actualMillisOnly = new Timestamp(withMicros.toEpochMilli());
+    Timestamp otherWithNanos = Timestamp.from(withMicros);
+    ErrorMessageFactory factory = shouldBeAfterOrEqualTo(actualMillisOnly, otherWithNanos);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN — both would look identical at ms precision; nanos must appear so the failure is understandable
+    then(message).contains("123456");
+    then(STANDARD_REPRESENTATION.toStringOf(actualMillisOnly)).doesNotContain("123456");
+    then(STANDARD_REPRESENTATION.toStringOf(otherWithNanos)).contains("123456");
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  %s%n" +
+                                   "to be after or equal to:%n" +
+                                   "  %s%n",
+                                   STANDARD_REPRESENTATION.toStringOf(actualMillisOnly),
+                                   STANDARD_REPRESENTATION.toStringOf(otherWithNanos)));
   }
 }

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_toStringOf_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/presentation/StandardRepresentation_toStringOf_Test.java
@@ -28,7 +28,9 @@ import java.io.Serial;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -322,6 +324,29 @@ class StandardRepresentation_toStringOf_Test extends AbstractBaseRepresentationT
     String dateRepresentation = STANDARD_REPRESENTATION.toStringOf(date);
     // THEN
     then(dateRepresentation).isEqualTo("2011-06-18T23:53:17.000 (java.util.Date)");
+  }
+
+  @Test
+  void should_return_toString_of_Timestamp_with_millisecond_precision_only() {
+    // GIVEN — millis-only Timestamp (e.g. from System.currentTimeMillis)
+    Timestamp timestamp = Timestamp.from(Instant.parse("2011-06-18T16:53:17.123Z"));
+    // WHEN
+    String representation = STANDARD_REPRESENTATION.toStringOf(timestamp);
+    // THEN
+    then(representation).endsWith(" (java.sql.Timestamp)");
+    then(representation).contains(".123");
+    then(representation).doesNotContain(".1234");
+  }
+
+  @Test
+  void should_return_toString_of_Timestamp_including_sub_millisecond_nanos() {
+    // GIVEN — nanos beyond millis (e.g. Timestamp.from(Instant.now()) on high-res clocks)
+    Timestamp timestamp = Timestamp.from(Instant.parse("2011-06-18T16:53:17.123456789Z"));
+    // WHEN
+    String representation = STANDARD_REPRESENTATION.toStringOf(timestamp);
+    // THEN — sub-ms digits must be visible so same-millis values are distinguishable in error messages
+    then(representation).endsWith(" (java.sql.Timestamp)");
+    then(representation).contains(".123456789");
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #4241
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

### Description

When asserting a millis-only `java.sql.Timestamp` (e.g. built from `System.currentTimeMillis()`) with `isAfterOrEqualTo(Instant)`, AssertJ converts the `Instant` via `Timestamp.from(instant)`, which keeps nanoseconds. Comparison is therefore nano-aware and can fail when the values share the same millisecond but differ in sub-ms precision.

The failure message used `SimpleDateFormat` with only millisecond precision, so both sides looked identical and the assertion error appeared to contradict itself.

### Change

`StandardRepresentation` now includes sub-millisecond digits from `Timestamp.getNanos()` (trailing zeros stripped, Instant-style) so the precision mismatch is visible in the error message.

Assertion behavior is unchanged — only the representation is improved.

### Example

```java
Instant withMicros = Instant.parse("2011-01-01T00:00:00.123456Z");
Timestamp actual = new Timestamp(withMicros.toEpochMilli()); // millis only

assertThat(actual).isAfterOrEqualTo(withMicros);
// still fails (correct), but the message now shows ...123 vs ...123456
```