### PR TITLE
Fix HashSetAssert contains/containsAll O(n²) on large sets

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/HashSetAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/HashSetAssert.java
@@ -97,6 +97,12 @@ public class HashSetAssert<ELEMENT>
 
     @Override
     public boolean iterableContains(Iterable<?> iterable, Object value) {
+      // HashSet#contains already answers membership in O(1) via hashCode. When the iterable under
+      // check is the set itself, scanning it again with super.iterableContains is redundant and
+      // turns contains/containsAll into O(n²) on large sets (see https://github.com/assertj/assertj/issues/4233).
+      if (iterable == originalSet) {
+        return originalSet.contains(value);
+      }
       return originalSet.contains(value) && super.iterableContains(iterable, value);
     }
 

--- a/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/assertj-core/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1116,11 +1116,15 @@ public class Iterables {
    *                              {@code Iterable}, in any order.
    */
   public void assertContainsAll(AssertionInfo info, Iterable<?> actual, Iterable<?> other) {
-    final List<?> actualAsList = newArrayList(actual);
+    // Reuse actual as-is when it is already a Collection (like assertContains does) instead of
+    // copying it to a List: this preserves the original reference so comparison strategies backed
+    // by an efficient contains (e.g. HashSetAssert) can answer membership in O(1) instead of
+    // scanning, see https://github.com/assertj/assertj/issues/4233.
+    final Collection<?> actualAsCollection = ensureActualCanBeReadMultipleTimes(actual);
     checkIterableIsNotNull(other);
-    assertNotNull(info, actualAsList);
+    assertNotNull(info, actualAsCollection);
     Object[] values = newArrayList(other).toArray();
-    assertIterableContainsGivenValues(actual.getClass(), actualAsList, values, info);
+    assertIterableContainsGivenValues(actual.getClass(), actualAsCollection, values, info);
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/hashset/HashSetAssert_contains_performance_Test.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/hashset/HashSetAssert_contains_performance_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.hashset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Reproduces <a href="https://github.com/assertj/assertj/issues/4233">#4233</a>: {@code contains} and
+ * {@code containsAll} used to scan the whole {@link HashSet} for each checked element (O(n²)). With the fix,
+ * membership is answered by {@link HashSet#contains(Object)} in O(1), so both complete well under the timeout.
+ */
+class HashSetAssert_contains_performance_Test {
+
+  private static final int ACTUAL_SIZE = 100_000;
+  private static final int EXPECTED_SIZE = 50_000;
+
+  @Test
+  @Timeout(value = 2, unit = TimeUnit.SECONDS)
+  void should_pass_contains_quickly_for_large_hash_set() {
+    // GIVEN
+    HashSet<Integer> actual = largeHashSet(ACTUAL_SIZE);
+    Integer[] expected = IntStream.range(0, EXPECTED_SIZE).boxed().toArray(Integer[]::new);
+    // WHEN/THEN
+    assertThat(actual).contains(expected);
+  }
+
+  @Test
+  @Timeout(value = 2, unit = TimeUnit.SECONDS)
+  void should_pass_containsAll_quickly_for_large_hash_set() {
+    // GIVEN
+    HashSet<Integer> actual = largeHashSet(ACTUAL_SIZE);
+    Set<Integer> expected = IntStream.range(0, EXPECTED_SIZE).boxed().collect(Collectors.toSet());
+    // WHEN/THEN
+    assertThat(actual).containsAll(expected);
+  }
+
+  private static HashSet<Integer> largeHashSet(int size) {
+    return IntStream.range(0, size).boxed().collect(Collectors.toCollection(HashSet::new));
+  }
+
+}


### PR DESCRIPTION
## Summary

`assertThat(hashSet).contains(...)` / `.containsAll(...)` scanned the whole set for every checked element, so both were O(n²) — `containsAll` of 50k elements against a 100k `HashSet` took several seconds (#4233).

`InHashSetComparisonStrategy` already holds the set under test, and `HashSet#contains` answers membership in O(1) via `hashCode`. Two small changes restore that:

- **`HashSetAssert.InHashSetComparisonStrategy#iterableContains`** — when the iterable being checked *is* the set under test, return `originalSet.contains(value)` only (skip the redundant linear scan).
- **`Iterables#assertContainsAll`** — reuse `ensureActualCanBeReadMultipleTimes` like `assertContains` so a `Collection` actual keeps its identity; the previous `newArrayList(actual)` copy forced the slow scan path for every element.

When the iterable is a different collection (e.g. after intermediate processing), behavior is unchanged: still `originalSet.contains(value) && super.iterableContains(...)`.

Fixes #4233

## Test plan

- [x] `HashSetAssert_contains_performance_Test` (RED→GREEN; 100k/50k under 2s timeout)
- [x] `org.assertj.core.api.hashset.**` — 110 tests GREEN
- [x] `./mvnw -pl assertj-core spotless:apply license:format`