### PR TITLE
Include failure causes in `AssertJMultipleFailuresError` message

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/error/AssertJMultipleFailuresError.java
+++ b/assertj-core/src/main/java/org/assertj/core/error/AssertJMultipleFailuresError.java
@@ -17,6 +17,7 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.util.Throwables.addLineNumberToErrorMessages;
+import static org.assertj.core.util.Throwables.describeErrors;
 
 import java.util.List;
 
@@ -51,9 +52,12 @@ public class AssertJMultipleFailuresError extends MultipleFailuresError {
                                                   .append(pluralize(failureCount, "failure", "failures"))
                                                   .append(")");
     List<Throwable> failuresWithLineNumbers = addLineNumberToErrorMessages(failures);
+    List<String> descriptions = describeErrors(failuresWithLineNumbers);
     for (int i = 0; i < failureCount; i++) {
       builder.append(errorSeparator(i + 1));
-      String message = nullSafeMessage(failuresWithLineNumbers.get(i));
+      Throwable failure = failuresWithLineNumbers.get(i);
+      // describeErrors adds the cause message and its first stack trace elements when the failure has a cause
+      String message = failure.getCause() == null ? nullSafeMessage(failure) : descriptions.get(i);
       // when we have a description, we add a line before for readability
       if (hasDescription(message)) builder.append(EOL);
       builder.append(message);

--- a/assertj-core/src/test/java/org/example/custom/SoftAssertionsErrorDescriptionTest.java
+++ b/assertj-core/src/test/java/org/example/custom/SoftAssertionsErrorDescriptionTest.java
@@ -36,6 +36,7 @@ public class SoftAssertionsErrorDescriptionTest {
                                                     + "-- failure 1 --"
                                                     + "failure%n"
                                                     + "at SoftAssertionsErrorDescriptionTest.should_display_the_error_cause_and_the_cause_first_stack_trace_elements(SoftAssertionsErrorDescriptionTest.java:31)"));
+    assertThat(error).hasMessageContainingAll("cause message: abc", "cause first five stack trace elements:");
   }
 
   protected static RuntimeException throwRuntimeException() {

--- a/assertj-core/src/test/java/org/example/test/AssertJMultipleFailuresError_getMessage_Test.java
+++ b/assertj-core/src/test/java/org/example/test/AssertJMultipleFailuresError_getMessage_Test.java
@@ -157,4 +157,19 @@ class AssertJMultipleFailuresError_getMessage_Test {
     then(error).hasStackTraceContaining("AssertJMultipleFailuresError_getMessage_Test.java:153");
   }
 
+  @Test
+  void should_describe_the_cause_of_errors_having_one() {
+    // GIVEN
+    AssertionError errorWithCause = new AssertionError("boom");
+    errorWithCause.initCause(new RuntimeException("root cause"));
+    AssertionError errorWithoutCause = new AssertionError("no cause");
+    AssertJMultipleFailuresError error = new AssertJMultipleFailuresError("", list(errorWithCause, errorWithoutCause));
+    // WHEN
+    String message = error.getMessage();
+    // THEN
+    then(message).contains("-- failure 1 --", "boom", "cause message: root cause", "cause first five stack trace elements:")
+                 .contains("-- failure 2 --", "no cause")
+                 .containsOnlyOnce("cause message:");
+  }
+
 }


### PR DESCRIPTION
Fixes #4125

Make `AssertJMultipleFailuresError#getMessage` render the cause of each failure that has one, so `SoftAssertions#fail(String, Throwable)` shows `cause message: ...` and the first stack trace elements of the cause again, as in 3.23.1. Failures without a cause are formatted exactly as before.

The cause was lost because `getMessage` only used the failure message; `Throwables.describeErrors` (the #864 fix) was reached only through the `SoftAssertionError` fallback, which never runs when opentest4j is on the classpath.

`SoftAssertionsErrorDescriptionTest` did not catch this since it asserted the opentest4j prefix but not the cause; it now asserts the cause too. `main` is not affected: 452cee73 already renders the cause in `MultipleAssertionsError`.
