### PR TITLE
Detect inherited extra fields under recursive comparison strict type checking

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/RecursiveComparisonAssert.java
@@ -75,8 +75,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * By default, the objects to compare can be of different types but must have the same properties/fields. For example if object under test has a {@code work} field of type {@code Address},
    * the expected object to compare the object under test to must also have one, but it can of a different type like {@code AddressDto}.
    * <p>
-   * It is possible to enforce strict type checking by calling {@link #withStrictTypeChecking()} and make the comparison fail whenever the compared objects or their fields are not compatible.<br>
-   * Compatible means that the expected object/field types are the same or a subtype of actual/field types, for example if actual is an {@code Animal} and expected a {@code Dog}, they will be compared field by field in strict type checking mode.
+   * It is possible to enforce strict type checking by calling {@link #withStrictTypeChecking()} and make the comparison fail whenever the compared objects or their fields do not have the same type.<br>
+   * For example if actual is an {@code Animal} and expected a {@code Dog}, they are considered different in strict type checking mode even if they have the same field values.
    * <p>
    * <strong>Ignoring null fields in the recursive comparison</strong>
    * <p>
@@ -1494,8 +1494,7 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
   }
 
   /**
-   * Makes the recursive comparison to check that actual's type is compatible with expected's type (and do the same for each field). <br>
-   * Compatible means that the expected's type is the same or a subclass of actual's type.
+   * Makes the recursive comparison fail whenever actual and expected have different types (and do the same for each field).
    * <p>
    * Examples:
    * <pre><code class='java'> class Person {
@@ -1541,8 +1540,8 @@ public class RecursiveComparisonAssert<SELF extends RecursiveComparisonAssert<SE
    * detectiveSherlock.bestFriend = new Person("Watson", 1.70);
    * detectiveSherlock.busy = true;
    *
-   * // assertion succeeds as Detective inherits from Person and
-   * // only Person's fields are included into the comparison.
+   * // assertion fails as Detective is not the same type as Person even though
+   * // Detective inherits from Person and they share Person's field values.
    * assertThat(sherlock).usingRecursiveComparison()
    *                     .withStrictTypeChecking()
    *                     .isEqualTo(detectiveSherlock);</code></pre>

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -801,12 +801,11 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
   }
 
   /**
-   * Sets whether the recursive comparison will check that actual's type is compatible with expected's type (the same applies for each field).
-   * Compatible means that the expected's type is the same or a subclass of actual's type.
+   * Sets whether the recursive comparison will fail whenever actual and expected have different types (the same applies for each field).
    * <p>
    * See {@link RecursiveComparisonAssert#withStrictTypeChecking()} for code examples.
    *
-   * @param strictTypeChecking whether the recursive comparison will check that actual's type is compatible with expected's type.
+   * @param strictTypeChecking whether the recursive comparison will fail when actual's type is not equal to expected's type.
    */
   public void strictTypeChecking(boolean strictTypeChecking) {
     this.strictTypeChecking = strictTypeChecking;
@@ -1657,12 +1656,11 @@ public class RecursiveComparisonConfiguration extends AbstractRecursiveOperation
     }
 
     /**
-     * Sets whether the recursive comparison will check that actual's type is compatible with expected's type (the same applies for each field).
-     * Compatible means that the expected's type is the same or a subclass of actual's type.
+     * Sets whether the recursive comparison will fail whenever actual and expected have different types (the same applies for each field).
      * <p>
      * See {@link RecursiveComparisonAssert#withStrictTypeChecking()} for code examples.
      *
-     * @param strictTypeChecking whether the recursive comparison will check that actual's type is compatible with expected's type.
+     * @param strictTypeChecking whether the recursive comparison will fail when actual's type is not equal to expected's type.
      * @return this builder.
      */
     public Builder withStrictTypeChecking(boolean strictTypeChecking) {

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test.java
@@ -115,6 +115,47 @@ class RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test
   }
 
   @Test
+  void should_fail_in_strict_type_checking_mode_when_actual_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    Giant expected = new Giant("John");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("", actual, expected,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Person is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Giant");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
+  void should_fail_in_strict_type_checking_mode_when_actual_is_a_subtype_of_expected() {
+    // GIVEN
+    Giant actual = new Giant("John");
+    Person expected = new Person("John");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("", actual, expected,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Giant is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Person");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
+  void should_fail_in_strict_type_checking_mode_when_nested_actual_field_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    actual.neighbour = new Person("Jack");
+    Person expected = new Person("John");
+    expected.neighbour = new Giant("Jack");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("neighbour", actual.neighbour, expected.neighbour,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Person is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Giant");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
   void should_fail_in_strict_type_checking_mode_when_actual_and_expected_fields_have_the_same_data_but_incompatible_types() {
     // GIVEN
     Something withA = new Something(new A(10));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isNotEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/fields/RecursiveComparisonAssert_isNotEqualTo_Test.java
@@ -22,6 +22,7 @@ import static org.assertj.tests.core.testkit.NeverEqualComparator.NEVER_EQUALS_S
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 
+import org.assertj.tests.core.api.recursive.data.Giant;
 import org.assertj.tests.core.api.recursive.data.Light;
 import org.assertj.tests.core.api.recursive.data.Person;
 import org.assertj.tests.core.api.recursive.data.TimeOffset;
@@ -111,6 +112,28 @@ class RecursiveComparisonAssert_isNotEqualTo_Test extends WithComparingFieldsInt
     // THEN
     // verifyShouldNotBeEqualComparingFieldByFieldRecursivelyCall(actual, other);
 
+  }
+
+  @Test
+  void should_pass_in_strict_type_checking_mode_when_actual_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    Giant expected = new Giant("John");
+    // THEN
+    then(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                .withStrictTypeChecking()
+                .isNotEqualTo(expected);
+  }
+
+  @Test
+  void should_pass_in_strict_type_checking_mode_when_actual_is_a_subtype_of_expected() {
+    // GIVEN
+    Giant actual = new Giant("John");
+    Person expected = new Person("John");
+    // THEN
+    then(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                .withStrictTypeChecking()
+                .isNotEqualTo(expected);
   }
 
   @Test

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test.java
@@ -115,6 +115,47 @@ class RecursiveComparisonAssert_isEqualTo_strictTypeCheck_Test
   }
 
   @Test
+  void should_fail_in_strict_type_checking_mode_when_actual_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    Giant expected = new Giant("John");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("", actual, expected,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Person is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Giant");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
+  void should_fail_in_strict_type_checking_mode_when_actual_is_a_subtype_of_expected() {
+    // GIVEN
+    Giant actual = new Giant("John");
+    Person expected = new Person("John");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("", actual, expected,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Giant is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Person");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
+  void should_fail_in_strict_type_checking_mode_when_nested_actual_field_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    actual.neighbour = new Person("Jack");
+    Person expected = new Person("John");
+    expected.neighbour = new Giant("Jack");
+    recursiveComparisonConfiguration.strictTypeChecking(true);
+
+    // WHEN/THEN
+    ComparisonDifference difference = diff("neighbour", actual.neighbour, expected.neighbour,
+                                           "the compared values are considered different since the recursive comparison enforces strict type checking and the actual value type org.assertj.tests.core.api.recursive.data.Person is not equal to the expected value type org.assertj.tests.core.api.recursive.data.Giant");
+    compareRecursivelyFailsWithDifferences(actual, expected, difference);
+  }
+
+  @Test
   void should_fail_in_strict_type_checking_mode_when_actual_and_expected_fields_have_the_same_data_but_incompatible_types() {
     // GIVEN
     Something withA = new Something(new A(10));

--- a/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isNotEqualTo_Test.java
+++ b/assertj-tests/assertj-integration-tests/assertj-core-tests/src/test/java/org/assertj/tests/core/api/recursive/comparison/legacy/RecursiveComparisonAssert_isNotEqualTo_Test.java
@@ -22,6 +22,7 @@ import static org.assertj.tests.core.testkit.NeverEqualComparator.NEVER_EQUALS_S
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 
+import org.assertj.tests.core.api.recursive.data.Giant;
 import org.assertj.tests.core.api.recursive.data.Light;
 import org.assertj.tests.core.api.recursive.data.Person;
 import org.assertj.tests.core.api.recursive.data.TimeOffset;
@@ -111,6 +112,28 @@ class RecursiveComparisonAssert_isNotEqualTo_Test extends WithLegacyIntrospectio
     // THEN
     // verifyShouldNotBeEqualComparingFieldByFieldRecursivelyCall(actual, other);
 
+  }
+
+  @Test
+  void should_pass_in_strict_type_checking_mode_when_actual_is_a_supertype_of_expected() {
+    // GIVEN
+    Person actual = new Person("John");
+    Giant expected = new Giant("John");
+    // THEN
+    then(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                .withStrictTypeChecking()
+                .isNotEqualTo(expected);
+  }
+
+  @Test
+  void should_pass_in_strict_type_checking_mode_when_actual_is_a_subtype_of_expected() {
+    // GIVEN
+    Giant actual = new Giant("John");
+    Person expected = new Person("John");
+    // THEN
+    then(actual).usingRecursiveComparison(recursiveComparisonConfiguration)
+                .withStrictTypeChecking()
+                .isNotEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
`withStrictTypeChecking()` used to treat a subtype expected value as compatible with a supertype actual value, so extra fields on the subtype were skipped. Main already fails the comparison when types differ (`typesDiffer`); this PR covers that case and updates the javadoc, which still described the old subtype-compatible behavior.

`isEqualTo` now fails (and `isNotEqualTo` passes) for `Person` vs `Giant` in both directions, including a nested field, with both introspection strategies.

Fixes #4263

#### Check List:
* Fixes #4263
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the contributing guidelines