### PR TITLE
Support record components in ComparingProperties

### DIFF
--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingProperties.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingProperties.java
@@ -15,48 +15,32 @@
  */
 package org.assertj.core.api.recursive.comparison;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toSet;
-import static org.assertj.core.util.introspection.ClassUtils.isInJavaLangPackage;
-
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.assertj.core.util.introspection.PropertySupport;
 
 /**
  * A {@link RecursiveComparisonIntrospectionStrategy} that introspects properties by looking at public getters like
- * {@code getName()} or {@code isActive()}/{@code getActive()} for boolean properties.
+ * {@code getName()} or {@code isActive()}/{@code getActive()} for regular objects and record components for records.
  */
 public class ComparingProperties extends AbstractRecursiveComparisonIntrospectionStrategy {
 
   /** Shared property introspection strategy instance. */
   public static final ComparingProperties COMPARING_PROPERTIES = new ComparingProperties();
 
+  private final ComparingRegularProperties regularProperties = new ComparingRegularProperties();
+  private final ComparingRecordProperties recordProperties = new ComparingRecordProperties();
+
   /** Creates a new property introspection strategy. */
   public ComparingProperties() {}
 
-  private static final String GET_PREFIX = "get";
-  private static final String IS_PREFIX = "is";
-
-  // use ConcurrentHashMap in case this strategy instance is used in a multi-thread context
-  private final Map<Class<?>, Set<String>> propertiesNamesPerClass = new ConcurrentHashMap<>();
-
   @Override
   public Set<String> getChildrenNodeNamesOf(Object node) {
-    if (node == null) return new HashSet<>();
-    return propertiesNamesPerClass.computeIfAbsent(node.getClass(), ComparingProperties::getPropertiesNamesOf);
+    return strategyFor(node).getChildrenNodeNamesOf(node);
   }
 
   @Override
   public Object getChildNodeValue(String childNodeName, Object instance) {
-    return PropertySupport.instance().propertyValueOf(childNodeName, Object.class, instance);
+    return strategyFor(instance).getChildNodeValue(childNodeName, instance);
   }
 
   @Override
@@ -69,57 +53,20 @@ public class ComparingProperties extends AbstractRecursiveComparisonIntrospectio
     throw new IllegalArgumentException("ignoringTransientFields is not supported since we are comparing properties");
   }
 
-  static Set<String> getPropertiesNamesOf(Class<?> clazz) {
-    return gettersIncludingInheritedOf(clazz).stream()
-                                             .map(Method::getName)
-                                             .map(ComparingProperties::toPropertyName)
-                                             .collect(toSet());
-  }
-
-  private static String toPropertyName(String methodName) {
-    String propertyWithCapitalLetter = methodName.startsWith(GET_PREFIX)
-        ? methodName.substring(GET_PREFIX.length())
-        : methodName.substring(IS_PREFIX.length());
-    return propertyWithCapitalLetter.toLowerCase().charAt(0) + propertyWithCapitalLetter.substring(1);
-  }
-
   /**
-   * Returns public getters declared by the given class or inherited from its superclasses.
+   * Returns public getters declared by the given class or inherited from its superclasses, or record component
+   * accessors when the given class is a record.
    *
    * @param clazz the class to inspect
    * @return the getter methods
    */
   public static Set<Method> gettersIncludingInheritedOf(Class<?> clazz) {
-    return gettersOf(clazz);
+    return clazz.isRecord() ? ComparingRecordProperties.gettersIncludingInheritedOf(clazz)
+        : ComparingRegularProperties.gettersIncludingInheritedOf(clazz);
   }
 
