### PR TITLE
Add hasEnclosingClass and hasNoEnclosingClass assertions

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -35,6 +35,7 @@ import static org.assertj.core.error.ShouldBeRecord.shouldBeRecord;
 import static org.assertj.core.error.ShouldBeRecord.shouldNotBeRecord;
 import static org.assertj.core.error.ShouldBeSealed.shouldBeSealed;
 import static org.assertj.core.error.ShouldBeSealed.shouldNotBeSealed;
+import static org.assertj.core.error.ShouldHaveEnclosingClass.shouldHaveEnclosingClass;
 import static org.assertj.core.error.ShouldHaveNoPackage.shouldHaveNoPackage;
 import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
 import static org.assertj.core.error.ShouldHavePackage.shouldHavePackage;
@@ -785,6 +786,64 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
   }
 
   /**
+   * Verifies that the actual {@code Class} has the given class as direct enclosing class (as in
+   * {@link Class#getEnclosingClass()}).
+   * <p>
+   * The expected {@code enclosingClass} should always be not {@code null}. To verify the absence of the enclosing class,
+   * use {@link #hasNoEnclosingClass()}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> class Outer {
+   *
+   *   static class Nested { }
+   *
+   *   class Inner { }
+   *
+   *   static Class&lt;?&gt; local() {
+   *     class Local { }
+   *     return Local.class;
+   *   }
+   *
+   *   static Class&lt;?&gt; anonymous() {
+   *     return new Object() { }.getClass();
+   *   }
+   * }
+   *
+   * // these assertions succeed:
+   * assertThat(Outer.Nested.class).hasEnclosingClass(Outer.class);
+   * assertThat(Outer.Inner.class).hasEnclosingClass(Outer.class);
+   * assertThat(Outer.local()).hasEnclosingClass(Outer.class);
+   * assertThat(Outer.anonymous()).hasEnclosingClass(Outer.class);
+   *
+   * // this assertion fails as top-level classes have no enclosing class:
+   * assertThat(Outer.class).hasEnclosingClass(Object.class);
+   *
+   * // this assertion fails as only the direct enclosing class matches:
+   * assertThat(Map.Entry.class).hasEnclosingClass(Object.class);</code></pre>
+   *
+   * @param enclosingClass the class which must be the direct enclosing class of actual.
+   * @return {@code this} assertions object
+   * @throws NullPointerException if {@code enclosingClass} is {@code null}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} doesn't have the given class as direct enclosing class.
+   * @since 3.28.0
+   * @see #hasNoEnclosingClass()
+   */
+  public SELF hasEnclosingClass(Class<?> enclosingClass) {
+    isNotNull();
+    assertHasEnclosingClass(enclosingClass);
+    return myself;
+  }
+
+  private void assertHasEnclosingClass(Class<?> enclosingClass) {
+    requireNonNull(enclosingClass, shouldNotBeNull("enclosingClass")::create);
+    Class<?> actualEnclosingClass = actual.getEnclosingClass();
+    if (actualEnclosingClass == null || !actualEnclosingClass.equals(enclosingClass)) {
+      throw assertionError(shouldHaveEnclosingClass(actual, enclosingClass));
+    }
+  }
+
+  /**
    * @deprecated use {@link #hasPublicFields(String...)} instead.
    * @param fields the fields who must be in the class.
    * @return {@code this} assertions object
@@ -1021,7 +1080,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * Verifies that the actual {@code Class} has the given package name (as in {@link Class#getPackage()}).
    * <p>
    * The expected package name should always be not {@code null}. To verify the absence of the package, use
-   * {@link #hasNoPackage()}. 
+   * {@link #hasNoPackage()}.
    * <p>
    * Example:
    * <pre><code class='java'> package one.two;
@@ -1061,7 +1120,7 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
    * Verifies that the actual {@code Class} has the given package (as in {@link Class#getPackage()}).
    * <p>
    * The expected package should always be not {@code null}. To verify the absence of the package, use
-   * {@link #hasNoPackage()}. 
+   * {@link #hasNoPackage()}.
    * <p>
    * Example:
    * <pre><code class='java'> package one.two;

--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractClassAssert.java
@@ -36,6 +36,7 @@ import static org.assertj.core.error.ShouldBeRecord.shouldNotBeRecord;
 import static org.assertj.core.error.ShouldBeSealed.shouldBeSealed;
 import static org.assertj.core.error.ShouldBeSealed.shouldNotBeSealed;
 import static org.assertj.core.error.ShouldHaveEnclosingClass.shouldHaveEnclosingClass;
+import static org.assertj.core.error.ShouldHaveNoEnclosingClass.shouldHaveNoEnclosingClass;
 import static org.assertj.core.error.ShouldHaveNoPackage.shouldHaveNoPackage;
 import static org.assertj.core.error.ShouldHaveNoSuperclass.shouldHaveNoSuperclass;
 import static org.assertj.core.error.ShouldHavePackage.shouldHavePackage;
@@ -841,6 +842,47 @@ public abstract class AbstractClassAssert<SELF extends AbstractClassAssert<SELF>
     if (actualEnclosingClass == null || !actualEnclosingClass.equals(enclosingClass)) {
       throw assertionError(shouldHaveEnclosingClass(actual, enclosingClass));
     }
+  }
+
+  /**
+   * Verifies that the actual {@code Class} has no enclosing class (as in {@link Class#getEnclosingClass()}, when
+   * {@code null} is returned), which is the case for top-level classes.
+   * <p>
+   * Example:
+   * <pre><code class='java'> class Outer {
+   *
+   *   static class Nested { }
+   * }
+   *
+   * // this assertion succeeds as Outer is a top-level class:
+   * assertThat(Outer.class).hasNoEnclosingClass();
+   *
+   * // this assertion succeeds as array classes have no enclosing class, even for nested component types:
+   * assertThat(Outer.Nested[].class).hasNoEnclosingClass();
+   *
+   * // this assertion succeeds as primitive types have no enclosing class:
+   * assertThat(Integer.TYPE).hasNoEnclosingClass();
+   *
+   * // this assertion succeeds as void type has no enclosing class:
+   * assertThat(Void.TYPE).hasNoEnclosingClass();
+   *
+   * // this assertion fails as Nested is enclosed in Outer:
+   * assertThat(Outer.Nested.class).hasNoEnclosingClass();</code></pre>
+   *
+   * @return {@code this} assertions object
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the actual {@code Class} has an enclosing class.
+   * @since 3.28.0
+   * @see #hasEnclosingClass(Class)
+   */
+  public SELF hasNoEnclosingClass() {
+    isNotNull();
+    assertHasNoEnclosingClass();
+    return myself;
+  }
+
+  private void assertHasNoEnclosingClass() {
+    if (actual.getEnclosingClass() != null) throw assertionError(shouldHaveNoEnclosingClass(actual));
   }
 
   /**

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveEnclosingClass.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveEnclosingClass.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.error;
+
+import java.util.StringJoiner;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class has a given enclosing class failed.
+ *
+ * @author Chanwon Lee
+ */
+public class ShouldHaveEnclosingClass extends BasicErrorMessageFactory {
+
+  private static final String SHOULD_HAVE_ENCLOSING_CLASS = new StringJoiner("%n", "%n", "").add("Expecting")
+                                                                                            .add("  %s")
+                                                                                            .add("to have enclosing class:")
+                                                                                            .add("  %s")
+                                                                                            .toString();
+
+  private static final String BUT_HAD_NONE = new StringJoiner("%n", "%n", "").add("but had none.")
+                                                                             .toString();
+
+  private static final String BUT_HAD = new StringJoiner("%n", "%n", "").add("but had:")
+                                                                        .add("  %s")
+                                                                        .toString();
+
+  /**
+   * Creates a new <code>{@link ShouldHaveEnclosingClass}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param enclosingClass expected enclosing class for this class.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveEnclosingClass(Class<?> actual, Class<?> enclosingClass) {
+    Class<?> actualEnclosingClass = actual.getEnclosingClass();
+    return (actualEnclosingClass == null)
+        ? new ShouldHaveEnclosingClass(actual, enclosingClass)
+        : new ShouldHaveEnclosingClass(actual, enclosingClass, actualEnclosingClass);
+  }
+
+  private ShouldHaveEnclosingClass(Class<?> actual, Class<?> expectedEnclosingClass) {
+    super(SHOULD_HAVE_ENCLOSING_CLASS + BUT_HAD_NONE, actual, expectedEnclosingClass);
+  }
+
+  private ShouldHaveEnclosingClass(Class<?> actual, Class<?> expectedEnclosingClass, Class<?> actualEnclosingClass) {
+    super(SHOULD_HAVE_ENCLOSING_CLASS + BUT_HAD, actual, expectedEnclosingClass, actualEnclosingClass);
+  }
+}

--- a/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveNoEnclosingClass.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/ShouldHaveNoEnclosingClass.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.error;
+
+import java.util.StringJoiner;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a class has no enclosing class failed.
+ *
+ * @author Chanwon Lee
+ */
+public class ShouldHaveNoEnclosingClass extends BasicErrorMessageFactory {
+
+  private static final String SHOULD_HAVE_NO_ENCLOSING_CLASS = new StringJoiner("%n", "%n",
+                                                                                "").add("Expecting")
+                                                                                   .add("  %s")
+                                                                                   .add("to have no enclosing class, but had:")
+                                                                                   .add("  %s")
+                                                                                   .toString();
+
+  /**
+   * Creates a new <code>{@link ShouldHaveNoEnclosingClass}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveNoEnclosingClass(Class<?> actual) {
+    return new ShouldHaveNoEnclosingClass(actual);
+  }
+
+  private ShouldHaveNoEnclosingClass(Class<?> actual) {
+    super(SHOULD_HAVE_NO_ENCLOSING_CLASS, actual, actual.getEnclosingClass());
+  }
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveEnclosingClass_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveEnclosingClass_create_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveEnclosingClass.shouldHaveEnclosingClass;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import java.util.Map;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+class ShouldHaveEnclosingClass_create_Test {
+
+  @Test
+  void should_create_error_message_if_actual_has_enclosing_class() {
+    // WHEN
+    String message = shouldHaveEnclosingClass(Map.Entry.class, Integer.class).create(new TestDescription("TEST"),
+                                                                                     STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %n" +
+                                   "Expecting%n" +
+                                   "  java.util.Map.Entry%n" +
+                                   "to have enclosing class:%n" +
+                                   "  java.lang.Integer%n" +
+                                   "but had:%n" +
+                                   "  java.util.Map"));
+  }
+
+  @Test
+  void should_create_error_message_if_actual_has_no_enclosing_class() {
+    // WHEN
+    String message = shouldHaveEnclosingClass(String.class, Integer.class).create(new TestDescription("TEST"),
+                                                                                  STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %n" +
+                                   "Expecting%n" +
+                                   "  java.lang.String%n" +
+                                   "to have enclosing class:%n" +
+                                   "  java.lang.Integer%n" +
+                                   "but had none."));
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveNoEnclosingClass_create_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/error/ShouldHaveNoEnclosingClass_create_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveNoEnclosingClass.shouldHaveNoEnclosingClass;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import java.util.Map;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+class ShouldHaveNoEnclosingClass_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // WHEN
+    String message = shouldHaveNoEnclosingClass(Map.Entry.class).create(new TestDescription("TEST"),
+                                                                        STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[TEST] %n" +
+                                   "Expecting%n" +
+                                   "  java.util.Map.Entry%n" +
+                                   "to have no enclosing class, but had:%n" +
+                                   "  java.util.Map"));
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasEnclosingClass_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasEnclosingClass_Test.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveEnclosingClass.shouldHaveEnclosingClass;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ClassAssert_hasEnclosingClass_Test {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Class<?> actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasEnclosingClass(Object.class));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_null_class_is_given() {
+    // GIVEN
+    Class<?> actual = Nested.class;
+    Class<?> enclosingClass = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertThat(actual).hasEnclosingClass(enclosingClass));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(shouldNotBeNull("enclosingClass").create());
+  }
+
+  @ParameterizedTest
+  @MethodSource("enclosedClasses")
+  void should_pass_if_actual_has_given_class_as_direct_enclosing_class(Class<?> actual) {
+    // WHEN/THEN
+    assertThat(actual).hasEnclosingClass(ClassAssert_hasEnclosingClass_Test.class);
+  }
+
+  private static Stream<Class<?>> enclosedClasses() {
+    return Stream.of(Nested.class,
+                     Inner.class,
+                     localClass(),
+                     anonymousClass());
+  }
+
+  @ParameterizedTest
+  @MethodSource("noEnclosingClassTypes")
+  void should_fail_if_actual_has_no_enclosing_class(Class<?> actual) {
+    // GIVEN
+    Class<?> enclosingClass = Object.class;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasEnclosingClass(enclosingClass));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveEnclosingClass(actual, enclosingClass).create());
+  }
+
+  private static Stream<Class<?>> noEnclosingClassTypes() {
+    return Stream.of(ClassAssert_hasEnclosingClass_Test.class, // any top-level class
+                     Nested[].class, // array classes have no enclosing class
+                     Integer.TYPE,
+                     Void.TYPE);
+  }
+
+  @Test
+  void should_fail_if_actual_has_not_given_class_as_enclosing_class() {
+    // GIVEN
+    Class<?> actual = Nested.class;
+    Class<?> enclosingClass = Object.class;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasEnclosingClass(enclosingClass));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveEnclosingClass(actual, enclosingClass).create());
+  }
+
+  @Test
+  void should_fail_if_actual_has_given_class_as_indirect_enclosing_class() {
+    // GIVEN
+    Class<?> actual = Nested.DeeplyNested.class;
+    Class<?> enclosingClass = ClassAssert_hasEnclosingClass_Test.class;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasEnclosingClass(enclosingClass));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveEnclosingClass(actual, enclosingClass).create());
+  }
+
+  private static Class<?> localClass() {
+    class Local {
+    }
+    return Local.class;
+  }
+
+  private static Class<?> anonymousClass() {
+    return new Object() {}.getClass();
+  }
+
+  private static class Nested {
+
+    private static class DeeplyNested {
+    }
+  }
+
+  private class Inner {
+  }
+
+}

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasNoEnclosingClass_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/class_/ClassAssert_hasNoEnclosingClass_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.tests.core.api.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveNoEnclosingClass.shouldHaveNoEnclosingClass;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.tests.core.util.AssertionsUtil.expectAssertionError;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ClassAssert_hasNoEnclosingClass_Test {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Class<?> actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasNoEnclosingClass());
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @ParameterizedTest
+  @MethodSource("enclosedClasses")
+  void should_fail_if_actual_has_an_enclosing_class(Class<?> actual) {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasNoEnclosingClass());
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoEnclosingClass(actual).create());
+  }
+
+  private static Stream<Class<?>> enclosedClasses() {
+    return Stream.of(Nested.class, // static member class
+                     Inner.class, // non-static member class
+                     localClass(),
+                     anonymousClass());
+  }
+
+  @ParameterizedTest
+  @MethodSource("noEnclosingClassTypes")
+  void should_pass_if_actual_has_no_enclosing_class(Class<?> actual) {
+    // WHEN/THEN
+    assertThat(actual).hasNoEnclosingClass();
+  }
+
+  private static Stream<Class<?>> noEnclosingClassTypes() {
+    return Stream.of(ClassAssert_hasNoEnclosingClass_Test.class, // any top-level class
+                     Cloneable.class, // any top-level interface
+                     Nested[].class, // array classes have no enclosing class
+                     Integer.TYPE,
+                     Void.TYPE);
+  }
+
+  private static Class<?> localClass() {
+    class Local {
+    }
+    return Local.class;
+  }
+
+  private static Class<?> anonymousClass() {
+    return new Object() {}.getClass();
+  }
+
+  private static class Nested {
+  }
+
+  private class Inner {
+  }
+
+}


### PR DESCRIPTION
Closes #4343

Added two new assertions:
- `hasEnclosingClass`
- `hasNoEnclosingClass`

Both are implemented similarly to `hasSuperclass(Class)`/`hasNoSuperclass()`

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)