### PR TITLE
Fix SoftAssertions#fail(String, Throwable) losing realCause info in aggregated error (#4125)

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/AbstractSoftAssertions.java
@@ -17,6 +17,7 @@ package org.assertj.core.api;
 
 import static java.lang.String.format;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.assertj.core.annotation.CanIgnoreReturnValue;
@@ -110,7 +111,7 @@ public abstract class AbstractSoftAssertions extends DefaultAssertionErrorCollec
   @CanIgnoreReturnValue
   @Contract("_, _ -> fail")
   public <T> T fail(String failureMessage, Throwable realCause) {
-    AssertionError error = Failures.instance().failure(failureMessage);
+    AssertionError error = Failures.instance().failure(describeFailureWithCause(failureMessage, realCause));
     error.initCause(realCause);
     collectAssertionError(error);
     return null;
@@ -130,7 +131,36 @@ public abstract class AbstractSoftAssertions extends DefaultAssertionErrorCollec
   @CanIgnoreReturnValue
   @Contract("_ -> fail")
   public <T> T fail(Throwable realCause) {
-    return fail("", realCause);
+    AssertionError error = Failures.instance().failure("");
+    error.initCause(realCause);
+    collectAssertionError(error);
+    return null;
+  }
+
+  /**
+   * Builds the failure message for {@link #fail(String, Throwable)} so that the {@code realCause} information
+   * (its message and first five stack trace elements) is preserved and shown when the soft assertion error is
+   * reported (e.g. by {@code assertAll()}), restoring the behaviour expected per issue #864.
+   *
+   * @param failureMessage the failure message.
+   * @param realCause the cause of the error (may be {@code null}).
+   * @return the failure message augmented with the cause description when a cause is present.
+   */
+  private static String describeFailureWithCause(String failureMessage, Throwable realCause) {
+    if (realCause == null) return failureMessage;
+    StackTraceElement[] stackTrace = realCause.getStackTrace();
+    StackTraceElement[] firstElements = Arrays.copyOf(stackTrace, Math.min(5, stackTrace.length));
+    StringBuilder stackTraceDescription = new StringBuilder();
+    for (StackTraceElement stackTraceElement : firstElements) {
+      stackTraceDescription.append(format("\tat %s%n", stackTraceElement));
+    }
+    return format("%s%n" +
+                  "cause message: %s%n" +
+                  "cause first five stack trace elements:%n" +
+                  "%s",
+                  failureMessage,
+                  realCause.getMessage(),
+                  stackTraceDescription);
   }
 
   /**

--- a/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1053,6 +1053,19 @@ class SoftAssertionsTest extends BaseAssertionsTest {
   }
 
   @Test
+  void should_display_real_cause_in_aggregated_error() {
+    // GIVEN
+    String failureMessage = "failure";
+    RuntimeException realCause = new RuntimeException("abc");
+    // WHEN / THEN
+    assertThatThrownBy(() -> {
+      softly.fail(failureMessage, realCause);
+      softly.assertAll();
+    }).hasMessageContaining(failureMessage)
+      .hasMessageContaining("cause message: abc");
+  }
+
+  @Test
   void should_return_failure_after_fail_with_message_and_cause() {
     // GIVEN
     String failureMessage = "Should not reach here";


### PR DESCRIPTION
## Summary

Fixes #4125 — a regression of #864 where `SoftAssertions#fail(String failureMessage, Throwable realCause)` no longer shows the `realCause` information in the aggregated error reported by `assertAll()` (reported as broken again in 3.27.6).

## Root cause

The original 2017 fix (commit `c487af4`) rendered the cause's message and first five stack-trace elements when building the `SoftAssertionError`. After soft assertions started rendering the aggregated error through `AssertionErrorCreator.multipleSoftFailuresError` → `AssertJMultipleFailuresError`, the cause is no longer shown, because `AssertJMultipleFailuresError.getMessage()` only uses each failure's `getMessage()` and does not render the cause.

## Fix

In `AbstractSoftAssertions.fail(String, Throwable)` we now embed the cause description into the failure message (message + `cause message:` + first five stack-trace elements), matching the original 2017 behaviour. `fail(Throwable)` keeps an empty message and only sets the cause, so existing behaviour for the no-message variant is unchanged.

This is a targeted change that restores the lost information without altering the global error-formatting classes.

## Verification

- Added `SoftAssertionsTest.should_display_real_cause_in_aggregated_error` asserting that the error thrown by `assertAll()` contains `cause message: abc`.
- Ran `SoftAssertionsTest` and `BDDSoftAssertionsTest` — all green.
- `spotless:check` passes.

This targets the `3.x` line (the reported regression is in 3.27.6).