-  private static Set<Method> gettersOf(Class<?> clazz) {
-    return stream(clazz.getMethods()).filter(method -> !isInJavaLangPackage(method.getDeclaringClass()))
-                                     .filter(method -> !isStatic(method))
-                                     .filter(ComparingProperties::isGetter)
-                                     .collect(toCollection(LinkedHashSet::new));
-  }
-
-  private static boolean isStatic(Method method) {
-    return Modifier.isStatic(method.getModifiers());
-  }
-
-  private static boolean isGetter(Method method) {
-    if (hasParameters(method)) return false;
-    return isRegularGetter(method) || isBooleanProperty(method);
-  }
-
-  private static boolean isRegularGetter(Method method) {
-    return method.getName().startsWith(GET_PREFIX);
-  }
-
-  private static boolean hasParameters(Method method) {
-    return method.getParameters().length > 0;
-  }
-
-  private static boolean isBooleanProperty(Method method) {
-    Class<?> returnType = method.getReturnType();
-    return method.getName().startsWith(IS_PREFIX) && (returnType.equals(boolean.class) || returnType.equals(Boolean.class));
+  private RecursiveComparisonIntrospectionStrategy strategyFor(Object node) {
+    return node != null && node.getClass().isRecord() ? recordProperties : regularProperties;
   }
 
 }

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingRecordProperties.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingRecordProperties.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.assertj.core.util.introspection.IntrospectionError;
+
+/**
+ * A {@link RecursiveComparisonIntrospectionStrategy} that introspects Java records through their record components.
+ */
+final class ComparingRecordProperties implements RecursiveComparisonIntrospectionStrategy {
+
+  // use ConcurrentHashMap in case this strategy instance is used in a multi-thread context
+  private final Map<Class<?>, Set<String>> recordComponentNamesPerClass = new ConcurrentHashMap<>();
+
+  static Set<Method> gettersIncludingInheritedOf(Class<?> recordType) {
+    return stream(recordType.getRecordComponents())
+                                                   .map(RecordComponent::getAccessor)
+                                                   .collect(toSet());
+  }
+
+  @Override
+  public Set<String> getChildrenNodeNamesOf(Object node) {
+    if (node == null || !node.getClass().isRecord()) {
+      return new HashSet<>();
+    }
+    return recordComponentNamesPerClass.computeIfAbsent(
+                                                        node.getClass(),
+                                                        ComparingRecordProperties::getPropertiesNamesOf);
+  }
+
+  @Override
+  public Object getChildNodeValue(String childNodeName, Object instance) {
+    if (instance.getClass().isRecord()) {
+      //@format:off
+      Method getter = stream(instance.getClass().getRecordComponents())
+        .filter(component -> component.getName().equals(childNodeName))
+        .findFirst()
+        .map(RecordComponent::getAccessor)
+        .orElseThrow(() -> new IntrospectionError("No record component '%s' in %s".formatted(childNodeName,instance.getClass())));
+      //@format:on
+      String message = "Unable to read record component <'%s'> from <%s>".formatted(childNodeName, instance.getClass());
+      try {
+        getter.setAccessible(true);
+        return getter.invoke(instance);
+      } catch (InvocationTargetException e) {
+        throw new IntrospectionError(message, e, e.getTargetException());
+      } catch (IllegalAccessException e) {
+        throw new IntrospectionError(message, e);
+      }
+    } else {
+      throw new IllegalArgumentException("given instance is not record " + instance.getClass());
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "comparing records";
+  }
+
+  static Set<String> getPropertiesNamesOf(Class<?> recordType) {
+    return stream(recordType.getRecordComponents())
+                                                   .map(RecordComponent::getName)
+                                                   .collect(toSet());
+  }
+
+}

--- a/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingRegularProperties.java
+++ b/assertj-core/src/main/java/org/assertj/core/api/recursive/comparison/ComparingRegularProperties.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.util.introspection.ClassUtils.isInJavaLangPackage;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.assertj.core.util.introspection.PropertySupport;
+
+/**
+ * Introspects regular objects by looking at public JavaBean-style getters.
+ */
+final class ComparingRegularProperties implements RecursiveComparisonIntrospectionStrategy {
+
+  private static final String GET_PREFIX = "get";
+  private static final String IS_PREFIX = "is";
+
+  // use ConcurrentHashMap in case this strategy instance is used in a multi-thread context
+  private final Map<Class<?>, Set<String>> propertiesNamesPerClass = new ConcurrentHashMap<>();
+
+  @Override
+  public Set<String> getChildrenNodeNamesOf(Object node) {
+    if (node == null) return new HashSet<>();
+    return propertiesNamesPerClass.computeIfAbsent(node.getClass(), ComparingRegularProperties::getPropertiesNamesOf);
+  }
+
+  @Override
+  public Object getChildNodeValue(String childNodeName, Object instance) {
+    return PropertySupport.instance().propertyValueOf(childNodeName, Object.class, instance);
+  }
+
+  @Override
+  public String getDescription() {
+    return "comparing regular properties";
+  }
+
+  static Set<String> getPropertiesNamesOf(Class<?> clazz) {
+    return gettersIncludingInheritedOf(clazz).stream()
+                                             .map(Method::getName)
+                                             .map(ComparingRegularProperties::toPropertyName)
+                                             .collect(toSet());
+  }
+
+  private static String toPropertyName(String methodName) {
+    String propertyWithCapitalLetter = methodName.startsWith(GET_PREFIX)
+        ? methodName.substring(GET_PREFIX.length())
+        : methodName.substring(IS_PREFIX.length());
+    return propertyWithCapitalLetter.toLowerCase().charAt(0) + propertyWithCapitalLetter.substring(1);
+  }
+
+  static Set<Method> gettersIncludingInheritedOf(Class<?> clazz) {
+    return gettersOf(clazz);
+  }
+
+  private static Set<Method> gettersOf(Class<?> clazz) {
+    return stream(clazz.getMethods()).filter(method -> !isInJavaLangPackage(method.getDeclaringClass()))
+                                     .filter(method -> !isStatic(method))
+                                     .filter(ComparingRegularProperties::isGetter)
+                                     .collect(toCollection(LinkedHashSet::new));
+  }
+
+  private static boolean isStatic(Method method) {
+    return Modifier.isStatic(method.getModifiers());
+  }
+
+  private static boolean isGetter(Method method) {
+    if (hasParameters(method)) return false;
+    return isRegularGetter(method) || isBooleanProperty(method);
+  }
+
+  private static boolean isRegularGetter(Method method) {
+    return method.getName().startsWith(GET_PREFIX);
+  }
+
+  private static boolean hasParameters(Method method) {
+    return method.getParameters().length > 0;
+  }
+
+  private static boolean isBooleanProperty(Method method) {
+    Class<?> returnType = method.getReturnType();
+    return method.getName().startsWith(IS_PREFIX) && (returnType.equals(boolean.class) || returnType.equals(Boolean.class));
+  }
+
+}

--- a/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/ComparingPropertiesTest.java
+++ b/assertj-core/src/test/java/org/assertj/core/api/recursive/comparison/ComparingPropertiesTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+class ComparingPropertiesTest {
+
+  public record Foo(Integer id,
+      Integer num,
+      String name) {
+
+    public String Ignored() {
+      return "ignored";
+    }
+
+    public String getName() {
+      return "foo name";
+    }
+  }
+
+  @Test
+  void should_compare_record_components_when_using_comparing_properties() {
+    // Given
+    RecursiveComparisonIntrospectionStrategy strategy = new ComparingProperties();
+
+    Foo ob1 = new Foo(1, 22, "name");
+    Foo ob2 = new Foo(2, 22, "other");
+
+    // When
+    var assertionError = expectAssertionError(() -> assertThat(ob1)
+                                                                   .usingRecursiveComparison()
+                                                                   .withIntrospectionStrategy(strategy)
+                                                                   .ignoringFields("id")
+                                                                   .isEqualTo(ob2));
+
+    // Then
+    then(strategy.getChildrenNodeNamesOf(ob1)).containsExactlyInAnyOrder("id", "num", "name");
+    then(assertionError).isInstanceOf(AssertionError.class)
+                        .hasMessageContaining("name");
+  }
+
+  @Test
+  void should_return_record_component_accessors_but_not_custom_getters() {
+    // Given & When
+    var getters = ComparingProperties.gettersIncludingInheritedOf(Foo.class);
+
+    // Then
+    then(getters)
+                 .extracting(Method::getName)
+                 .containsExactlyInAnyOrder("id", "num", "name");
+  }
+
+  @Test
+  void should_use_record_component_accessors_but_not_custom_getters() {
+    // Given
+    Foo ob1 = new Foo(1, 22, "name");
+    ComparingProperties comparingProperties = new ComparingProperties();
+    // When
+    var value = comparingProperties.getChildNodeValue("name", ob1);
+    // Then
+    then(value).isEqualTo(ob1.name());
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #3601 
* Unit tests : YES
* Javadoc with a code example (on API only) :  NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
#### Outline
`ComparingProperties` only discovers JavaBean-style getters, so Java record
components exposed through bare accessors such as `name()` are omitted from
recursive comparison.
#### Changes
- Regular classes continue to use JavaBean-style getters through
  `ComparingRegularProperties`.
- Records use their declared `RecordComponent`s through
  `ComparingRecordProperties`.
- Record component values are read by invoking `RecordComponent#getAccessor`,
  ensuring that a custom `getName()` method does not take precedence over the
  canonical `name()` accessor.
